### PR TITLE
Refactor copy_to into sdf_import

### DIFF
--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -84,28 +84,7 @@ copy_to.spark_connection <- function(dest,
                                      overwrite = FALSE,
                                      ...)
 {
-  if (!is.data.frame(df)) {
-    stop("copy_to expects a local data frame")
-  }
-
-  sc <- dest
-
-  if (overwrite)
-    spark_remove_table_if_exists(sc, name)
-
-  if (name %in% src_tbls(sc))
-    stop("table ", name, " already exists (pass overwrite = TRUE to overwrite)")
-
-  dots <- list(...)
-  serializer <- dots$serializer
-  spark_data_copy(sc, df, name = name, repartition = repartition, serializer = serializer)
-
-  if (memory)
-    tbl_cache(sc, name)
-
-  on_connection_updated(sc, name)
-
-  tbl(sc, name)
+  sdf_copy_to(dest, df, name, memory, repartition, overwrite)
 }
 
 #' @export

--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -27,10 +27,10 @@
 #' @export
 sdf_copy_to <- function(sc,
                         x,
-                        name = deparse(substitute(x)),
-                        memory = TRUE,
-                        repartition = 0L,
-                        overwrite = FALSE,
+                        name,
+                        memory,
+                        repartition,
+                        overwrite,
                         ...) {
   UseMethod("sdf_copy_to")
 }
@@ -38,12 +38,12 @@ sdf_copy_to <- function(sc,
 #' @export
 sdf_copy_to.default <- function(sc,
                                 x,
-                                name,
-                                memory,
-                                repartition,
-                                overwrite,
+                                name = deparse(substitute(x)),
+                                memory = TRUE,
+                                repartition = 0L,
+                                overwrite = FALSE,
                                 ...
-                                ) {
+) {
   sdf_import(x, sc, name, memory, repartition, overwrite)
 }
 
@@ -51,10 +51,10 @@ sdf_copy_to.default <- function(sc,
 #' @export
 sdf_import <- function(x,
                        sc,
-                       name = random_string("sparklyr_tmp_"),
-                       memory = TRUE,
-                       repartition = 0L,
-                       overwrite = FALSE,
+                       name,
+                       memory,
+                       repartition,
+                       overwrite,
                        ...) {
   UseMethod("sdf_import")
 }
@@ -62,10 +62,10 @@ sdf_import <- function(x,
 #' @export
 sdf_import.default <- function(x,
                                sc,
-                               name,
-                               memory,
-                               repartition,
-                               overwrite,
+                               name = random_string("sparklyr_tmp_"),
+                               memory = TRUE,
+                               repartition = 0L,
+                               overwrite = FALSE,
                                ...)
 {
   # ensure data.frame

--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -78,23 +78,6 @@ sdf_import.default <- function(x,
     )
   }
 
-  # generate a CSV file from the associated data frame
-  # note that these files need to live for the R session
-  # duration so we don't clean these up eagerly
-  # write file based on hash to avoid writing too many files
-  # on repeated import calls
-  hash <- digest::digest(x, algo = "sha256")
-  filename <- paste("spark_csv_", hash, ".csv", sep = "")
-  tempfile <- file.path(tempdir(), filename)
-
-  if (!file.exists(tempfile)) {
-    readr::write_csv(
-      x,
-      path = tempfile,
-      col_names = TRUE
-    )
-  }
-
   if (overwrite)
     spark_remove_table_if_exists(sc, name)
   else if (name %in% src_tbls(sc))

--- a/man/sdf_copy_to.Rd
+++ b/man/sdf_copy_to.Rd
@@ -5,14 +5,27 @@
 \alias{sdf_import}
 \title{Copy an Object into Spark}
 \usage{
-sdf_copy_to(sc, x, ...)
+sdf_copy_to(sc, x, name = deparse(substitute(x)), memory = TRUE,
+  repartition = 0L, overwrite = FALSE, ...)
 
-sdf_import(x, sc, ...)
+sdf_import(x, sc, name = random_string("sparklyr_tmp_"), memory = TRUE,
+  repartition = 0L, overwrite = FALSE, ...)
 }
 \arguments{
 \item{sc}{The associated Spark connection.}
 
 \item{x}{An \R object from which a Spark DataFrame can be generated.}
+
+\item{name}{The name to assign to the copied table in Spark.}
+
+\item{memory}{Boolean; should the table be cached into memory?}
+
+\item{repartition}{The number of partitions to use when distributing the
+table across the Spark cluster. The default (0) can be used to avoid
+partitioning.}
+
+\item{overwrite}{Boolean; overwrite a pre-existing table with the name \code{name}
+if one already exists?}
 
 \item{...}{Optional arguments, passed to implementing methods.}
 }

--- a/man/sdf_copy_to.Rd
+++ b/man/sdf_copy_to.Rd
@@ -5,11 +5,9 @@
 \alias{sdf_import}
 \title{Copy an Object into Spark}
 \usage{
-sdf_copy_to(sc, x, name = deparse(substitute(x)), memory = TRUE,
-  repartition = 0L, overwrite = FALSE, ...)
+sdf_copy_to(sc, x, name, memory, repartition, overwrite, ...)
 
-sdf_import(x, sc, name = random_string("sparklyr_tmp_"), memory = TRUE,
-  repartition = 0L, overwrite = FALSE, ...)
+sdf_import(x, sc, name, memory, repartition, overwrite, ...)
 }
 \arguments{
 \item{sc}{The associated Spark connection.}


### PR DESCRIPTION
This is a merge from the functionality in `copy_to` (the copying based on serialization methods to support cluster copies) and the functionality in `sdf_import` (the hashing and conversion to data frame if needed).

Two reasons fopr this change:
1) Is confusing to users that only `copy_to` is redocumented in the `dplyr` documentation. Instead, we want `sdf_copy_to` to be the default entry point for documentation since there are users that use `sparklyr` but not `dplyr`.
2) `sdf_import` does not support copying into a cluster where the HDFS file that is persisted is not available to all nodes, therefore, we use the `string_serializer` as needed in `sdf_import` as well.

I'm also planning to remove `copy_to` from the documentation and rename the "dplyr Interface" section into "dplyr Extensions" since we want to not re-document each dplyr function.

CC: @kevinushey