### PR TITLE
Not calling System.exit() inside the gateway thread in service mode

### DIFF
--- a/java/backend.scala
+++ b/java/backend.scala
@@ -234,7 +234,7 @@ object Backend {
         System.exit(1)
     }
 
-    System.exit(0)
+    if (!isService) System.exit(0)
   }
 
   def bind(): Unit = {

--- a/java/backend.scala
+++ b/java/backend.scala
@@ -231,7 +231,7 @@ object Backend {
     } catch {
       case e: IOException =>
         logError("Server shutting down: failed with exception ", e)
-        System.exit(1)
+        if (!isService) System.exit(1)
     }
 
     if (!isService) System.exit(0)


### PR DESCRIPTION
sparklyr gateway thread calls System.exit when we come out of the infinite loop even when we are in service mode. This patch changes that. In both cases where I introduce a check against `isService`, not calling `System.exit` is harmless and the thread will exit.