### PR TITLE
make connection times at a par with sparkr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- Improved `spark_connect` performance.
+
 - `sample_frac` takes a fraction instead of a percent to match `dplyr`.
 
 - Improved performance of `spark_read_csv` reading remote data when

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -149,7 +149,6 @@ spark_connect <- function(master,
 
   # update spark_context and hive_context connections with DBIConnection
   scon$spark_context$connection <- scon
-  scon$hive_context$connection <- scon
 
   # notify connection viewer of connection
   libs <- c("sparklyr", extensions)

--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -56,13 +56,19 @@ java_context <- function(sc) {
 #' @name spark-api
 #' @export
 hive_context <- function(sc) {
-  sc$hive_context
+  if (!is.null(sc$hive_context))
+    sc$hive_context
+  else
+    create_hive_context(sc)
 }
 
 #' @name spark-api
 #' @export
 spark_session <- function(sc) {
-  sc$hive_context
+  if (!is.null(sc$hive_context))
+    sc$hive_context
+  else
+    create_hive_context(sc)
 }
 
 #' Retrieve the Spark Connection Associated with an R Object

--- a/R/spark_gateway.R
+++ b/R/spark_gateway.R
@@ -25,10 +25,8 @@ wait_connect_gateway <- function(gatewayAddress, gatewayPort, config, isStarting
 
     retries <- retries  - 1;
 
-    # wait for one second without depending on the behavior of socketConnection timeout
-    while (commandStart + 1 > Sys.time()) {
-      Sys.sleep(0.1)
-    }
+    startWait <- spark_config_value(config, "sparklyr.gateway.start.wait", 50)
+    Sys.sleep(startWait / 1000)
   }
 
   gateway

--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -541,10 +541,6 @@ initialize_connection.spark_shell_connection <- function(sc) {
     )
     sc$java_context$connection <- sc
 
-    # create the hive context and assign the connection to it
-    sc$hive_context <- create_hive_context(sc)
-    sc$hive_context$connection <- sc
-
     # return the modified connection
     sc
   }, error = function(e) {

--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -342,9 +342,6 @@ stop_shell <- function(sc, terminate = FALSE) {
 
   close(sc$backend)
   close(sc$monitor)
-
-  # allow time to clean resources for multiple spark_connect/spark_disconnect calls
-  Sys.sleep(1)
 }
 
 #' @export


### PR DESCRIPTION
## SparkR 2.1.0 ##

```
microbenchmark({
    sparkR.session(
        master = "local",
        sparkHome = sparklyr::spark_home_dir(version = "2.1.0"))
    sparkR.stop()
}, times = 5)
```
| min  | lq | mean  | median | uq  | max | neval  |
| ---  | --- | ---  | --- | --- | --- | ---  |
|2.56269 |2.889828| 3.21184| 2.905866| 3.011003| 4.689812  |   5|

```
microbenchmark({
    sparkR.session(
        master = "local",
        sparkHome = sparklyr::spark_home_dir(version = "2.1.0"))
    head(sql("SELECT 1"))
    sparkR.stop()
}, times = 5)
```
| min  | lq | mean  | median | uq  | max | neval  |
| ---  | --- | ---  | --- | --- | --- | ---  |
| 9.375756 |9.383988| 9.809023 |9.448403 |9.588716| 11.24825   |  5|

## sparklyr no-fix ##
For `sparklyr devel` installing with `devtools::install_github("rstudio/sparklyr")`:

```
microbenchmark({
    sc <- spark_connect(master = "local", version = "2.1.0")
    spark_disconnect(sc)
}, times = 5)
```

| min  | lq | mean  | median | uq  | max | neval  |
| ---  | --- | ---  | --- | --- | --- | ---  |
|11.05338| 11.07813| 11.38247| 11.22747 |11.37131 |12.18205 |    5|

```
microbenchmark({
    sc <- spark_connect(master = "local", version = "2.1.0")
    DBI::dbGetQuery(sc, "SELECT 1")
    spark_disconnect(sc)
}, times = 5)
```
| min  | lq | mean  | median | uq  | max | neval  |
| ---  | --- | ---  | --- | --- | --- | ---  |
|13.59941 |13.61477 |14.48272| 13.94531 |14.20849 |17.04561   |  5|

## sparklyr with-fix ##
For `sparklyr` with this fix, we reduce polling time to `50ms` and delay the creation of `SparkSession`:

```
microbenchmark({
    sc <- spark_connect(master = "local", version = "2.1.0")
    spark_disconnect(sc)
}, times = 5)
```

| min  | lq | mean  | median | uq  | max | neval  |
| ---  | --- | ---  | --- | --- | --- | ---  |
|2.848138| 2.849929| 2.875147| 2.85279| 2.87637| 2.948509 |    5|

```
microbenchmark({
    sc <- spark_connect(master = "local", version = "2.1.0")
    DBI::dbGetQuery(sc, "SELECT 1")
    spark_disconnect(sc)
}, times = 5)
```
| min  | lq | mean  | median | uq  | max | neval  |
| ---  | --- | ---  | --- | --- | --- | ---  |
|9.591433 |9.733171 |9.814171 |9.795956 |9.850215 |10.10008 |    5|