### PR TITLE
spark windows installation over wow64

### DIFF
--- a/R/connection_windows.R
+++ b/R/connection_windows.R
@@ -12,11 +12,12 @@ is_wow64 <- function() {
 verify_msvcr100 <- function() {
   # determine location of MSVCR100.DLL
   systemRoot <- Sys.getenv("SystemRoot")
-  msvcr100Path <- normalizePath(file.path(systemRoot, ifelse(is_wow64(), "SysWOW64", "System32"), "msvcr100.dll"),
+  systemDir <- ifelse(is_win64(), ifelse(is_wow64(), "sysnative", "SysWOW64"), "SysWOW64")
+  msvcr100Path <- normalizePath(file.path(systemRoot, systemDir, "msvcr100.dll"),
                                 winslash = "/", mustWork = FALSE)
   haveMsvcr100 <- file.exists(msvcr100Path)
   if (!haveMsvcr100) {
-    msvcr100Url <- ifelse(is_win64() && !is_wow64() , 
+    msvcr100Url <- ifelse(is_win64() , 
                           "https://www.microsoft.com/download/en/details.aspx?id=13523",
                           "https://www.microsoft.com/download/en/details.aspx?id=8328")
     stop("Running Spark on Windows requires the ",

--- a/R/connection_windows.R
+++ b/R/connection_windows.R
@@ -5,7 +5,7 @@ is_win64 <- function() {
 }
 
 is_wow64 <- function() {
-  Sys.getenv("PROCESSOR_ARCHITECTURE") == "x86" ||
+  Sys.getenv("PROCESSOR_ARCHITECTURE") == "x86" &&
   Sys.getenv("PROCESSOR_ARCHITEW6432") == "AMD64"
 }
 


### PR DESCRIPTION
While running x86 r in x64 windows, the Visual Studio x64 redistributable can be only found under a masked `sysnative` directory, this change uses this path to validate installation in x64r/x86win.

@jjallaire 