### PR TITLE
fixes livy_service_start() when version is not specified

### DIFF
--- a/R/livy_service.R
+++ b/R/livy_service.R
@@ -12,6 +12,11 @@ livy_service_start <- function(version = NULL, spark_version = NULL) {
     "SPARK_HOME" = spark_home_dir(version = spark_version)
   ))
 
+  if (identical(version, NULL)) {
+    version <- livy_install_find() %>%
+      .[["livy"]]
+  }
+
   # warn if the user attempts to use livy 0.2.0 with Spark >= 2.0.0
   if (!identical(spark_version, NULL)) {
     spark_version <- ensure_scalar_character(spark_version)


### PR DESCRIPTION
...but `spark_version` is.

```
# > livy_service_start(spark_version = "2.1.0")
# Error in if (version == "0.2.0" && numeric_version(spark_version) >= "2.0.0") { : 
#     missing value where TRUE/FALSE needed
```