### PR TITLE
Commentd out shell_args <- NULL so that the shell args will be passed to the command line

### DIFF
--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -131,7 +131,7 @@ start_shell <- function(master,
   output_file <- NULL
   error_file <- NULL
   spark_submit_path <- NULL
-  shell_args <- NULL
+  #shell_args <- NULL
   shQuoteType <- if (.Platform$OS.type == "windows") "cmd" else NULL
 
   if (is.null(gatewayInfo) || gatewayInfo$backendPort == 0)

--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -131,7 +131,7 @@ start_shell <- function(master,
   output_file <- NULL
   error_file <- NULL
   spark_submit_path <- NULL
-  #shell_args <- NULL
+
   shQuoteType <- if (.Platform$OS.type == "windows") "cmd" else NULL
 
   if (is.null(gatewayInfo) || gatewayInfo$backendPort == 0)


### PR DESCRIPTION
shell_args was always set to NULL. This had the undesired effect that the "sparklyr.shell.xxxxx" config settings were always ignored.