### PR TITLE
Add support to supecify column names in spark_read_csv

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- Added support to specify a vector of column names in `spark_read_csv` to
+  specify column names without having to set the type of each column.
+
 - Improved `copy_to`, `sdf_copy_to` and `dbWriteTable` performance under
   `yarn-client` mode.
 

--- a/R/dplyr_spark_data.R
+++ b/R/dplyr_spark_data.R
@@ -8,7 +8,7 @@ spark_partition_register_df <- function(sc, df, name, repartition, memory) {
   invoke(df, "registerTempTable", name)
 
   if (memory) {
-    dbGetQuery(sc, paste("CACHE TABLE", dplyr::escape(ident(name), con = sc)))
+    dbSendQuery(sc, paste("CACHE TABLE", dplyr::escape(ident(name), con = sc)))
     dbGetQuery(sc, paste("SELECT count(*) FROM", dplyr::escape(ident(name), con = sc)))
   }
 


### PR DESCRIPTION
@kevinushey how do you feel about supporting this? To me, `columns` was a bit confusing since I assumed it supported column names, not just column types; specially since column renames are already supported through `columns` when the types are specified.

This change would enable:

```
sc <- spark_connect(master = "local", version = "2.1.0")
temp_csv <- tempfile(fileext = ".csv")
iris_tbl <- copy_to(sc, iris)
spark_write_csv(iris_tbl, temp_csv, header = TRUE)

spark_read_csv(
  sc,
  "iris_csv",
  temp_csv,
  columns = c("Sepal_Length",
              "Sepal_Width",
              "Petal_Length",
              "Petal_Width",
              "Species_Renamed"))

```

```
Source:   query [150 x 5]
Database: spark connection master=local[8] app=sparklyr local=TRUE

   Sepal_Length Sepal_Width Petal_Length Petal_Width Species_Renamed
          <dbl>       <dbl>        <dbl>       <dbl>           <chr>
1           5.1         3.5          1.4         0.2          setosa
2           4.9         3.0          1.4         0.2          setosa
3           4.7         3.2          1.3         0.2          setosa
4           4.6         3.1          1.5         0.2          setosa
5           5.0         3.6          1.4         0.2          setosa
6           5.4         3.9          1.7         0.4          setosa
7           4.6         3.4          1.4         0.3          setosa
8           5.0         3.4          1.5         0.2          setosa
9           4.4         2.9          1.4         0.2          setosa
10          4.9         3.1          1.5         0.1          setosa
# ... with 140 more rows
```