### PR TITLE
Normalize jar paths for windows under spark 1.6

### DIFF
--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -205,9 +205,9 @@ start_shell <- function(master,
         length(grep(config[["sparklyr.csv.embedded"]], spark_version)) > 0) {
       jars <- c(
         jars,
-        system.file(file.path("java", "spark-csv_2.11-1.3.0.jar"), package = "sparklyr"),
-        system.file(file.path("java", "commons-csv-1.1.jar"), package = "sparklyr"),
-        system.file(file.path("java", "univocity-parsers-1.5.1.jar"), package = "sparklyr")
+        normalizePath(system.file(file.path("java", "spark-csv_2.11-1.3.0.jar"), package = "sparklyr")),
+        normalizePath(system.file(file.path("java", "commons-csv-1.1.jar"), package = "sparklyr")),
+        normalizePath(system.file(file.path("java", "univocity-parsers-1.5.1.jar"), package = "sparklyr"))
       )
     }
 


### PR DESCRIPTION
Normalize jar paths for windows under spark 1.6 to fix #491 #490 #414 #410 #398 #305

Planning to backport this one to CRAN, since this is causing a bunch of issues. The problem is scoped to **only** Windows and Spark 1.6.x; however, a lot of users use this configuration since our documentation defaults to 1.6.2.

The fix is straightforward, we need to normalize the paths to jars we specify for the embedded CSV parser. Unfortunately, this affects almost any operation since other non-csv operations also cause Spark to enumerate jar dependencies which trigger an ` java.io.IOException: No FileSystem for scheme` exception.