### PR TITLE
feat: include driver class path in base config

### DIFF
--- a/inst/conf/config-template.yml
+++ b/inst/conf/config-template.yml
@@ -12,4 +12,4 @@ default:
 
   # command line arguments to spark-shell
   # sparklyr.shell.*
-
+  sparklyr.shell.driver-class-path: !Sys.getenv("SPARK_DRIVER_CLASSPATH")


### PR DESCRIPTION
This respects the `$SPARK_DRIVER_CLASSPATH` environment variable so that when spark-shell is invoked the class path is set properly.

Originally I started bringing this in as part of the `spark_config` function then realized it would work well in the base config. Let me know if you'd like it in here a different way.