### PR TITLE
set sparklyr.do.implicit.dot to FALSE

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -8,5 +8,5 @@ set_option_default <- function(...) {
 
 .onLoad <- function(...) {
   set_option_default(sparklyr.na.action.verbose = TRUE,
-                     sparklyr.do.implicit.dot   = TRUE)
+                     sparklyr.do.implicit.dot   = FALSE)
 }


### PR DESCRIPTION
@kevinushey:

I think setting this to `TRUE` makes this feature a bit harder to use, for instance, I was helping someone troubleshoot:

```
iris_tbl %>% group_by(Species) %>% do(other = "x")
```

The other user we know of was following this guide: https://cran.r-project.org/web/packages/dplyr/dplyr.pdf which also uses explicit `.` so I can't find a good example at the moment where people would expect to pass `.` implicitly, thoughts?