### PR TITLE
fix sparklyr in windows for spark 2.0.1 #323

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.4.27
+Version: 0.4.28
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -244,7 +244,8 @@ spark_install <- function(version = NULL,
         installInfo,
         list(
           "spark.sql.warehouse.dir" = paste0("spark.sql.warehouse.dir          ", hivePath)
-        )
+        ),
+        reset
       )
     }, error = function(e) {
       warning("Failed to set spark-defaults.conf settings")

--- a/inst/conf/config-template.yml
+++ b/inst/conf/config-template.yml
@@ -5,7 +5,7 @@ default:
   spark.env.SPARK_LOCAL_IP.local: 127.0.0.1
 
   # include the embedded csv package for spark 1.x
-  sparklyr.csv.embedded: "1.*"
+  sparklyr.csv.embedded: "^1.*"
 
   # default spark packages to load
   # sparklyr.defaultPackages:


### PR DESCRIPTION
The root cause of https://github.com/rstudio/sparklyr/issues/323 is that we were deploying the `spark-csv.jar` on `2.0.1`; however, the error being thrown was completely unrelated since reflection was causing unforeseen consequences.