### PR TITLE
Detect protocols in remote resources to avoid normalizing path

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -187,19 +187,18 @@ spark_sanitize_names <- function(names) {
   newNames
 }
 
-# normalize a path we are going to send to spark (pass mustWork = FALSE
-# so that e.g. hdfs:// and s3n:// paths don't produce a warning). note
+# normalizes a path that we are going to send to spark but avoids
+# normalizing remote identifiers like hdfs:// or s3n://. note
 # that this will take care of path.expand ("~") as well as converting
 # relative paths to absolute (necessary since the path will be read by
 # another process that has a different current working directory)
 spark_normalize_path <- function(path) {
-  # only normalize paths in OS that behave correctly for custom
-  # protocols, in windows, this is not the case. See #432
-  if (normalizePath("s3n://", mustWork = FALSE) == "s3n://") {
-    normalizePath(path, mustWork = FALSE)
+  # don't normalize paths that are urls
+  if (grepl("[a-zA-Z]+://", path)) {
+    path
   }
   else {
-    path
+    normalizePath(path, mustWork = FALSE)
   }
 }
 


### PR DESCRIPTION
Previous normalize path broke relative paths in windows, fixing that.