### PR TITLE
ensure_scalar_* respects allow.null arg

### DIFF
--- a/R/precondition.R
+++ b/R/precondition.R
@@ -61,6 +61,7 @@ make_ensure_scalar_impl <- function(checker,
 
     if (is.na(object)) object <- NA_integer_
     if (!allow.na)     ensure_not_na(object)
+    if (!allow.null)   ensure_not_null(object)
 
     converter(object)
   }

--- a/R/precondition.R
+++ b/R/precondition.R
@@ -54,12 +54,13 @@ make_ensure_scalar_impl <- function(checker,
   {
     object <- object %||% default
 
+    if (allow.null && is.null(object)) return(object)
+
     if (!checker(object))
       stopf("'%s' is not %s", deparse(substitute(object)), message)
 
     if (is.na(object)) object <- NA_integer_
     if (!allow.na)     ensure_not_na(object)
-    if (!allow.null)   ensure_not_null(object)
 
     converter(object)
   }

--- a/tests/testthat/test-ensure.R
+++ b/tests/testthat/test-ensure.R
@@ -1,0 +1,18 @@
+context("ensure")
+
+test_that("ensure_* functions work as expected", {
+  expect_equal(
+    "foo",
+    ensure_scalar_character("foo")
+  )
+
+  expect_equal(
+    NULL,
+    ensure_scalar_character(NULL, allow.null = TRUE)
+  )
+
+  expect_error(
+    ensure_scalar_character(NULL),
+    "'NULL' is not a length-one character vector"
+  )
+})


### PR DESCRIPTION
This change moves the logic for checking `NULL` up in the function returned by `make_ensure_scalar_impl()`. Fixes #642

`ensure_not_null()` seems redundant to the `checker(object)` condition so I removed it.