### PR TITLE
Add `ml_als_factorization()` options

### DIFF
--- a/R/ml_alternating_least_squares.R
+++ b/R/ml_alternating_least_squares.R
@@ -8,6 +8,8 @@
 #' @param item.column The name of the column containing item IDs.
 #' @param rank Rank of the factorization.
 #' @param regularization.parameter The regularization parameter.
+#' @param implicit.preferences Use implicit preference.
+#' @param alpha The parameter in the implicit preference formulation.
 #' @template roxlate-ml-iter-max
 #' @template roxlate-ml-options
 #' @template roxlate-ml-dots
@@ -21,6 +23,8 @@ ml_als_factorization <- function(x,
                                  item.column = "item",
                                  rank = 10L,
                                  regularization.parameter = 0.1,
+                                 implicit.preferences = FALSE,
+                                 alpha = 1.0,
                                  iter.max = 10L,
                                  ml.options = ml_options(),
                                  ...)
@@ -35,6 +39,8 @@ ml_als_factorization <- function(x,
   item.column <- ensure_scalar_character(item.column)
   rank <- ensure_scalar_integer(rank)
   regularization.parameter <- ensure_scalar_double(regularization.parameter)
+  implicit.preferences <- ensure_scalar_boolean(implicit.preferences, default = FALSE)
+  alpha <- ensure_scalar_double(alpha)
   iter.max <- ensure_scalar_integer(iter.max)
   only.model <- ensure_scalar_boolean(ml.options$only.model, default = FALSE)
 
@@ -54,6 +60,8 @@ ml_als_factorization <- function(x,
     invoke("setItemCol", item.column) %>%
     invoke("setRank", rank) %>%
     invoke("setRegParam", regularization.parameter) %>%
+    invoke("setImplicitPrefs", implicit.preferences) %>%
+    invoke("setAlpha", alpha) %>%
     invoke("setMaxIter", iter.max)
 
   if (is.function(ml.options$model.transform))

--- a/R/ml_alternating_least_squares.R
+++ b/R/ml_alternating_least_squares.R
@@ -10,6 +10,7 @@
 #' @param regularization.parameter The regularization parameter.
 #' @param implicit.preferences Use implicit preference.
 #' @param alpha The parameter in the implicit preference formulation.
+#' @param nonnegative Use nonnegative constraints for least squares.
 #' @template roxlate-ml-iter-max
 #' @template roxlate-ml-options
 #' @template roxlate-ml-dots
@@ -25,6 +26,7 @@ ml_als_factorization <- function(x,
                                  regularization.parameter = 0.1,
                                  implicit.preferences = FALSE,
                                  alpha = 1.0,
+                                 nonnegative = FALSE,
                                  iter.max = 10L,
                                  ml.options = ml_options(),
                                  ...)
@@ -41,6 +43,7 @@ ml_als_factorization <- function(x,
   regularization.parameter <- ensure_scalar_double(regularization.parameter)
   implicit.preferences <- ensure_scalar_boolean(implicit.preferences, default = FALSE)
   alpha <- ensure_scalar_double(alpha)
+  nonnegative <- ensure_scalar_boolean(nonnegative, default = FALSE)
   iter.max <- ensure_scalar_integer(iter.max)
   only.model <- ensure_scalar_boolean(ml.options$only.model, default = FALSE)
 
@@ -62,6 +65,7 @@ ml_als_factorization <- function(x,
     invoke("setRegParam", regularization.parameter) %>%
     invoke("setImplicitPrefs", implicit.preferences) %>%
     invoke("setAlpha", alpha) %>%
+    invoke("setNonnegative", nonnegative) %>%
     invoke("setMaxIter", iter.max)
 
   if (is.function(ml.options$model.transform))

--- a/man/ml_als_factorization.Rd
+++ b/man/ml_als_factorization.Rd
@@ -6,7 +6,8 @@
 \usage{
 ml_als_factorization(x, rating.column = "rating", user.column = "user",
   item.column = "item", rank = 10L, regularization.parameter = 0.1,
-  iter.max = 10L, ml.options = ml_options(), ...)
+  implicit.preferences = FALSE, alpha = 1, iter.max = 10L,
+  ml.options = ml_options(), ...)
 }
 \arguments{
 \item{x}{An object coercable to a Spark DataFrame (typically, a
@@ -21,6 +22,10 @@ ml_als_factorization(x, rating.column = "rating", user.column = "user",
 \item{rank}{Rank of the factorization.}
 
 \item{regularization.parameter}{The regularization parameter.}
+
+\item{implicit.preferences}{Use implicit preference.}
+
+\item{alpha}{The parameter in the implicit preference formulation.}
 
 \item{iter.max}{The maximum number of iterations to use.}
 

--- a/man/ml_als_factorization.Rd
+++ b/man/ml_als_factorization.Rd
@@ -6,8 +6,8 @@
 \usage{
 ml_als_factorization(x, rating.column = "rating", user.column = "user",
   item.column = "item", rank = 10L, regularization.parameter = 0.1,
-  implicit.preferences = FALSE, alpha = 1, iter.max = 10L,
-  ml.options = ml_options(), ...)
+  implicit.preferences = FALSE, alpha = 1, nonnegative = FALSE,
+  iter.max = 10L, ml.options = ml_options(), ...)
 }
 \arguments{
 \item{x}{An object coercable to a Spark DataFrame (typically, a
@@ -26,6 +26,8 @@ ml_als_factorization(x, rating.column = "rating", user.column = "user",
 \item{implicit.preferences}{Use implicit preference.}
 
 \item{alpha}{The parameter in the implicit preference formulation.}
+
+\item{nonnegative}{Use nonnegative constraints for least squares.}
 
 \item{iter.max}{The maximum number of iterations to use.}
 


### PR DESCRIPTION
This PR adds `ml_als_factorization()` options as follows:
- Implicit matrix factorization. close #561 
- Nonnegative least square option

I couldn't find a prediction example of ALS and finally found #313, I created a simple example of patched version. http://rpubs.com/chezou/sparklyr-als 