### PR TITLE
added waiting state

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -396,7 +396,7 @@ livy_post_statement <- function(sc, code) {
   waitTimeout <- spark_config_value(sc$config, "livy.session.command.timeout", 60)
   waitTimeout <- waitTimeout * 10
   sleepTime <- 0.001
-  while (statementReponse$state == "running" &&
+  while ((statementReponse$state == "running"||statementReponse$state == "waiting" )&&
          waitTimeout > 0) {
     statementReponse <- livy_get_statement(sc, statementReponse$id)
 


### PR DESCRIPTION
To fix the issue addressed at https://github.com/rstudio/sparklyr/issues/383, added waiting state to livy connection. As far as I understand, livy's waiting state just means that the statement is waiting for server to execute, as you can see from here: https://github.com/cloudera/livy/commit/b4642b193956b287bb1c1b32bafe4c5a15e71eac

So I thought it would make sense to wait for the waiting status too, since that will eventually transition into running and get finished. Not sure about writing test cases, but after I fixed this, I could make livy work in my cluster. Any feedback will be appreciated.