### PR TITLE
default to 'internal' tar

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.4.17
+Version: 0.4.18
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr 0.5.0 (UNRELEASED)
 
+- `sparklyr` now defaults to `tar = "internal"` in its calls to `untar()`.
+  This should help resolve issues some Windows users have seen related to
+  an inability to connect to Spark, which ultimately were caused by a lack
+  of permissions on the Spark installation.
+
 - Resolved an issue where `copy_to()` and other R => Spark data transfer
   functions could fail when the last column contained missing / empty values.
   (#265)

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -178,7 +178,10 @@ spark_install <- function(version = NULL,
     if (status)
       stopf("Failed to download Spark: download exited with status %s", status)
 
-    untar(tarfile = installInfo$packageLocalPath, exdir = installInfo$sparkDir)
+    untar(tarfile = installInfo$packageLocalPath,
+          exdir = installInfo$sparkDir,
+          tar = "internal")
+
     unlink(installInfo$packageLocalPath)
 
     if (verbose)
@@ -273,7 +276,9 @@ spark_install_tar <- function(tarfile) {
       "The given file does not conform with the following pattern: ", filePattern))
   }
 
-  untar(tarfile = tarfile, exdir = spark_install_dir())
+  untar(tarfile = tarfile,
+        exdir = spark_install_dir(),
+        tar = "internal")
 }
 
 spark_conf_file_set_value <- function(installInfo, properties, reset) {


### PR DESCRIPTION
This PR ensures that we always use R's internal `tar` implementation. This should help in cases where file permissions are not copied as expected when using a version of `tar.exe` discovered on the PATH for Windows users.

NOTE: need to adequately test this PR before merge.