### PR TITLE
Add split separator pattern for R deser in Livy connections

### DIFF
--- a/R/livy_service.R
+++ b/R/livy_service.R
@@ -12,11 +12,6 @@ livy_service_start <- function(version = NULL, spark_version = NULL) {
     "SPARK_HOME" = spark_home_dir(version = spark_version)
   ))
 
-  if (identical(version, NULL)) {
-    version <- livy_install_find() %>%
-      .[["livy"]]
-  }
-
   # warn if the user attempts to use livy 0.2.0 with Spark >= 2.0.0
   if (!identical(spark_version, NULL)) {
     spark_version <- ensure_scalar_character(spark_version)

--- a/R/livy_service.R
+++ b/R/livy_service.R
@@ -12,6 +12,11 @@ livy_service_start <- function(version = NULL, spark_version = NULL) {
     "SPARK_HOME" = spark_home_dir(version = spark_version)
   ))
 
+  if (identical(version, NULL)) {
+    version <- livy_install_find() %>%
+      .[["livy"]]
+  }
+
   # warn if the user attempts to use livy 0.2.0 with Spark >= 2.0.0
   if (!identical(spark_version, NULL)) {
     spark_version <- ensure_scalar_character(spark_version)

--- a/R/sdf_wrapper.R
+++ b/R/sdf_wrapper.R
@@ -49,7 +49,7 @@ sdf_deserialize_column <- function(column, sc) {
   separator <- split_separator(sc)
 
   if (is.character(column)) {
-    splat <- strsplit(column, separator$r, fixed = TRUE)[[1]]
+    splat <- strsplit(column, separator$r_deser, fixed = TRUE)[[1]]
     splat[splat == "<NA>"] <- NA
     Encoding(splat) <- "UTF-8"
     return(splat)

--- a/R/utils.R
+++ b/R/utils.R
@@ -283,7 +283,7 @@ trim_whitespace <- function(strings) {
 
 split_separator <- function(sc) {
   if (inherits(sc, "livy_connection"))
-    list(scala = "\\|~\\|", r = "|~|")
+    list(scala = "\\|~\\|", r = "|~|", r_deser = "\\|~\\|")
   else
-    list(scala = "\31", r = "\31")
+    list(scala = "\31", r = "\31", r_deser = "\31")
 }


### PR DESCRIPTION
This change adds `r_deser` to the return value of `split_separator()` for Livy so string columns deserialize back to R correctly