### PR TITLE
expose read/write mode/options in parquet and json interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.2.13
+Version: 0.2.14
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/R/api_spark.R
+++ b/R/api_spark.R
@@ -327,15 +327,28 @@ spark_print_schema <- function(api, tableName) {
   )
 }
 
-spark_api_read_generic <- function(api, path, fileMethod) {
-  read <- invoke(spark_sql_or_hive(api), "read")
-  invoke(read, fileMethod, path)
+spark_api_read_generic <- function(api, path, fileMethod, csvOptions = list()) {
+  options <- invoke(spark_sql_or_hive(api), "read")
+  
+  lapply(names(csvOptions), function(csvOptionName) {
+    options <<- invoke(options, "option", csvOptionName, csvOptions[[csvOptionName]])
+  })
+  
+  invoke(options, fileMethod, path)
 }
 
-spark_api_write_generic <- function(df, path, fileMethod) {
-  write <- invoke(df, "write")
-  invoke(write, fileMethod, path)
-
+spark_api_write_generic <- function(df, path, fileMethod, mode = NULL, csvOptions = list()) {
+  options <- invoke(df, "write")
+  
+  if (!is.null(mode)) {
+    options <- invoke(options, "mode", mode)
+  }
+  
+  lapply(names(csvOptions), function(csvOptionName) {
+    options <<- invoke(options, "option", csvOptionName, csvOptions[[csvOptionName]])
+  })
+  
+  invoke(options, fileMethod, path)
   invisible(TRUE)
 }
 

--- a/R/api_spark_data.R
+++ b/R/api_spark_data.R
@@ -30,6 +30,7 @@ spark_csv_options <- function(header,
 #' @param escape The chatacter used to escape other characters, defaults to \code{\\}.
 #' @param charset The character set, defaults to \code{"UTF-8"}.
 #' @param null_value The character to use for default values, defaults to \code{NULL}.
+#' @param mode Specifies the behavior when data or table already exists.
 #' @param options A list of strings with additional options.
 #' @param repartition Total of partitions used to distribute table or 0 (default) to avoid partitioning
 #' @param overwrite Overwrite the table with the given name if it already exists
@@ -141,12 +142,18 @@ spark_write_csv.spark_jobj <- function(x,
 #' @family reading and writing data
 #'
 #' @export
-spark_read_parquet <- function(sc, name, path, repartition = 0, memory = TRUE, overwrite = TRUE) {
+spark_read_parquet <- function(sc,
+                               name,
+                               path,
+                               options = list(),
+                               repartition = 0,
+                               memory = TRUE,
+                               overwrite = TRUE) {
 
   if (overwrite) spark_remove_table_if_exists(sc, name)
   
   api <- spark_api(sc)
-  df <- spark_api_read_generic(api, list(path.expand(path)), "parquet")
+  df <- spark_api_read_generic(api, list(path.expand(path)), "parquet", options)
   spark_partition_register_df(sc, df, api, name, repartition, memory)
 }
 
@@ -157,20 +164,20 @@ spark_read_parquet <- function(sc, name, path, repartition = 0, memory = TRUE, o
 #' @family reading and writing data
 #'
 #' @export
-spark_write_parquet <- function(x, path) {
+spark_write_parquet <- function(x, path, mode = NULL, options = list()) {
   UseMethod("spark_write_parquet")
 }
 
 #' @export
-spark_write_parquet.tbl_spark <- function(x, path) {
+spark_write_parquet.tbl_spark <- function(x, path, mode = NULL, options = list()) {
   sqlResult <- spark_sqlresult_from_dplyr(x)
-  spark_api_write_generic(sqlResult, path.expand(path), "parquet")
+  spark_api_write_generic(sqlResult, path.expand(path), "parquet", mode, options)
 }
 
 #' @export
-spark_write_parquet.spark_jobj <- function(x, path) {
+spark_write_parquet.spark_jobj <- function(x, path, mode = NULL, options = list()) {
   spark_expect_jobj_class(x, "org.apache.spark.sql.DataFrame")
-  spark_api_write_generic(x, path.expand(path), "parquet")
+  spark_api_write_generic(x, path.expand(path), "parquet", mode, options)
 }
 
 #' Read a JSON file into a Spark DataFrame
@@ -187,12 +194,18 @@ spark_write_parquet.spark_jobj <- function(x, path) {
 #' @family reading and writing data
 #'
 #' @export
-spark_read_json <- function(sc, name, path, repartition = 0, memory = TRUE, overwrite = TRUE) {
+spark_read_json <- function(sc,
+                            name,
+                            path,
+                            options = list(),
+                            repartition = 0,
+                            memory = TRUE,
+                            overwrite = TRUE) {
   
   if (overwrite) spark_remove_table_if_exists(sc, name)
   
   api <- spark_api(sc)
-  df <- spark_api_read_generic(api, path.expand(path), "json")
+  df <- spark_api_read_generic(api, path.expand(path), "json", options)
   spark_partition_register_df(sc, df, api, name, repartition, memory)
 }
 
@@ -203,20 +216,20 @@ spark_read_json <- function(sc, name, path, repartition = 0, memory = TRUE, over
 #' @family reading and writing data
 #'
 #' @export
-spark_write_json <- function(x, path) {
+spark_write_json <- function(x, path, mode = NULL, options = list()) {
   UseMethod("spark_write_json")
 }
 
 #' @export
-spark_write_json.tbl_spark <- function(x, path) {
+spark_write_json.tbl_spark <- function(x, path, mode = NULL, options = list()) {
   sqlResult <- spark_sqlresult_from_dplyr(x)
-  spark_api_write_generic(sqlResult, path.expand(path), "json")
+  spark_api_write_generic(sqlResult, path.expand(path), "json", mode, options)
 }
 
 #' @export
-spark_write_json.spark_jobj <- function(x, path) {
+spark_write_json.spark_jobj <- function(x, path, mode = NULL, options = list()) {
   spark_expect_jobj_class(x, "org.apache.spark.sql.DataFrame")
-  spark_api_write_generic(x, path.expand(path), "json")
+  spark_api_write_generic(x, path.expand(path), "json", mode, options)
 }
 
 spark_expect_jobj_class <- function(jobj, expectedClassName) {

--- a/R/api_spark_data.R
+++ b/R/api_spark_data.R
@@ -30,7 +30,6 @@ spark_csv_options <- function(header,
 #' @param escape The chatacter used to escape other characters, defaults to \code{\\}.
 #' @param charset The character set, defaults to \code{"UTF-8"}.
 #' @param null_value The character to use for default values, defaults to \code{NULL}.
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param options A list of strings with additional options.
 #' @param repartition Total of partitions used to distribute table or 0 (default) to avoid partitioning
 #' @param overwrite Overwrite the table with the given name if it already exists
@@ -160,7 +159,8 @@ spark_read_parquet <- function(sc,
 #' Write a Spark DataFrame to a Parquet file
 #'
 #' @inheritParams spark_write_csv
-#'
+#' @param mode Specifies the behavior when data or table already exists.
+#' 
 #' @family reading and writing data
 #'
 #' @export
@@ -183,7 +183,7 @@ spark_write_parquet.spark_jobj <- function(x, path, mode = NULL, options = list(
 #' Read a JSON file into a Spark DataFrame
 #'
 #' @inheritParams spark_read_csv
-#'
+#' 
 #' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3n://}), as well as 
 #'   the local file system (\code{file://}). 
 #'   
@@ -212,7 +212,8 @@ spark_read_json <- function(sc,
 #' Write a Spark DataFrame to a JSON file
 #'
 #' @inheritParams spark_write_csv
-#'
+#' @param mode Specifies the behavior when data or table already exists.
+#' 
 #' @family reading and writing data
 #'
 #' @export

--- a/man/spark_read_csv.Rd
+++ b/man/spark_read_csv.Rd
@@ -34,6 +34,8 @@ spark_read_csv(sc, name, path, header = TRUE, delimiter = ",",
 \item{memory}{Load data eagerly into memory}
 
 \item{overwrite}{Overwrite the table with the given name if it already exists}
+
+\item{mode}{Specifies the behavior when data or table already exists.}
 }
 \value{
 Reference to a Spark DataFrame / dplyr tbl

--- a/man/spark_read_csv.Rd
+++ b/man/spark_read_csv.Rd
@@ -34,8 +34,6 @@ spark_read_csv(sc, name, path, header = TRUE, delimiter = ",",
 \item{memory}{Load data eagerly into memory}
 
 \item{overwrite}{Overwrite the table with the given name if it already exists}
-
-\item{mode}{Specifies the behavior when data or table already exists.}
 }
 \value{
 Reference to a Spark DataFrame / dplyr tbl

--- a/man/spark_read_json.Rd
+++ b/man/spark_read_json.Rd
@@ -4,8 +4,8 @@
 \alias{spark_read_json}
 \title{Read a JSON file into a Spark DataFrame}
 \usage{
-spark_read_json(sc, name, path, repartition = 0, memory = TRUE,
-  overwrite = TRUE)
+spark_read_json(sc, name, path, options = list(), repartition = 0,
+  memory = TRUE, overwrite = TRUE)
 }
 \arguments{
 \item{sc}{The Spark connection}
@@ -13,6 +13,8 @@ spark_read_json(sc, name, path, repartition = 0, memory = TRUE,
 \item{name}{Name of table}
 
 \item{path}{The path to the file. Needs to be accessible from the cluster. Supports: "hdfs://" or "s3n://"}
+
+\item{options}{A list of strings with additional options.}
 
 \item{repartition}{Total of partitions used to distribute table or 0 (default) to avoid partitioning}
 

--- a/man/spark_read_parquet.Rd
+++ b/man/spark_read_parquet.Rd
@@ -4,8 +4,8 @@
 \alias{spark_read_parquet}
 \title{Read a Parquet file into a Spark DataFrame}
 \usage{
-spark_read_parquet(sc, name, path, repartition = 0, memory = TRUE,
-  overwrite = TRUE)
+spark_read_parquet(sc, name, path, options = list(), repartition = 0,
+  memory = TRUE, overwrite = TRUE)
 }
 \arguments{
 \item{sc}{The Spark connection}
@@ -13,6 +13,8 @@ spark_read_parquet(sc, name, path, repartition = 0, memory = TRUE,
 \item{name}{Name of table}
 
 \item{path}{The path to the file. Needs to be accessible from the cluster. Supports: "hdfs://" or "s3n://"}
+
+\item{options}{A list of strings with additional options.}
 
 \item{repartition}{Total of partitions used to distribute table or 0 (default) to avoid partitioning}
 

--- a/man/spark_write_json.Rd
+++ b/man/spark_write_json.Rd
@@ -11,6 +11,8 @@ spark_write_json(x, path, mode = NULL, options = list())
 
 \item{path}{The path to the file. Needs to be accessible from the cluster. Supports: "hdfs://" or "s3n://"}
 
+\item{mode}{Specifies the behavior when data or table already exists.}
+
 \item{options}{A list of strings with additional options.}
 }
 \description{

--- a/man/spark_write_json.Rd
+++ b/man/spark_write_json.Rd
@@ -4,12 +4,14 @@
 \alias{spark_write_json}
 \title{Write a Spark DataFrame to a JSON file}
 \usage{
-spark_write_json(x, path)
+spark_write_json(x, path, mode = NULL, options = list())
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
 
 \item{path}{The path to the file. Needs to be accessible from the cluster. Supports: "hdfs://" or "s3n://"}
+
+\item{options}{A list of strings with additional options.}
 }
 \description{
 Write a Spark DataFrame to a JSON file

--- a/man/spark_write_parquet.Rd
+++ b/man/spark_write_parquet.Rd
@@ -4,12 +4,14 @@
 \alias{spark_write_parquet}
 \title{Write a Spark DataFrame to a Parquet file}
 \usage{
-spark_write_parquet(x, path)
+spark_write_parquet(x, path, mode = NULL, options = list())
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
 
 \item{path}{The path to the file. Needs to be accessible from the cluster. Supports: "hdfs://" or "s3n://"}
+
+\item{options}{A list of strings with additional options.}
 }
 \description{
 Write a Spark DataFrame to a Parquet file

--- a/man/spark_write_parquet.Rd
+++ b/man/spark_write_parquet.Rd
@@ -11,6 +11,8 @@ spark_write_parquet(x, path, mode = NULL, options = list())
 
 \item{path}{The path to the file. Needs to be accessible from the cluster. Supports: "hdfs://" or "s3n://"}
 
+\item{mode}{Specifies the behavior when data or table already exists.}
+
 \item{options}{A list of strings with additional options.}
 }
 \description{


### PR DESCRIPTION
Unblock missing options in read/write parquet/json pointed out by: https://github.com/rstudio/sparklyr/issues/72

@jjallaire feedback welcomed, otherwise, merging later today.