### PR TITLE
Use get directly rather than duplicating the function

### DIFF
--- a/R/connection_viewer.R
+++ b/R/connection_viewer.R
@@ -14,14 +14,9 @@ on_connection_opened <- function(scon, connectCall) {
 
       # finder function
       finder = function(env, host) {
-        # we duplicate the to_host function here b/c R CMD check
-        # doesn't like our using ::: to access to_host in the
+        # R CMD check doesn't like our using ::: to access to_host in the
         # finder function
-        to_host <- function(sc) {
-          paste0(gsub("local\\[(\\d+|\\*)\\]", "local", sc$master),
-                 " - ",
-                 sc$app_name)
-        }
+        to_host <- get("to_host", asNamespace("sparklyr"))
         objs <- ls(env)
         for (name in objs) {
           x <- base::get(name, envir = env)


### PR DESCRIPTION
Should make maintainability easier if the definition of `to_host()` ever changes in the future.

See also [`devtools:::"%:::%"`](https://github.com/hadley/devtools/blob/e6df6cf8f410371241a21f32d1960771b4acd7c9/R/utils.r#L15-L17) for a nice syntax if you end up needing to do this more frequently.