### PR TITLE
Implement DBIs dbExecute an dbSendStatement for spark_connection

### DIFF
--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -65,3 +65,4 @@ setMethod("dbSetProperty", c("spark_connection", "character", "character"), func
     )
   )
 })
+

--- a/R/dbi_spark_connection.R
+++ b/R/dbi_spark_connection.R
@@ -65,4 +65,3 @@ setMethod("dbSetProperty", c("spark_connection", "character", "character"), func
     )
   )
 })
-

--- a/R/dbi_spark_result.R
+++ b/R/dbi_spark_result.R
@@ -110,3 +110,13 @@ setMethod("dbHasCompleted", "DBISparkResult", function(res, ...) {
 setMethod("dbClearResult", "DBISparkResult", function(res, ...) {
   TRUE
 })
+
+setMethod("dbSendStatement", "spark_connection", function(conn, statement, ...) {
+  dbSendQuery(conn, statement, ...)
+})
+
+setMethod("dbExecute", "spark_connection", function(conn, statement, ...) {
+  rs <- dbSendStatement(conn, statement, ...)
+  on.exit(dbClearResult(rs))
+  dbGetRowsAffected(rs)
+})


### PR DESCRIPTION
Implement DBIs `dbExecute` an `dbSendStatement` for spark_connection to fix #577.