### PR TITLE
`spark_normalize_path` not working correctly in windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- Fixed issue in spark_read_parquet and other read methods in which
+  spark_normalize_path would not work in some platforms while loading
+  data using custom protocols like s3n:// for Amazon S3.
+
 - Implemented ft_count_vectorizer to be able to use ml_lda with ease.
 
 - Added support for the sparklyr.ui.connections option which adds additional

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,7 +193,11 @@ spark_sanitize_names <- function(names) {
 # relative paths to absolute (necessary since the path will be read by
 # another process that has a different current working directory)
 spark_normalize_path <- function(path) {
-  normalizePath(path, mustWork = FALSE)
+  # only normalize paths in OS that behave correctly for custom
+  # protocols, in windows, this is not the case. See #432
+  if (normalizePath("s3n://", mustWork = FALSE) == "s3n://") {
+    normalizePath(path, mustWork = FALSE)
+  }
 }
 
 stopf <- function(fmt, ..., call. = TRUE, domain = NULL) {


### PR DESCRIPTION
Do not use normalizePath in os that do not respect custom protocols fix #432