### PR TITLE
use spark.sql.warehouse.dir especially for spark 2.0 windows installs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.4.25
+Version: 0.4.26
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.5.0 (UNRELEASED)
 
+- Improved Spark 2.0 installation in Windows by creating spark-defaults.conf
+  and configuring spark.sql.warehouse.dir.
+
 - Embedded Apache Spark package dependencies to avoid requiring internet 
   connectivity while connecting for the first thhrough `spark_connect`. The
   `sparklyr.csv.embedded` config setting was added to configure a regular

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -199,7 +199,7 @@ spark_install <- function(version = NULL,
 
   if (!identical(logging, NULL)) {
     tryCatch({
-      spark_conf_file_set_value(
+      spark_conf_log4j_set_value(
         installInfo,
         list(
           "log4j.rootCategory" = paste0("log4j.rootCategory=", logging, ",console,localfile"),
@@ -214,6 +214,7 @@ spark_install <- function(version = NULL,
   }
 
   hiveSitePath <- file.path(installInfo$sparkConfDir, "hive-site.xml")
+  hivePath <- NULL
   if (!file.exists(hiveSitePath) || reset) {
     tryCatch({
       hiveProperties <- list(
@@ -234,6 +235,19 @@ spark_install <- function(version = NULL,
       spark_hive_file_set_value(hiveSitePath, hiveProperties)
     }, error = function(e) {
       warning("Failed to apply custom hive-site.xml configuration")
+    })
+  }
+
+  if (!is.null(hivePath)) {
+    tryCatch({
+      spark_conf_file_set_value(
+        installInfo,
+        list(
+          "spark.sql.warehouse.dir" = paste0("spark.sql.warehouse.dir          ", hivePath)
+        )
+      )
+    }, error = function(e) {
+      warning("Failed to set spark-defaults.conf settings")
     })
   }
 
@@ -281,7 +295,7 @@ spark_install_tar <- function(tarfile) {
         tar = "internal")
 }
 
-spark_conf_file_set_value <- function(installInfo, properties, reset) {
+spark_conf_log4j_set_value <- function(installInfo, properties, reset) {
   log4jPropertiesPath <- file.path(installInfo$sparkConfDir, "log4j.properties")
   if (!file.exists(log4jPropertiesPath) || reset) {
     log4jTemplatePath <- file.path(installInfo$sparkConfDir, "log4j.properties.template")
@@ -292,7 +306,6 @@ spark_conf_file_set_value <- function(installInfo, properties, reset) {
   lines <- readLines(log4jPropertiesFile)
 
   lines[[length(lines) + 1]] <- ""
-  lines[[length(lines) + 1]] <- "# Other settings"
 
   lapply(names(properties), function(property) {
     value <- properties[[property]]
@@ -328,4 +341,32 @@ spark_hive_file_set_value <- function(hivePath, properties) {
   hiveFile <- file(hivePath)
   writeLines(unlist(lines), hiveFile)
   close(hiveFile)
+}
+
+spark_conf_file_set_value <- function(installInfo, properties, reset) {
+  confPropertiesPath <- file.path(installInfo$sparkConfDir, "spark-defaults.conf")
+  if (!file.exists(confPropertiesPath) || reset) {
+    confTemplatePath <- file.path(installInfo$sparkConfDir, "spark-defaults.conf.template")
+    file.copy(confTemplatePath, confPropertiesPath, overwrite = TRUE)
+  }
+
+  confPropertiesFile <- file(confPropertiesPath)
+  lines <- readLines(confPropertiesFile)
+
+  lines[[length(lines) + 1]] <- ""
+
+  lapply(names(properties), function(property) {
+    value <- properties[[property]]
+    pattern <- paste(property, ".*", sep = "")
+
+    if (length(grep(pattern, lines)) > 0) {
+      lines <<- gsub(pattern, value, lines, perl = TRUE)
+    }
+    else {
+      lines[[length(lines) + 1]] <<- value
+    }
+  })
+
+  writeLines(lines, confPropertiesFile)
+  close(confPropertiesFile)
 }


### PR DESCRIPTION
Windows users in Spark 2.0 have to been setting the `spark.sql.warehouse.dir` to the hive path to workaround exceptions. I have not been able to repro this but enough people pointed to this workaround that is worth to include: https://github.com/rstudio/sparklyr/issues/189

Also, this Spark issue (https://issues.apache.org/jira/browse/SPARK-15034) points out that in 2.0 `hive.metastore.warehouse.dir` is no longer in use and has been replaced by `spark.sql.warehouse.dir`.

Will merge in a few days in case there is feedback.