### PR TITLE
Handling database name again

### DIFF
--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -1,6 +1,6 @@
 #' @export
 sql_escape_ident.spark_connection <- function(con, x) {
-  sql_quote(x, '`')
+  tbl_quote_name(x)
 }
 
 build_sql_if_compare <- function(..., con, compare) {

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -1,6 +1,10 @@
 #' @export
 sql_escape_ident.spark_connection <- function(con, x) {
-  tbl_quote_name(x)
+  # Assuming it might include database name like: `dbname.tableName`
+  if (length(x) == 1)
+    tbl_quote_name(x)
+  else
+    sql_quote(x, '`')
 }
 
 build_sql_if_compare <- function(..., con, compare) {

--- a/R/tables_spark.R
+++ b/R/tables_spark.R
@@ -1,8 +1,12 @@
 tbl_quote_name <- function(name) {
-  name <- gsub("`", "``", name, fixed = TRUE)
-  splitted_name <- strsplit(name, "\\.")[[1]]
-  name <- paste(splitted_name, collapse = "`.`")
-  paste("`", name, "`", sep = "")
+  y <- gsub("`", "``", name, fixed = TRUE)
+  y <- strsplit(y, "\\.")[[1]]
+  y <- paste(y, collapse = "`.`")
+  y <- paste("`", y, "`", sep = "")
+  y[is.na(name)] <- "NULL"
+  names(y) <- names(name)
+
+  y
 }
 
 tbl_cache_sdf <- function(sc, name, force) {


### PR DESCRIPTION
This PR is retry of https://github.com/rstudio/sparklyr/pull/481 fixing https://github.com/rstudio/sparklyr/pull/500

I find out `sql_escape_ident()` handles array like variables, such as column names, and `tbl_quote_name()` can't handle array because it uses `strsplit()`. So, I add the heuristics if the length of an object is 1, it might be a table name.