### PR TITLE
extend spark_config documentation with a link to config-template.yml

### DIFF
--- a/man/spark_config.Rd
+++ b/man/spark_config.Rd
@@ -9,7 +9,7 @@ spark_config(file = "config.yml", use_default = TRUE)
 \arguments{
 \item{file}{Name of the configuration file}
 
-\item{use_default}{TRUE to use the built-in detaults provided in this package}
+\item{use_default}{TRUE to use the built-in defaults provided in this package - see \code{file.edit(system.file(file.path("conf", "config-template.yml"), package = "sparklyr"))}
 }
 \value{
 Named list with configuration data


### PR DESCRIPTION
Not every user knows where is that default specification :)