### PR TITLE
Fix row count message in cbind

### DIFF
--- a/R/mutation.R
+++ b/R/mutation.R
@@ -191,7 +191,7 @@ sdf_bind_cols <- function(...) {
     which()
 
   envir <- rlang::caller_env()
-  quosures <- rlang::dots_exprs(...) %>%
+  quosures <- rlang::exprs(...) %>%
     # if 'list(sdf)' is one of the args we want 'sdf'
     lapply(function(x) if (rlang::is_lang(x))
       rlang::lang_tail(x) else x) %>%

--- a/R/mutation.R
+++ b/R/mutation.R
@@ -156,8 +156,7 @@ cbind.tbl_spark <- function(..., deparse.level = 1, name = random_string("sparkl
 
   dots_num_rows <- dots_with_ids %>%
     lapply(function(x) sdf_last_index(x, id = id)) %>%
-    unlist %>%
-    (function(x) x + 1)
+    unlist
 
   if (length(unique(dots_num_rows)) > 1) {
     names_tbls <- substitute(list(...))[-1] %>%


### PR DESCRIPTION
Forgot to change this when we moved the base for `sdf_with_sequential_id()` to 1. There's a test but it passed locally at the time...

Also removed a deprecated alias from rlang.