### PR TITLE
Enables to get a SparkContext and to use a running R Backend

### DIFF
--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -3,6 +3,7 @@
 #' @export
 #' @param file Name of the configuration file
 #' @param use_default TRUE to use the built-in detaults provided in this package
+#' @param extraConfig List of configuration parameters provided by the user
 #'
 #' @details
 #'

--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -9,7 +9,7 @@
 #' Read Spark configuration using the \pkg{\link[config]{config}} package.
 #'
 #' @return Named list with configuration data
-spark_config <- function(file = "config.yml", use_default = TRUE) {
+spark_config <- function(file = "config.yml", use_default = TRUE, extraConfig = NULL) {
   baseConfig <- list()
 
   if (use_default) {
@@ -17,7 +17,8 @@ spark_config <- function(file = "config.yml", use_default = TRUE) {
     baseConfig <- config::get(file = localConfigFile)
   }
 
-  userConfig <- tryCatch(config::get(file = file), error = function(e) NULL)
+  userConfig <- merge_lists(tryCatch(config::get(file = file), error = function(e) NULL),
+                            extraConfig)
 
   mergedConfig <- merge_lists(baseConfig, userConfig)
   mergedConfig

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -40,11 +40,14 @@ spark_connect <- function(master,
                           app_name = "sparklyr",
                           version = NULL,
                           hadoop_version = NULL,
-                          config = spark_config(),
+                          config = NULL,
                           extensions = sparklyr::registered_extensions()) {
 
   # validate method
   method <- match.arg(method)
+
+  # merge user-provided config list
+  config <- spark_config(extraConfig = config)
 
   # master can be missing if it's specified in the config file
   if (missing(master)) {

--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -213,9 +213,10 @@ initialize_connection <- function(sc) {
   apply_config(context_config, conf, "set", "spark.")
 
   # create the spark context and assign the connection to it
-  sc$spark_context <- invoke_new(
+  sc$spark_context <- invoke_static(
     sc,
     "org.apache.spark.SparkContext",
+    "getOrCreate",
     conf
   )
   sc$spark_context$connection <- sc

--- a/man/spark_config.Rd
+++ b/man/spark_config.Rd
@@ -4,12 +4,14 @@
 \alias{spark_config}
 \title{Read Spark Configuration}
 \usage{
-spark_config(file = "config.yml", use_default = TRUE)
+spark_config(file = "config.yml", use_default = TRUE, extraConfig = NULL)
 }
 \arguments{
 \item{file}{Name of the configuration file}
 
 \item{use_default}{TRUE to use the built-in detaults provided in this package}
+
+\item{extraConfig}{List of configuration parameters provided by the user}
 }
 \value{
 Named list with configuration data

--- a/man/spark_connect.Rd
+++ b/man/spark_connect.Rd
@@ -6,7 +6,7 @@
 \usage{
 spark_connect(master, spark_home = Sys.getenv("SPARK_HOME"),
   method = c("shell"), app_name = "sparklyr", version = NULL,
-  hadoop_version = NULL, config = spark_config(),
+  hadoop_version = NULL, config = NULL,
   extensions = sparklyr::registered_extensions())
 }
 \arguments{


### PR DESCRIPTION
This PR tries to extend the flexibility of sparklyr in two aspects:
* Get rather than create a SparkContext if there is already one in the background
* Can connect to a running R backend if the user provides the port number