### PR TITLE
fix http response validation for livy

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -4,7 +4,7 @@
 #' @importFrom httr text_content
 livy_validate_http_response <- function(message, req) {
   if (http_error(req)) {
-    if (all.equal(status_code(req), 401)) {
+    if (isTRUE(all.equal(status_code(req), 401))) {
       stop("Livy operation is unauthorized. Try spark_connect with config = livy_config()")
     }
     else {


### PR DESCRIPTION
From Windows desktop I was getting 
```
> sc <- spark_connect(master = "foobar", method = "livy")
Error in if (all.equal(status_code(req), 401)) { : 
  argument is not interpretable as logical
```