### PR TITLE
Bugfix: Allow column naming when HEADER=FALSE and columns defined

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -84,8 +84,8 @@ spark_read_csv <- function(sc,
   options <- spark_csv_options(header, infer_schema, delimiter, quote, escape, charset, null_value, options)
   df <- spark_csv_read(sc, spark_normalize_path(path), options, columns)
 
-  if (identical(header, FALSE)) {
-    # normalize column names when header = FALSE
+  if (identical(header, FALSE) & (identical(columns, NULL))) {
+    # create normalized column names when header = FALSE and a columns specification is not supplied
     columns <- invoke(df, "columns")
     n <- length(columns)
     newNames <- sprintf("V%s", seq_len(n))


### PR DESCRIPTION
When calling `spark_read_csv()` with column names defined in the 'columns' named list and the condition HEADER = FALSE, the column names parameter is currently ignored and 'normalized' column names are generated instead of using the supplied names.

Adding the above condition to the `if` statement for normalizing column names fixes the issue.