### PR TITLE
add admin support to configure spark ui url

### DIFF
--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -187,7 +187,12 @@ print.spark_log <- function(x, ...) {
 #'
 #' @export
 spark_web <- function(sc, ...) {
-  UseMethod("spark_web")
+  if (!is.null(sc$config$sparklyr.sparkui.url)) {
+    structure(sc$config$sparklyr.sparkui.url, class = "spark_web_url")
+  }
+  else {
+    UseMethod("spark_web")
+  }
 }
 
 #' @export


### PR DESCRIPTION
Small feature request that would make it really easy for admins to set up proxies/etc as needed for the spark ui url: https://github.com/rstudio/sparklyr/issues/206

Intended use:

```{r}
sconf <- spark_config()
sconf[["sparklyr.sparkui.url"]] <- "http://ec2-1-2-3-4.compute-1.amazonaws.com:18080/"
sc <- spark_connect(master = "local", version = "2.0.0", config = sconf)
spark_web(sc)
```

@nwstephens 