### PR TITLE
revert use of readr to allow writeLines to reuse file connection while writ…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.3.14
+Version: 0.3.15
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -281,7 +281,7 @@ spark_conf_file_set_value <- function(installInfo, properties, reset) {
   }
 
   log4jPropertiesFile <- file(log4jPropertiesPath)
-  lines <- readr::read_lines(log4jPropertiesFile)
+  lines <- readLines(log4jPropertiesFile)
 
   lines[[length(lines) + 1]] <- ""
   lines[[length(lines) + 1]] <- "# Other settings"


### PR DESCRIPTION
Revert https://github.com/rstudio/sparklyr/commit/ba8e2a to allow writeLines to reuse file connection while writing log settings.

Otherwise, users get the following warning during `spark_install`:

```
In value[[3L]](cond) : Failed to set logging settings
```

which was referenced in https://github.com/rstudio/sparklyr/issues/114