### PR TITLE
map date time columns as doubles

### DIFF
--- a/R/api_spark.R
+++ b/R/api_spark.R
@@ -271,6 +271,16 @@ spark_api_copy_data <- function(api, df, name, repartition, local_file = TRUE) {
     }
   } else {
     structType <- spark_api_build_types(api, columns)
+    
+    # Map date and time columns as standard doubles
+    as.data.frame(lapply(df, function(e) {
+      if (is.time(e) || is.date(e))
+        sapply(e, function(t) {
+          class(t) <- NULL
+          t})
+      else
+        e
+    }))
 
     rows <- lapply(seq_len(NROW(df)), function(e) as.list(df[e,]))
 


### PR DESCRIPTION
This one unblocks https://github.com/rstudio/sparklyr/issues/37. The problem was that the 2.0 version of flights contains a date time field and this is only problematic for the cluster version of copy_to. The fix is to cast time columns to doubles which unblocks this path. Further work would be require to maintain formatting while copying date time columns.
- @jjallaire @kevinushey 
