### PR TITLE
Increase logging while triggering spark_connect to allow exceptions to render

### DIFF
--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -159,14 +159,19 @@ start_shell <- function(master,
   # wait for the shell output file
   waitSeconds <- spark_config_value(config, "sparklyr.ports.wait.seconds", 100)
   if (!wait_file_exists(shell_output_path, waitSeconds)) {
-    stop(paste(
-      "Failed to launch Spark shell. Ports file does not exist.\n",
-      "    Path: ", spark_submit_path, "\n",
-      "    Parameters: ", paste(shell_args, collapse = ", "), "\n",
-      "    \n",
-      paste(readLines(output_file), collapse = "\n"),
-      if (file.exists(error_file)) paste(readLines(error_file), collapse = "\n") else "",
-      sep = ""))
+    withr::with_options(list(
+      warning.length = 5000
+    ), {
+      stop(paste(
+        "Failed to launch Spark shell. Ports file does not exist.\n",
+        "    Path: ", spark_submit_path, "\n",
+        "    Parameters: ", paste(shell_args, collapse = ", "), "\n",
+        "    \n",
+        paste(readLines(output_file), collapse = "\n"),
+        if (file.exists(error_file)) paste(readLines(error_file), collapse = "\n") else "",
+        sep = ""))
+    }
+    )
   }
 
   # read the shell output file


### PR DESCRIPTION
Increase logging while triggering spark_connect to allow exceptions to render. Not planning to take this one before the CRAN checkpoint since the workaround is to set this manually: 

```{r}
options(warning.length = 5000)
```

The issue is that `spark_connect` will show truncated logs when an exception happens:

```
> sc <- spark_connect(master = "local", version = "2.0.0")
Error in as.list(new_options) : 
  Failed to launch Spark shell. Ports file does not exist.
    Path: /Users/javierluraschi/Library/Caches/spark/spark-2.0.0-bin-hadoop2.7/bin/spark-submit
    Parameters: --class, sparklyr.Backend, --packages, 'com.databricks:spark-csv_2.11:1.3.0','com.amazonaws:aws-java-sdk-pom:1.10.34', '/Library/Frameworks/R.framework/Versions/3.2/Resources/library/sparklyr/java/sparklyr-2.0-2.11.jar', /var/folders/fz/v6wfsg2x1fb1rw4f6r0x4jwm0000gn/T//Rtmp9RHCmN/file4cde64b5c4d1.out
    
Ivy Default Cache set to: /Users/javierluraschi/.ivy2/cache
The jars for the packages stored in: /Users/javierluraschi/.ivy2/jars
:: loading settings :: url = jar:file:/Users/javierluraschi/Library/Caches/spark/spark-2.0.0-bin-hadoop2.7/jars/ivy-2.4.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
com.databricks#spark-csv_2.11 added as a dependency
com.amazonaws#aws-java-sdk-pom added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent;1.0
	confs: [default]
	found com.databri
```

This fix increases the printed message to accommodate enough logging to display the exception:

```
> sc <- spark_connect(master = "local", version = "2.0.0")
Error in force(code) : 
  Failed to launch Spark shell. Ports file does not exist.
    Path: /Users/javierluraschi/Library/Caches/spark/spark-2.0.0-bin-hadoop2.7/bin/spark-submit
    Parameters: --class, sparklyr.Backend, --packages, 'com.databricks:spark-csv_2.11:1.3.0','com.amazonaws:aws-java-sdk-pom:1.10.34', '/Library/Frameworks/R.framework/Versions/3.2/Resources/library/sparklyr/java/sparklyr-2.0-2.11.jar', /var/folders/fz/v6wfsg2x1fb1rw4f6r0x4jwm0000gn/T//RtmpuUFv8v/file4d142074892a.out
    
Ivy Default Cache set to: /Users/javierluraschi/.ivy2/cache
The jars for the packages stored in: /Users/javierluraschi/.ivy2/jars
:: loading settings :: url = jar:file:/Users/javierluraschi/Library/Caches/spark/spark-2.0.0-bin-hadoop2.7/jars/ivy-2.4.0.jar!/org/apache/ivy/core/settings/ivysettings.xml
com.databricks#spark-csv_2.11 added as a dependency
com.amazonaws#aws-java-sdk-pom added as a dependency
:: resolving dependencies :: org.apache.spark#spark-submit-parent;1.0
	confs: [default]
	found com.databricks#spark-csv_2.11;1.3.0 in central
	found org.apache.commons#commons-csv;1.1 in central
	found com.univocity#univocity-parsers;1.5.1 in central
	found com.amazonaws#aws-java-sdk-pom;1.10.34 in central
:: resolution report :: resolve 226ms :: artifacts dl 4ms
	:: modules in use:
	com.amazonaws#aws-java-sdk-pom;1.10.34 from central in [default]
	com.databricks#spark-csv_2.11;1.3.0 from central in [default]
	com.univocity#univocity-parsers;1.5.1 from central in [default]
	org.apache.commons#commons-csv;1.1 from central in [default]
	---------------------------------------------------------------------
	|                  |            modules            ||   artifacts   |
	|       conf       | number| search|dwnlded|evicted|| number|dwnlded|
	---------------------------------------------------------------------
	|      default     |   4   |   0   |   0   |   0   ||   3   |   0   |
	---------------------------------------------------------------------
:: retrieving :: org.apache.spark#spark-submit-parent
	confs: [default]
	0 artifacts copied, 3 already retrieved (0kB/7ms)
Exception in thread "main" java.lang.NoClassDefFoundError: org/eclipse/jetty/server/Handler
	at sparklyr.Backend$.main(backend.scala:80)
	at sparklyr.Backend.main(backend.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.spark.deploy.SparkSubmit$.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:729)
	at org.apache.spark.deploy.SparkSubmit$.doRunMain$1(SparkSubmit.scala:185)
	at org.apache.spark.deploy.SparkSubmit$.submit(SparkSubmit.scala:210)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:124)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.server.Handler
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 11 more
```