### PR TITLE
add support for infer_schema and columns options to spark_read_csv

### DIFF
--- a/R/data_csv.R
+++ b/R/data_csv.R
@@ -10,7 +10,7 @@ spark_csv_read <- function(sc,
   })
 
   if (identical(columns, NULL)) {
-    optionSchema <- invoke(options, "option", "inferSchema", "true")
+    optionSchema <- options
   }
   else {
     columnDefs <- spark_data_build_types(sc, columns)

--- a/R/data_csv.R
+++ b/R/data_csv.R
@@ -5,6 +5,17 @@ spark_csv_read <- function(sc,
   read <- invoke(hive_context(sc), "read")
   options <- invoke(read, "format", "com.databricks.spark.csv")
 
+  if (!identical(columns, NULL)) {
+    ncol_ds <- options %>%
+      invoke("load", path) %>%
+      invoke("schema") %>%
+      invoke("length")
+
+    if (ncol_ds != length(columns)) {
+      warning("Dataset has ", ncol_ds, " columns but 'columns' has length ", length(columns))
+    }
+  }
+
   lapply(names(csvOptions), function(csvOptionName) {
     options <<- invoke(options, "option", csvOptionName, csvOptions[[csvOptionName]])
   })

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -34,7 +34,7 @@ spark_csv_options <- function(header,
 #'   Defaults to \code{TRUE}.
 #' @param columns A named vector specifying column types.
 #' @param infer_schema Boolean; should column types be automatically inferred?
-#'   Requires one extra pass over the data. Defaults to \code{FALSE}.
+#'   Requires one extra pass over the data. Defaults to \code{TRUE}.
 #' @param delimiter The character used to delimit each column. Defaults to \samp{','}.
 #' @param quote The character used as a quote. Defaults to \samp{'"'}.
 #' @param escape The character used to escape other characters. Defaults to \samp{'\'}.
@@ -64,7 +64,7 @@ spark_read_csv <- function(sc,
                            path,
                            header = TRUE,
                            columns = NULL,
-                           infer_schema = FALSE,
+                           infer_schema = TRUE,
                            delimiter = ",",
                            quote = "\"",
                            escape = "\\",
@@ -140,7 +140,7 @@ spark_write_csv.tbl_spark <- function(x,
                                       null_value = NULL,
                                       options = list()) {
   sqlResult <- spark_sqlresult_from_dplyr(x)
-  options <- spark_csv_options(header, delimiter, quote, escape, charset, null_value, options)
+  options <- spark_csv_options(header, TRUE, delimiter, quote, escape, charset, null_value, options)
 
   spark_csv_write(sqlResult, spark_normalize_path(path), options)
 }
@@ -156,7 +156,7 @@ spark_write_csv.spark_jobj <- function(x,
                                        null_value = NULL,
                                        options = list()) {
   spark_expect_jobj_class(x, "org.apache.spark.sql.DataFrame")
-  options <- spark_csv_options(header, delimiter, quote, escape, charset, null_value, options)
+  options <- spark_csv_options(header, TRUE, delimiter, quote, escape, charset, null_value, options)
 
   spark_csv_write(x, spark_normalize_path(path), options)
 }

--- a/man/spark_read_csv.Rd
+++ b/man/spark_read_csv.Rd
@@ -4,9 +4,10 @@
 \alias{spark_read_csv}
 \title{Read a CSV file into a Spark DataFrame}
 \usage{
-spark_read_csv(sc, name, path, header = TRUE, delimiter = ",",
-  quote = "\\"", escape = "\\\\", charset = "UTF-8", null_value = NULL,
-  options = list(), repartition = 0, memory = TRUE, overwrite = TRUE)
+spark_read_csv(sc, name, path, header = TRUE, columns = NULL,
+  infer_schema = FALSE, delimiter = ",", quote = "\\"", escape = "\\\\",
+  charset = "UTF-8", null_value = NULL, options = list(),
+  repartition = 0, memory = TRUE, overwrite = TRUE)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -18,6 +19,11 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{header}{Boolean; should the first row of data be used as a header?
 Defaults to \code{TRUE}.}
+
+\item{columns}{A named vector specifying column types.}
+
+\item{infer_schema}{Boolean; should column types be automatically inferred?
+Requires one extra pass over the data. Defaults to \code{FALSE}.}
 
 \item{delimiter}{The character used to delimit each column. Defaults to \samp{','}.}
 

--- a/man/spark_read_csv.Rd
+++ b/man/spark_read_csv.Rd
@@ -5,7 +5,7 @@
 \title{Read a CSV file into a Spark DataFrame}
 \usage{
 spark_read_csv(sc, name, path, header = TRUE, columns = NULL,
-  infer_schema = FALSE, delimiter = ",", quote = "\\"", escape = "\\\\",
+  infer_schema = TRUE, delimiter = ",", quote = "\\"", escape = "\\\\",
   charset = "UTF-8", null_value = NULL, options = list(),
   repartition = 0, memory = TRUE, overwrite = TRUE)
 }
@@ -23,7 +23,7 @@ Defaults to \code{TRUE}.}
 \item{columns}{A named vector specifying column types.}
 
 \item{infer_schema}{Boolean; should column types be automatically inferred?
-Requires one extra pass over the data. Defaults to \code{FALSE}.}
+Requires one extra pass over the data. Defaults to \code{TRUE}.}
 
 \item{delimiter}{The character used to delimit each column. Defaults to \samp{','}.}
 


### PR DESCRIPTION
Expose `infer_schema` and `columns` options to `spark_read_csv`. The former is defaulted to `FALSE` even if no schema is provided because the inference takes a long time for large datasets.

Related to https://github.com/rstudio/sparklyr/issues/261
