### PR TITLE
Avoid spark_read_csv column checks when schema is proivided

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- Improved performance of `spark_read_csv` when `infer_schema = FALSE` to
+  avoid checking for column lengths which might force a read over remote
+  data. This warning is still available using the `sparklyr.versbose`
+  option.
+
 - Added `spark_read_jdbc`. This function reads from a JDBC connection
   into a Spark DataFrame.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,7 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
-- Improved performance of `spark_read_csv` when `infer_schema = FALSE` to
-  avoid checking for column lengths which might force a read over remote
-  data. This warning is still available using the `sparklyr.versbose`
-  option.
+- Improved performance of `spark_read_csv` reading remote data when
+  `infer_schema = FALSE`.
 
 - Added `spark_read_jdbc`. This function reads from a JDBC connection
   into a Spark DataFrame.

--- a/R/data_csv.R
+++ b/R/data_csv.R
@@ -42,7 +42,7 @@ spark_csv_read <- function(sc,
 
   options <- spark_csv_format_if_needed(read, sc)
 
-  if (!identical(columns, NULL)) {
+  if (sparklyr_boolean_option("sparklyr.verbose") && !identical(columns, NULL)) {
     ncol_ds <- options %>%
       invoke(spark_csv_load_name(sc), path) %>%
       invoke("schema") %>%


### PR DESCRIPTION
Only perform column length check in `spark_read_csv` when the `sparklyr.versbose` option is provided.

This makes the following command trigger no Spark jobs:

```
iris_csv_tbl <- spark_read_csv(sc, "iris_csv", temp_csv, memory = FALSE, columns = list(Sepal_length = "double", Sepal_Width = "double", Petal_Length = "double", Petal_Width = "double", Species = "character"), infer_schema = FALSE, overwrite = FALSE)
```

@edgararuiz 