### PR TITLE
import rather than depend upon dplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,9 +56,8 @@ Collate:
     'spark_data_frame.R'
     'spark_dependencies.R'
     'utils.R'
-Depends:
-    dplyr
 Imports:
+    dplyr,
     methods,
     readr,
     DBI,

--- a/R/api_spark.R
+++ b/R/api_spark.R
@@ -105,8 +105,17 @@ spark_api_create <- function(scon) {
 }
 
 spark_sql_or_hive <- function(api) {
+  
+  # get the connection instance
   sconInst <- spark_connection_get_inst(api$scon)
 
+  # if both hive and sql are null create sql context on demand
+  if (is.null(sconInst$hive) && is.null(sconInst$sql)) {
+    sconInst <- spark_connection_attach_sql_session_context(api$scon, sconInst)
+    spark_connection_set_inst(api$scon, sconInst)
+    on_connection_updated(api$scon, "")
+  }
+  
   if (!identical(sconInst$hive, NULL))
     sconInst$hive
   else

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -80,9 +80,6 @@ spark_connect <- function(master = "local",
   sconInst <- spark_connection_attach_context(scon, sconInst)
   spark_connection_set_inst(scon, sconInst)
 
-  sconInst <- spark_connection_attach_sql_session_context(scon, sconInst)
-  spark_connection_set_inst(scon, sconInst)
-
   on_connection_opened(scon, sconInst$connectCall)
   scon
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -11,6 +11,7 @@ A set of tools to provision, connect and interface to Apache Spark from within t
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(warning = FALSE, cache = FALSE, fig.path='res/')
 library(sparklyr)
+library(dplyr)
 library(ggplot2)
 library(nycflights13)
 library(Lahman)

--- a/docs/ml_examples.Rmd
+++ b/docs/ml_examples.Rmd
@@ -10,6 +10,7 @@ output:
 
 ```{r}
 library(sparklyr)
+library(dplyr)
 library(ggplot2)
 
 sc <- spark_connect("local", version = "1.6.1")

--- a/docs/perf_1b.Rmd
+++ b/docs/perf_1b.Rmd
@@ -15,7 +15,7 @@ sparklyr:::spark_install(version = "2.0.0-SNAPSHOT", reset = TRUE, logging = "WA
 
 ```{r}
 library(sparklyr)
-library(magrittr)
+library(dplyr)
 library(ggplot2)
 
 parquetPath <- file.path(getwd(), "billion.parquet")

--- a/docs/perf_dplyr.Rmd
+++ b/docs/perf_dplyr.Rmd
@@ -11,6 +11,7 @@ output:
 ```{r}
 knitr::opts_chunk$set(warning = FALSE, cache = FALSE)
 library(sparklyr)
+library(dplyr)
 library(reshape2)
 library(ggplot2)
 ```


### PR DESCRIPTION
- The hive/sql connection is now made on demand (helpful for scenarios where no sql connection is ever required)
- dplyr is imported -- this enables us to continue to make full use of dplyr internally without automatically affecting the search path
- Client code will now require "library(dplyr)" to use the DB functions, however this arguably makes the client code more readable and transparent.
