### PR TITLE
http_error was introduced in httr 1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     assertthat,
     rprojroot,
     withr,
-    httr,
+    httr (>= 1.1),
     jsonlite (>= 1.0),
     base64enc,
     shiny,


### PR DESCRIPTION
Customer reported while using `Livy`, bumping version for `httr`, latest is `1.2` but `1.1` is sufficient.