### PR TITLE
add support for 'data' argument in ml routines

### DIFF
--- a/R/ml_alternating_least_squares.R
+++ b/R/ml_alternating_least_squares.R
@@ -25,10 +25,10 @@ ml_als_factorization <- function(x,
                                  ml.options = ml_options(),
                                  ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   rating.column <- ensure_scalar_character(rating.column)
   user.column <- ensure_scalar_character(user.column)

--- a/R/ml_backwards_compatibility.R
+++ b/R/ml_backwards_compatibility.R
@@ -20,4 +20,10 @@ ml_backwards_compatibility_api <- function(envir = parent.frame()) {
   # allow 'output_col' as alias for output.col
   if (is.null(envir$output.col) && !is.null(dots$output_col))
     assign("output.col", dots$output_col, envir = envir)
+
+  # allow 'data' as an optional parameter
+  if (!is.null(dots$data) && is.formula(envir$x)) {
+    assign("response", envir$x, envir = envir)
+    assign("x", dots$data, envir = envir)
+  }
 }

--- a/R/ml_decision_tree.R
+++ b/R/ml_decision_tree.R
@@ -23,10 +23,10 @@ ml_decision_tree <- function(x,
                              ml.options = ml_options(),
                              ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_generalized_linear_regression.R
+++ b/R/ml_generalized_linear_regression.R
@@ -31,11 +31,12 @@ ml_generalized_linear_regression <-
            ml.options = ml_options(),
            ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-  spark_require_version(sc, "2.0.0")
 
-  ml_backwards_compatibility_api()
+  spark_require_version(sc, "2.0.0")
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_gradient_boosted_tree.R
+++ b/R/ml_gradient_boosted_tree.R
@@ -23,10 +23,10 @@ ml_gradient_boosted_trees <- function(x,
                                       ml.options = ml_options(),
                                       ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_kmeans.R
+++ b/R/ml_kmeans.R
@@ -30,10 +30,10 @@ ml_kmeans <- function(x,
                       ml.options = ml_options(),
                       ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   df <- ml_prepare_features(
     x = df,

--- a/R/ml_lda.R
+++ b/R/ml_lda.R
@@ -34,12 +34,10 @@ ml_lda <- function(x,
                    ml.options = ml_options(),
                    ...)
 {
-  stopifnot(alpha > 1)
+  ml_backwards_compatibility_api()
 
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   df <- ml_prepare_features(
     x = df,
@@ -52,6 +50,8 @@ ml_lda <- function(x,
   beta       <- ensure_scalar_double(beta)
   k          <- ensure_scalar_integer(k)
   only.model <- ensure_scalar_boolean(ml.options$only.model)
+
+  stopifnot(alpha > 1)
 
   envir <- new.env(parent = emptyenv())
 

--- a/R/ml_linear_regression.R
+++ b/R/ml_linear_regression.R
@@ -24,10 +24,10 @@ ml_linear_regression <- function(x,
                                  ml.options = ml_options(),
                                  ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_logistic_regression.R
+++ b/R/ml_logistic_regression.R
@@ -24,10 +24,10 @@ ml_logistic_regression <- function(x,
                                    ml.options = ml_options(),
                                    ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_multilayer_perceptron.R
+++ b/R/ml_multilayer_perceptron.R
@@ -26,10 +26,10 @@ ml_multilayer_perceptron <- function(x,
                                      ml.options = ml_options(),
                                      ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_naive_bayes.R
+++ b/R/ml_naive_bayes.R
@@ -19,10 +19,10 @@ ml_naive_bayes <- function(x,
                            ml.options = ml_options(),
                            ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_one_vs_rest.R
+++ b/R/ml_one_vs_rest.R
@@ -20,10 +20,10 @@ ml_one_vs_rest <- function(x,
                            ml.options = ml_options(),
                            ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_pca.R
+++ b/R/ml_pca.R
@@ -16,10 +16,10 @@ ml_pca <- function(x,
                    ml.options = ml_options(),
                    ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   df <- ml_prepare_features(
     x = df,

--- a/R/ml_random_forest.R
+++ b/R/ml_random_forest.R
@@ -25,10 +25,10 @@ ml_random_forest <- function(x,
                              ml.options = ml_options(),
                              ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/R/ml_survival_regression.R
+++ b/R/ml_survival_regression.R
@@ -26,10 +26,10 @@ ml_survival_regression <- function(x,
                                    ml.options = ml_options(),
                                    ...)
 {
+  ml_backwards_compatibility_api()
+
   df <- spark_dataframe(x)
   sc <- spark_connection(df)
-
-  ml_backwards_compatibility_api()
 
   categorical.transformations <- new.env(parent = emptyenv())
   df <- ml_prepare_response_features_intercept(

--- a/man-roxygen/roxlate-ml-dots.R
+++ b/man-roxygen/roxlate-ml-dots.R
@@ -1,1 +1,4 @@
-#' @param ... Optional arguments; currently unused.
+#' @param ... Optional arguments. The \code{data} argument can be used to
+#'   specify the data to be used when \code{x} is a formula; this allows calls
+#'   of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+#'   especially useful in conjunction with \code{\link{do}}.

--- a/man/ml_als_factorization.Rd
+++ b/man/ml_als_factorization.Rd
@@ -27,7 +27,10 @@ ml_als_factorization(x, rating.column = "rating", user.column = "user",
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform alternating least squares matrix factorization on a Spark DataFrame.

--- a/man/ml_decision_tree.Rd
+++ b/man/ml_decision_tree.Rd
@@ -38,7 +38,10 @@ then regression is used; classification otherwise.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform regression or classification using decision trees.

--- a/man/ml_generalized_linear_regression.Rd
+++ b/man/ml_generalized_linear_regression.Rd
@@ -32,7 +32,10 @@ passed in to calls to \R's own \code{\link{glm}}.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform generalized linear regression on a Spark DataFrame.

--- a/man/ml_gradient_boosted_trees.Rd
+++ b/man/ml_gradient_boosted_trees.Rd
@@ -38,7 +38,10 @@ then regression is used; classification otherwise.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform regression or classification using gradient-boosted trees.

--- a/man/ml_kmeans.Rd
+++ b/man/ml_kmeans.Rd
@@ -24,7 +24,10 @@ ml_kmeans(x, centers, iter.max = 100, features = dplyr::tbl_vars(x),
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \value{
 \link{ml_model} object of class \code{kmeans} with overloaded \code{print}, \code{fitted} and \code{predict} functions.

--- a/man/ml_lda.Rd
+++ b/man/ml_lda.Rd
@@ -23,7 +23,10 @@ By default \code{alpha = (50 / k) + 1}, where \code{50/k} is common in LDA libra
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Fit a Latent Dirichlet Allocation (LDA) model to a Spark DataFrame.

--- a/man/ml_linear_regression.Rd
+++ b/man/ml_linear_regression.Rd
@@ -32,7 +32,10 @@ information.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform linear regression on a Spark DataFrame.

--- a/man/ml_logistic_regression.Rd
+++ b/man/ml_logistic_regression.Rd
@@ -32,7 +32,10 @@ information.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform logistic regression on a Spark DataFrame.

--- a/man/ml_multilayer_perceptron.Rd
+++ b/man/ml_multilayer_perceptron.Rd
@@ -34,7 +34,10 @@ reproducible across repeated calls.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Creates and trains multilayer perceptron on a Spark DataFrame.

--- a/man/ml_naive_bayes.Rd
+++ b/man/ml_naive_bayes.Rd
@@ -26,7 +26,10 @@ The intercept term can be omitted by using \code{- 1} in the model fit.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform regression or classification using naive bayes.

--- a/man/ml_one_vs_rest.Rd
+++ b/man/ml_one_vs_rest.Rd
@@ -27,7 +27,10 @@ The intercept term can be omitted by using \code{- 1} in the model fit.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform regression or classification using one vs rest.

--- a/man/ml_pca.Rd
+++ b/man/ml_pca.Rd
@@ -16,7 +16,10 @@ analysis. Defaults to all columns in \code{x}.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform principal components analysis on a Spark DataFrame.

--- a/man/ml_prepare_dataframe.Rd
+++ b/man/ml_prepare_dataframe.Rd
@@ -21,7 +21,10 @@ parameters (if available). Currently, only simple linear combinations of
 existing parameters is supposed; e.g. \code{response ~ feature1 + feature2 + ...}.
 The intercept term can be omitted by using \code{- 1} in the model fit.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -40,7 +40,10 @@ then regression is used; classification otherwise.}
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform regression or classification using random forests with a Spark DataFrame.

--- a/man/ml_survival_regression.Rd
+++ b/man/ml_survival_regression.Rd
@@ -32,7 +32,10 @@ This should be a numeric vector, with 0 marking uncensored data, and
 \item{ml.options}{Optional arguments, used to affect the model generated. See
 \code{\link{ml_options}} for more details.}
 
-\item{...}{Optional arguments; currently unused.}
+\item{...}{Optional arguments. The \code{data} argument can be used to
+specify the data to be used when \code{x} is a formula; this allows calls
+of the form \code{ml_linear_regression(y ~ x, data = tbl)}, and is
+especially useful in conjunction with \code{\link{do}}.}
 }
 \description{
 Perform survival regression on a Spark DataFrame, using an Accelerated

--- a/tests/testthat/test-dplyr-do.R
+++ b/tests/testthat/test-dplyr-do.R
@@ -5,7 +5,6 @@ test_requires("ggplot2")
 diamonds_tbl <- testthat_tbl("diamonds")
 
 test_that("the (serial) implementation of 'do' functions as expected", {
-
   test_requires("dplyr")
 
   R <- diamonds %>%
@@ -25,5 +24,14 @@ test_that("the (serial) implementation of 'do' functions as expected", {
     rhs <- S$model[[i]]
     expect_equal(lhs$coefficients, rhs$coefficients)
   }
+
+})
+
+test_that("ml routines handle 'data' argument with 'do'", {
+  test_requires("dplyr")
+
+  S <- diamonds_tbl %>%
+    group_by(color) %>%
+    do(model = ml_linear_regression(price ~ x + y + z, data = .))
 
 })


### PR DESCRIPTION
This PR adds support for ml calls of the form `ml_linear_regression(y ~ x, data = data)`.