### PR TITLE
Improve performance for dplyr chains with ml

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.4.34
+Version: 0.4.35
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Sparklyr 0.5.0 (UNRELEASED)
 
+- Improved performance when a complex dplyr chain is piped directly into
+  ml routines.
+
+- Fixed issue in spark_read_csv when headers=FALSE but columns are provided
+  where columns would still get normalized.
+
 - Support to configure Livy using the `livy.` prefix in the `config.yml` file.
 
 - Implemented experimental support for Livy through: `livy_install`, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,5 @@
 # Sparklyr 0.5.0 (UNRELEASED)
 
-- Improved performance when a complex dplyr chain is piped directly into
-  ml routines.
-
 - Fixed issue in spark_read_csv when headers=FALSE but columns are provided
   where columns would still get normalized.
 

--- a/R/formulas.R
+++ b/R/formulas.R
@@ -107,11 +107,6 @@ ml_prepare_response_features_intercept <- function(x = NULL,
   # construct dummy data.frame from Spark DataFrame schema
   df <- x
 
-  # register df to improve performance, this is specially critical when
-  # a complex dplyr chain is piped directly into an ml function, see #308.
-  df <- sdf_register(df)
-  invoke(spark_dataframe(df), "cache")
-
   schema <- sdf_schema(df)
   names <- lapply(schema, `[[`, "name")
   rdf <- as.data.frame(names, stringsAsFactors = FALSE, optional = TRUE)

--- a/R/formulas.R
+++ b/R/formulas.R
@@ -106,6 +106,11 @@ ml_prepare_response_features_intercept <- function(x = NULL,
 {
   # construct dummy data.frame from Spark DataFrame schema
   df <- x
+
+  # register df to improve performance, this is specially critical when
+  # a complex dplyr chain is piped directly into an ml function, see #308.
+  df <- sdf_register(df)
+
   schema <- sdf_schema(df)
   names <- lapply(schema, `[[`, "name")
   rdf <- as.data.frame(names, stringsAsFactors = FALSE, optional = TRUE)

--- a/R/formulas.R
+++ b/R/formulas.R
@@ -110,6 +110,7 @@ ml_prepare_response_features_intercept <- function(x = NULL,
   # register df to improve performance, this is specially critical when
   # a complex dplyr chain is piped directly into an ml function, see #308.
   df <- sdf_register(df)
+  invoke(spark_dataframe(df), "cache")
 
   schema <- sdf_schema(df)
   names <- lapply(schema, `[[`, "name")

--- a/R/formulas.R
+++ b/R/formulas.R
@@ -106,7 +106,6 @@ ml_prepare_response_features_intercept <- function(x = NULL,
 {
   # construct dummy data.frame from Spark DataFrame schema
   df <- x
-
   schema <- sdf_schema(df)
   names <- lapply(schema, `[[`, "name")
   rdf <- as.data.frame(names, stringsAsFactors = FALSE, optional = TRUE)

--- a/R/na_actions.R
+++ b/R/na_actions.R
@@ -58,7 +58,15 @@ na.omit.spark_jobj <- function(object, columns = NULL, ...) {
     }
   }
 
-  sdf_register(dropped)
+  # using a df created from drop actions reduces performance, see #308.
+  if (identical(n_before, n_after)) {
+    object
+  } else {
+    result <- sdf_register(dropped)
+    invoke(spark_dataframe(result), "cache")
+
+    result
+  }
 }
 
 #' @export

--- a/R/na_actions.R
+++ b/R/na_actions.R
@@ -44,9 +44,9 @@ na.omit.spark_jobj <- function(object, columns = NULL, ...) {
     "sparklyr.verbose"
   )
 
-  n_before <- if (verbose) invoke(object, "count")
+  n_before <- invoke(object, "count")
   dropped  <- sdf_na_omit(object, columns)
-  n_after  <- if (verbose) invoke(dropped, "count")
+  n_after  <- invoke(dropped, "count")
 
   if (verbose) {
     n_diff <- n_before - n_after


### PR DESCRIPTION
Perf regression investigation for https://github.com/rstudio/sparklyr/issues/308, in summary, 4728843 and 591fd31 added valuable functionality to match behavior of `na.action` and to ensure columns are stable across computations; therefore, the computations are needed. Users can avoid the `na.action` functionality by setting `na.action = NULL` in their `ml.options` the other one is required for correct computations.

This PR does improve the case where `na.action` has no side-effect or when it does have a side effect, it caches the output.

The following are perf results for a real `ml_linear_regression` provided by a user over a 260MB partitioned over 200 csv files ran in EMR with a single `m3.xlarge` instance and the data loaded in a S3 bucket.

With `0.4.0` from CRAN:

```
   user  system elapsed 
  1.400   0.144  246.99
```

With master branch this hangs for more than an hour in my particular configuration in EMR.

With master and `na.action = NULL`

```
   user  system elapsed 
  1.936   0.308 373.917 
```

With this PR

```
   user  system elapsed 
  2.060   0.388 478.441 
```

With this PR and `na.action = NULL`

```
   user  system elapsed 
  1.988   0.232 395.106 
```