### PR TITLE
Add support to add spark-submit params with sparklyr.shell.args env var

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 - Implemented basic authorization for livy connections using livy_config_auth().
 
+- Added support to sepcify additional spark-submit parameters using the
+  sparklyr.shell.args environment variable.
+
 - Renamed sdf_load and sdf_save to spark_read and spark_write for consistency.
 
 - Support to use tbl_cache and tbl_uncache when dplyr is not imported.

--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -221,6 +221,12 @@ start_shell <- function(master,
       shell_args <- c(shell_args, "--packages", paste(shQuote(packages, type = shQuoteType), collapse=","))
     }
 
+    # add environment parameters to arguments
+    shell_env_args <- Sys.getenv("sparklyr.shell.args")
+    if (nchar(shell_env_args) > 0) {
+      shell_args <- c(shell_args, strsplit(shell_env_args, " ")[[1]])
+    }
+
     # add app_jar to args
     shell_args <- c(shell_args, app_jar)
 


### PR DESCRIPTION
To simplify configuration for custom Spark distributions (see https://github.com/rstudio/sparklyr/issues/209) that require additional `spark-submit` parameters, this PR adds ability to read a new `sparklyr.shell.args` environment variable to provide additional parameters, as in:

```{r}
Sys.setenv("sparklyr.shell.args" = "--driver-memory 3g")
sc <- spark_connect(master = "local", version = "2.0.0")
```