### PR TITLE
SQL Translation: modified `paste` to map to "CONCAT_WS" &  added `paste0` mapping to "CONCAT"

### DIFF
--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -15,7 +15,8 @@ sql_translate_env.spark_connection <- function(con) {
       as.logical = function(x) build_sql("CAST(", x, " AS BOOLEAN)"),
       as.character  = function(x) build_sql("CAST(", x, " AS STRING)"),
       as.date  = function(x) build_sql("CAST(", x, " AS DATE)"),
-      paste = function(...) build_sql("CONCAT", list(...)),
+      paste = function(..., sep = " ") build_sql("CONCAT_WS", list(sep, ...)),
+      paste0 = function(...) build_sql("CONCAT", list(...)),
       xor = function(x, y) build_sql(x, " ^ ", y),
       or = function(x, y) build_sql(x, " or ", y),
       and = function(x, y) build_sql(x, " and ", y)


### PR DESCRIPTION
Allows specification of a separator when contacting string variables, and brings behaviour more in-line with `paste`\`paste0` in base R.