### PR TITLE
Support additional jars in `spark_compile`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright (C) 2009-17 by RStudio, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr 0.6.0 (UNRELEASED)
 
+- Added support for `jar_dep` in the compilation specification to
+  support additional `jars` through `spark_compile`.
+  
+- `spark_compile` now prints deprecation warnings.
+
 - Added `spark_read_source()`. This function reads data from a
   Spark data source which can be loaded through an Spark package.
 

--- a/R/spark_compile.R
+++ b/R/spark_compile.R
@@ -13,6 +13,7 @@
 #'   compilation of \code{scala} files.
 #' @param jar The path to the \code{jar} program to be used, for
 #'   generating of the resulting \code{jar}.
+#' @param jar_dep An optional list of additional \code{jar} dependencies.
 #'
 #' @import rprojroot
 #' @import digest
@@ -23,7 +24,8 @@ spark_compile <- function(jar_name,
                           spark_home = NULL,
                           filter = NULL,
                           scalac = NULL,
-                          jar = NULL)
+                          jar = NULL,
+                          jar_dep = NULL)
 {
   default_install <- spark_install_find()
   spark_home <- if (is.null(spark_home) && !is.null(default_install))
@@ -78,6 +80,8 @@ spark_compile <- function(jar_name,
     if (length(jars))
       break
   }
+
+  jars <- c(jars, jar_dep)
 
   if (!length(jars))
     stop("failed to discover Spark jars")
@@ -144,6 +148,7 @@ compile_package_jars <- function(..., spec = NULL) {
     scalac_path   <- el$scalac_path
     filter        <- el$scala_filter
     jar_path      <- el$jar_path
+    jar_dep       <- el$jar_dep
 
     # try to automatically download + install Spark
     if (is.null(spark_home) && !is.null(spark_version)) {
@@ -157,7 +162,8 @@ compile_package_jars <- function(..., spec = NULL) {
       spark_home = spark_home,
       filter = filter,
       scalac = scalac_path,
-      jar = jar_path
+      jar = jar_path,
+      jar_dep = jar_dep
     )
 
   }
@@ -190,6 +196,7 @@ compile_package_jars <- function(..., spec = NULL) {
 #' @param jar_name The name to be assigned to the generated \code{jar}.
 #' @param jar_path The path to the \code{jar} tool to be used
 #'   during compilation of your Spark extension.
+#' @param jar_dep An optional list of additional \code{jar} dependencies.
 #'
 #' @export
 spark_compilation_spec <- function(spark_version = NULL,
@@ -197,7 +204,8 @@ spark_compilation_spec <- function(spark_version = NULL,
                                    scalac_path = NULL,
                                    scala_filter = NULL,
                                    jar_name = NULL,
-                                   jar_path = NULL)
+                                   jar_path = NULL,
+                                   jar_dep = NULL)
 {
   spark_home    <- spark_home %||% spark_home_dir(spark_version)
   spark_version <- spark_version %||% spark_version_from_home(spark_home)
@@ -207,7 +215,8 @@ spark_compilation_spec <- function(spark_version = NULL,
        scalac_path = scalac_path,
        scala_filter = scala_filter,
        jar_name = jar_name,
-       jar_path = jar_path)
+       jar_path = jar_path,
+       jar_dep = jar_dep)
 }
 
 find_jar <- function() {

--- a/R/spark_compile.R
+++ b/R/spark_compile.R
@@ -94,7 +94,7 @@ spark_compile <- function(jar_name,
   Sys.setenv(CLASSPATH = CLASSPATH)
   on.exit(Sys.setenv(CLASSPATH = classpath), add = TRUE)
   scala_files_quoted <- paste(shQuote(scala_files), collapse = " ")
-  status <- execute(shQuote(scalac), "-optimise", scala_files_quoted)
+  status <- execute(shQuote(scalac), "-optimise", "-deprecation", scala_files_quoted)
   if (status)
     stop("==> failed to compile Scala source files")
 

--- a/java/backend.scala
+++ b/java/backend.scala
@@ -193,10 +193,23 @@ object Backend {
       System.exit(-1)
     }
 
-    port = args(0).toInt
-    sessionId = args(1).toInt
-    isService = args.length > 2 && args(2) == "--service"
-    isRemote = args.length > 3 && args(3) == "--remote"
+    val port = args(0).toInt
+    val sessionId = args(1).toInt
+    val isService = args.length > 2 && args(2) == "--service"
+    val isRemote = args.length > 3 && args(3) == "--remote"
+
+    init(port, sessionId, isService, isRemote)
+  }
+
+  def init(portParam: Int,
+           sessionIdParam: Int,
+           isServiceParam: Boolean,
+           isRemoteParam :Boolean): Unit = {
+
+    port = portParam
+    sessionId = sessionIdParam
+    isService = isServiceParam
+    isRemote = isRemoteParam
 
     if (isRemote) {
       val anyIpAddress = Array[Byte](0, 0, 0, 0)

--- a/man/spark_compilation_spec.Rd
+++ b/man/spark_compilation_spec.Rd
@@ -6,7 +6,7 @@
 \usage{
 spark_compilation_spec(spark_version = NULL, spark_home = NULL,
   scalac_path = NULL, scala_filter = NULL, jar_name = NULL,
-  jar_path = NULL)
+  jar_path = NULL, jar_dep = NULL)
 }
 \arguments{
 \item{spark_version}{The Spark version to build against. This can
@@ -31,6 +31,8 @@ certain versions of Spark.}
 
 \item{jar_path}{The path to the \code{jar} tool to be used
 during compilation of your Spark extension.}
+
+\item{jar_dep}{An optional list of additional \code{jar} dependencies.}
 }
 \description{
 For use with \code{\link{compile_package_jars}}. The Spark compilation

--- a/man/spark_compile.Rd
+++ b/man/spark_compile.Rd
@@ -5,7 +5,7 @@
 \title{Compile Scala sources into a Java Archive}
 \usage{
 spark_compile(jar_name, spark_home = NULL, filter = NULL, scalac = NULL,
-  jar = NULL)
+  jar = NULL, jar_dep = NULL)
 }
 \arguments{
 \item{spark_home}{The path to the Spark sources to be used
@@ -20,6 +20,8 @@ compilation of \code{scala} files.}
 
 \item{jar}{The path to the \code{jar} program to be used, for
 generating of the resulting \code{jar}.}
+
+\item{jar_dep}{An optional list of additional \code{jar} dependencies.}
 
 \item{name}{The name to assign to the target \code{jar}.}
 }


### PR DESCRIPTION
I've been working in the `sparkworker` extensions and hit a couple minor caess:
 1. There is currently no way of adding additional `jars` to `spark_compile` (I wanted to add the `sparklyr` jars).
 2. Deprecation warnings are not printed out while compiling.