### PR TITLE
Add dplyr tests and fix `sample_frac`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- `sample_frac` takes a fraction instead of a percent to match `dplyr`.
+
 - Improved performance of `spark_read_csv` reading remote data when
   `infer_schema = FALSE`.
 

--- a/R/dplyr_sql.R
+++ b/R/dplyr_sql.R
@@ -30,7 +30,7 @@ sql_build.op_sample_frac <- function(op, con, ...) {
     from = sql(paste(
       sql_build(op$x, con = con),
       " TABLESAMPLE (",
-      op$args$size,
+      op$args$size * 100,
       " PERCENT)", sep = "")),
     select = build_sql("*")
   )

--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -51,10 +51,22 @@ test_that("'head' uses 'limit' clause", {
 test_that("'left_join' does not use 'using' clause", {
   test_requires("dplyr")
 
-  expect_false(
+  expect_equal(
+    spark_version(sc) >= "2.0.0" && packageVersion("dplyr") < "0.6.0",
     grepl(
       "USING",
       sql_render(left_join(df1_tbl, df2_tbl))
+    )
+  )
+})
+
+test_that("the implementation of 'left_join' functions as expected", {
+  test_requires("dplyr")
+
+  expect_true(
+    all.equal(
+      left_join(df1, df2),
+      left_join(df1_tbl, df2_tbl) %>% collect()
     )
   )
 })


### PR DESCRIPTION
Most a set of tests to cover integration with `dplyr` `0.6` and a fix to `sample_frac` which is implemented using `TABLESAMPLE` and `PERCENT`; however, `dplyr` defines this function as a fraction, not percent.