### PR TITLE
Support saving to default hive path for spark_write_table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- `spark_write_table` now supports saving to default Hive path.
+
 - Improved `spark_connect` performance.
 
 - `sample_frac` takes a fraction instead of a percent to match `dplyr`.

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -394,12 +394,13 @@ spark_load_table <- function(sc,
 #' Writes a Spark DataFrame into a Spark table.
 #'
 #' @inheritParams spark_write_csv
+#' @param name The name to assign to the newly generated table.
 #' @param mode Specifies the behavior when data or table already exists.
 #'
 #' @family Spark serialization routines
 #'
 #' @export
-spark_write_table <- function(x, name = NULL, mode = NULL, options = list()) {
+spark_write_table <- function(x, name, mode = NULL, options = list()) {
   UseMethod("spark_write_table")
 }
 

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -426,7 +426,7 @@ spark_write_table.tbl_spark <- function(x, name, mode = NULL, options = list()) 
 
   if (spark_version(sc) < "2.0.0" && spark_master_is_local(sc$master)) {
     stop(
-      "spark_write_table is not supported in local clusters for ",
+      "spark_write_table is not supported in local clusters for Spark ",
       spark_version(sc), ". ",
       "Upgrade to Spark 2.X or use this function in a non-local Spark cluster.")
   }

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -424,6 +424,13 @@ spark_write_table.tbl_spark <- function(x, name, mode = NULL, options = list()) 
   sqlResult <- spark_sqlresult_from_dplyr(x)
   sc <- spark_connection(x)
 
+  if (spark_version(sc) < "2.0.0" && spark_master_is_local(sc$master)) {
+    stop(
+      "spark_write_table is not supported in local clusters for ",
+      spark_version(sc), ". ",
+      "Upgrade to Spark 2.X or use this function in a non-local Spark cluster.")
+  }
+
   spark_data_write_generic(sqlResult, name, "saveAsTable", mode, options)
 }
 

--- a/R/dplyr_spark_data.R
+++ b/R/dplyr_spark_data.R
@@ -5,7 +5,9 @@ spark_partition_register_df <- function(sc, df, name, repartition, memory) {
     df <- invoke(df, "repartition", as.integer(repartition))
   }
 
-  invoke(df, "registerTempTable", name)
+  if (!name %in% DBI::dbListTables(sc)) {
+    invoke(df, "registerTempTable", name)
+  }
 
   if (memory) {
     dbSendQuery(sc, paste("CACHE TABLE", dplyr::escape(ident(name), con = sc)))

--- a/man/spark_read_table.Rd
+++ b/man/spark_read_table.Rd
@@ -4,16 +4,13 @@
 \alias{spark_read_table}
 \title{Reads from a Spark Table into a Spark DataFrame.}
 \usage{
-spark_read_table(sc, name, path, options = list(), repartition = 0,
+spark_read_table(sc, name, options = list(), repartition = 0,
   memory = TRUE, overwrite = TRUE)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
 
 \item{name}{The name to assign to the newly generated table.}
-
-\item{path}{The path to the file. Needs to be accessible from the cluster.
-Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{options}{A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.}
 

--- a/man/spark_write_table.Rd
+++ b/man/spark_write_table.Rd
@@ -4,10 +4,12 @@
 \alias{spark_write_table}
 \title{Writes a Spark DataFrame into a Spark table}
 \usage{
-spark_write_table(x, name = NULL, mode = NULL, options = list())
+spark_write_table(x, name, mode = NULL, options = list())
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
+
+\item{name}{The name to assign to the newly generated table.}
 
 \item{mode}{Specifies the behavior when data or table already exists.}
 

--- a/man/spark_write_table.Rd
+++ b/man/spark_write_table.Rd
@@ -4,13 +4,10 @@
 \alias{spark_write_table}
 \title{Writes a Spark DataFrame into a Spark table}
 \usage{
-spark_write_table(x, path, mode = NULL, options = list())
+spark_write_table(x, name = NULL, mode = NULL, options = list())
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
-
-\item{path}{The path to the file. Needs to be accessible from the cluster.
-Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{mode}{Specifies the behavior when data or table already exists.}
 


### PR DESCRIPTION
Intended use:

```
spark_write_table(iris_tbl, "iris_named")
iris_named_tbl <- spark_read_table(sc, "iris_named")
```

@edgararuiz found out this is how customers expect to use read/write tables into Hive which avoids having to specify the `path`.