### PR TITLE
Fix Livy for Spark 2.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- Added `tbl_change_tb()`. This function changes current database.
+
 - Added `sdf_pivot()`. This function provides a mechanism for constructing
   pivot tables, using Spark's 'groupBy' + 'pivot' functionality, with a
   formula interface similar to that of `reshape2::dcast()`.
@@ -13,7 +15,7 @@
   `spark_normalize_path()` would not work in some platforms while loading
   data using custom protocols like s3n:// for Amazon S3.
 
-- Added `ft_count_vectorizer()` -- this function can be used to transform
+- Added `ft_count_vectorizer()`. This function can be used to transform
   columns of a Spark DataFrame so that they might be used as input to `ml_lda()`.
   This should make it easier to invoke `ml_lda()` on Spark data sets.
 

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -463,6 +463,12 @@ livy_invoke_statement <- function(sc, statement) {
 livy_invoke_statement_fetch <- function(sc, static, jobj, method, ...) {
   statement <- livy_statement_compose(sc, static, jobj, method, ...)
 
+  # Note: Spark 2.0 requires magic to be present in the statement with the definition.
+  statement$code <- paste(
+    statement$code,
+    livy_statement_compose_magic(statement$lobj, "json")$code,
+    sep = "\n")
+
   result <- livy_invoke_statement(sc, statement)
 
   if (!is.character(result)) {

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -32,17 +32,19 @@ livy_validate_http_response <- function(message, req) {
 #' define the basic authentication settings for a Livy session.
 #'
 #' @return Named list with configuration data
-livy_config <- function(config = spark_config(), username, password) {
-  secret <- base64_enc(paste(username, password, sep = ":"))
+livy_config <- function(config = spark_config(), username = NULL, password = NULL) {
+  if (!is.null(username) || !is.null(password)) {
+    secret <- base64_enc(paste(username, password, sep = ":"))
 
-  config[["sparklyr.livy.headers"]] <- c(
-    config[["sparklyr.livy.headers"]], list(
-      Authorization = paste(
-        "Basic",
-        base64_enc(paste(username, password, sep = ":"))
+    config[["sparklyr.livy.headers"]] <- c(
+      config[["sparklyr.livy.headers"]], list(
+        Authorization = paste(
+          "Basic",
+          base64_enc(paste(username, password, sep = ":"))
+        )
       )
     )
-  )
+  }
 
   config
 }

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -121,6 +121,17 @@ livy_install <- function(version       = "0.3.0",
   if (!file.exists(livy_path))
     stopf("failed to move '%s' to '%s'", folder_name, basename(livy_path))
 
+  livyStart <- file.path(livy_path, "bin/livy-server")
+  livyLogs <- file.path(livy_path, "logs")
+
+  if (!dir.exists(livyLogs)) {
+    dir.create(livyLogs)
+  }
+
+  if (.Platform$OS.type == "unix") {
+    system2("chmod", c("744", livyStart))
+  }
+
   # return installation path on success
   if (interactive())
     message("* livy ", version, " installed successfully!")

--- a/R/livy_service.R
+++ b/R/livy_service.R
@@ -23,10 +23,6 @@ livy_service_start <- function(version = NULL, spark_version = NULL) {
 
   livyStart <- file.path(livy_home_dir(version = version), "bin/livy-server")
 
-  if (.Platform$OS.type == "unix") {
-    system2("chmod", c("744", livyStart))
-  }
-
   withr::with_envvar(env, {
     system2(
       livyStart,


### PR DESCRIPTION
Livy 0.3.0 with Spark 2.0 does not support the use of magic referencing a variable executed in the previous statement, which we use to retrieve data as `json` when the response is too long. This change makes `%json <var name>` the default while retrieving any object through Livy.

It also moves the permissions checks from `spark_connect.livy_connection` to `livy_install` which is more appropriate since some systems, like EMR, should not be modified on connection.