### PR TITLE
Supporting sparklyr in Databricks clusters

### DIFF
--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -54,9 +54,9 @@ NULL
 #' spark_disconnect(sc)
 #'
 #' @export
-spark_connect <- function(master,
+spark_connect <- function(master = "local",
                           spark_home = Sys.getenv("SPARK_HOME"),
-                          method = c("shell", "livy", "test"),
+                          method = c("shell", "livy", "databricks", "test"),
                           app_name = "sparklyr",
                           version = NULL,
                           hadoop_version = NULL,
@@ -67,7 +67,7 @@ spark_connect <- function(master,
   method <- match.arg(method)
 
   # master can be missing if it's specified in the config file
-  if (missing(master)) {
+  if (missing(master) && method != "databricks") {
     master <- config$spark.master
     if (is.null(master))
       stop("You must either pass a value for master or include a spark.master ",
@@ -129,6 +129,9 @@ spark_connect <- function(master,
                             version,
                             hadoop_version ,
                             extensions)
+  } else if (method == "databricks") {
+    scon <- databricks_connection(config = config,
+                                  extensions)
   } else if (method == "test") {
     scon <- test_connection(master = master,
                             config = config,

--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -1,0 +1,64 @@
+databricks_connection <- function(config, extensions) {
+  tryCatch({
+    callSparkR <- get("callJStatic", envir = asNamespace("SparkR"))
+    gatewayPort <- as.numeric(callSparkR("com.databricks.backend.daemon.driver.RDriverLocal",
+                                         "startSparklyr",
+                                         # In Databricks notebooks, this variable is in the default namespace
+                                         get("DATABRICKS_GUID", envir = .GlobalEnv),
+                                         # startSparklyr will search & find proper JAR file
+                                         system.file("java/", package = "sparklyr")))
+  }, error = function(err) {
+    stop(paste("Failed to start sparklyr backend:", err$message))
+  })
+
+  tryCatch({
+    gatewayInfo <- spark_connect_gateway(gatewayAddress = "localhost",
+                                        gatewayPort = gatewayPort,
+                                        sessionId = gatewayPort,
+                                        config = config,
+                                        isStarting = TRUE)
+  }, error = function(err) {
+    stop(paste("Failed to open connection to sparklyr gateway:", err$message))
+  })
+
+  output_file <- tempfile(fileext = "_spark.log")
+  error_file <- tempfile(fileext = "_spark.err")
+
+  tryCatch({
+    # set timeout for socket connection
+    timeout <- spark_config_value(config, "sparklyr.backend.timeout", 30 * 24 * 60 * 60)
+    backend <- socketConnection(host = "localhost",
+                                port = gatewayInfo$backendPort,
+                                server = FALSE,
+                                blocking = TRUE,
+                                open = "wb",
+                                timeout = timeout)
+  }, error = function(err) {
+    stop(paste("Failed to open connection to sparklyr backend:", err$message))
+  })
+
+  # create the databricks connection
+  sc <- structure(class = c("spark_connection", "spark_shell_connection"), list(
+    # spark_connection
+    master = "databricks",
+    method = "shell",
+    app_name = "Databricks",
+    config = config,
+    # spark_shell_connection
+    spark_home = Sys.getenv("SPARK_HOME"),
+    backend = backend,
+    monitor = gatewayInfo$gateway,
+    output_file = output_file
+  ))
+
+  # stop shell on R exit
+  reg.finalizer(baseenv(), function(x) {
+    if (connection_is_open(sc)) {
+      stop_shell(sc)
+    }
+  }, onexit = TRUE)
+
+  sc
+}
+
+

--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -7,6 +7,68 @@ shell_connection_validate_config <- function(config) {
   config
 }
 
+databricks_connection <- function(config, extensions) {
+  tryCatch({
+    gatewayPort <- as.numeric(SparkR:::callJStatic("com.databricks.backend.daemon.driver.RDriverLocal",
+                                                  "startSparklyr",
+                                                  # In Databricks notebooks, this variable is in the default namespace
+                                                  get("DATABRICKS_GUID", envir = .GlobalEnv),
+                                                  # startSparklyr will search & find proper JAR file
+                                                  system.file("java/", package = "sparklyr")))
+  }, error = function(err) {
+    stop(paste("Failed to start sparklyr backend:", err$message))
+  })
+
+  tryCatch({
+    gatewayInfo <- spark_connect_gateway(gatewayAddress = "localhost",
+                                        gatewayPort = gatewayPort,
+                                        sessionId = gatewayPort,
+                                        config = config,
+                                        isStarting = TRUE)
+  }, error = function(err) {
+    stop(paste("Failed to open connection to sparklyr gateway:", err$message))
+  })
+
+  output_file <- tempfile(fileext = "_spark.log")
+  error_file <- tempfile(fileext = "_spark.err")
+
+  tryCatch({
+    # set timeout for socket connection
+    timeout <- spark_config_value(config, "sparklyr.backend.timeout", 30 * 24 * 60 * 60)
+    backend <- socketConnection(host = "localhost",
+                                port = gatewayInfo$backendPort,
+                                server = FALSE,
+                                blocking = TRUE,
+                                open = "wb",
+                                timeout = timeout)
+  }, error = function(err) {
+    stop(paste("Failed to open connection to sparklyr backend:", err$message))
+  })
+
+  # create the databricks connection
+  sc <- structure(class = c("spark_connection", "spark_shell_connection"), list(
+    # spark_connection
+    master = "databricks",
+    method = "shell",
+    app_name = "Databricks",
+    config = config,
+    # spark_shell_connection
+    spark_home = Sys.getenv("SPARK_HOME"),
+    backend = backend,
+    monitor = gatewayInfo$gateway,
+    output_file = output_file
+  ))
+
+  # stop shell on R exit
+  reg.finalizer(baseenv(), function(x) {
+    if (connection_is_open(sc)) {
+      stop_shell(sc)
+    }
+  }, onexit = TRUE)
+
+  sc
+}
+
 # create a shell connection
 shell_connection <- function(master,
                              spark_home,

--- a/R/spark_shell.R
+++ b/R/spark_shell.R
@@ -7,68 +7,6 @@ shell_connection_validate_config <- function(config) {
   config
 }
 
-databricks_connection <- function(config, extensions) {
-  tryCatch({
-    gatewayPort <- as.numeric(SparkR:::callJStatic("com.databricks.backend.daemon.driver.RDriverLocal",
-                                                  "startSparklyr",
-                                                  # In Databricks notebooks, this variable is in the default namespace
-                                                  get("DATABRICKS_GUID", envir = .GlobalEnv),
-                                                  # startSparklyr will search & find proper JAR file
-                                                  system.file("java/", package = "sparklyr")))
-  }, error = function(err) {
-    stop(paste("Failed to start sparklyr backend:", err$message))
-  })
-
-  tryCatch({
-    gatewayInfo <- spark_connect_gateway(gatewayAddress = "localhost",
-                                        gatewayPort = gatewayPort,
-                                        sessionId = gatewayPort,
-                                        config = config,
-                                        isStarting = TRUE)
-  }, error = function(err) {
-    stop(paste("Failed to open connection to sparklyr gateway:", err$message))
-  })
-
-  output_file <- tempfile(fileext = "_spark.log")
-  error_file <- tempfile(fileext = "_spark.err")
-
-  tryCatch({
-    # set timeout for socket connection
-    timeout <- spark_config_value(config, "sparklyr.backend.timeout", 30 * 24 * 60 * 60)
-    backend <- socketConnection(host = "localhost",
-                                port = gatewayInfo$backendPort,
-                                server = FALSE,
-                                blocking = TRUE,
-                                open = "wb",
-                                timeout = timeout)
-  }, error = function(err) {
-    stop(paste("Failed to open connection to sparklyr backend:", err$message))
-  })
-
-  # create the databricks connection
-  sc <- structure(class = c("spark_connection", "spark_shell_connection"), list(
-    # spark_connection
-    master = "databricks",
-    method = "shell",
-    app_name = "Databricks",
-    config = config,
-    # spark_shell_connection
-    spark_home = Sys.getenv("SPARK_HOME"),
-    backend = backend,
-    monitor = gatewayInfo$gateway,
-    output_file = output_file
-  ))
-
-  # stop shell on R exit
-  reg.finalizer(baseenv(), function(x) {
-    if (connection_is_open(sc)) {
-      stop_shell(sc)
-    }
-  }, onexit = TRUE)
-
-  sc
-}
-
 # create a shell connection
 shell_connection <- function(master,
                              spark_home,

--- a/man/spark-connections.Rd
+++ b/man/spark-connections.Rd
@@ -12,8 +12,8 @@
 \alias{spark_disconnect_all}
 \title{Manage Spark Connections}
 \usage{
-spark_connect(master, spark_home = Sys.getenv("SPARK_HOME"),
-  method = c("shell", "livy", "test"), app_name = "sparklyr",
+spark_connect(master = "local", spark_home = Sys.getenv("SPARK_HOME"),
+  method = c("shell", "livy", "databricks", "test"), app_name = "sparklyr",
   version = NULL, hadoop_version = NULL, config = spark_config(),
   extensions = sparklyr::registered_extensions())
 
@@ -34,8 +34,8 @@ provided by the \code{SPARK_HOME} environment variable. If
 \code{version} parameter is specified to force the use of a locally
 installed version.}
 
-\item{method}{The method used to connect to Spark. Currently, only
-\code{"shell"} is supported.}
+\item{method}{The method used to connect to Spark. Inside Databricks notebooks and jobs use
+\code{"databricks"}. In other environments use \code{"shell"} as method.}
 
 \item{app_name}{The application name to be used while running in the Spark
 cluster.}


### PR DESCRIPTION
## What changes are proposed in this pull request?
This patch adds support for Databricks Spark clusters by adding a method type to `spark_connect`. When `method = 'databricks'`, there is no need for any additional arguments to `spark_connect`.

## Implementation details
The new internal `databricks_connection()` function, does two main things:
1. Makes an internal Databricks call to start the sparklyr backend on the currently attached cluster. This call passes the current location of sparklyr JARs to Databricks backend. The backend will perform the work on searching and find the right JAR and will call its main method.
2. Uses the gateway port returned from step 1 to establish gateway and backend connections

We think sparklyr is going to be an active project with multiple releases in coming months. As a result, we think hard coding the JARs in Databricks spark images will tie users to older versions of the project. We will continue using the JARs that are installed by the R package.

In Databricks notebooks and jobs, the JVM and Spark Context are managed by Databricks. Therefore, applications need to use the existing context and using `spark-submit` will not work. Also, in Databricks notebooks SparkR connection is already established and provides a mechanism for calling into the JVM. We are using SparkR to bootstrap the sparklyr connection