### PR TITLE
Mutate does not collect the correct columns

### DIFF
--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -1,6 +1,6 @@
 #' @export
 sql_escape_ident.spark_connection <- function(con, x) {
-  tbl_quote_name(x)
+  sql_quote(x, '`')
 }
 
 build_sql_if_compare <- function(..., con, compare) {

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -1,0 +1,13 @@
+context("dplyr")
+sc <- testthat_spark_connection()
+
+iris_tbl <- testthat_tbl("iris")
+
+test_that("the implementation of 'mutate' functions as expected", {
+  test_requires("dplyr")
+
+  expect_equal(
+    iris %>% mutate(x = Species) %>% tbl_vars() %>% length(),
+    iris_tbl %>% mutate(x = Species) %>% collect() %>% tbl_vars() %>% length()
+  )
+})


### PR DESCRIPTION
I have not fully investigated the cause of this regression but reverting commit that introduced this: https://github.com/rstudio/sparklyr/pull/481

Added test to validate `mutate`, see test for regression details: https://github.com/rstudio/sparklyr/compare/bugfix/revert-mutate-regression?expand=1#diff-5d42bbc677d8b59abb94f9b67c48556e