### PR TITLE
Fix spark_config regression introduced by verbose connections

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.4-9002
+Version: 0.5.4-9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -24,11 +24,11 @@ spark_config <- function(file = "config.yml", use_default = TRUE) {
 }
 
 spark_config_value <- function(config, name, default = NULL) {
-  if (!name %in% config) default else config[[name]]
+  if (!name %in% names(config)) default else config[[name]]
 }
 
 spark_config_exists <- function(config, name, default = NULL) {
-  if (!name %in% name) default else !identical(config[[name]], FALSE)
+  if (!name %in% names(config)) default else !identical(config[[name]], FALSE)
 }
 
 # recursively merge two lists -- extracted from code used by rmarkdown

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -1,0 +1,45 @@
+context("config")
+
+test_that("spark_config_exists function works as expected", {
+  expect_false(
+    spark_config_exists(list(), "sparklyr.log.console", FALSE)
+  )
+
+  expect_true(
+    spark_config_exists(list(), "sparklyr.log.console", TRUE)
+  )
+
+  expect_true(
+    spark_config_exists(list("sparklyr.log.console"), "sparklyr.log.console", FALSE)
+  )
+
+  expect_true(
+    spark_config_exists(list(sparklyr.log.console = TRUE), "sparklyr.log.console", FALSE)
+  )
+
+  expect_true(
+    spark_config_exists(list(sparklyr.log.console = FALSE), "sparklyr.log.console", TRUE)
+  )
+})
+
+test_that("spark_config_value function works as expected", {
+  expect_equals(
+    "1",
+    spark_config_value(list(), "sparklyr.nothing", "1")
+  )
+
+  expect_equals(
+    "2",
+    spark_config_value(list(sparklyr.something = 2), "sparklyr.something", "1")
+  )
+
+  expect_equals(
+    1,
+    spark_config_value(list(), "sparklyr.nothing", 1)
+  )
+
+  expect_equals(
+    2,
+    spark_config_value(list(sparklyr.something = 2), "sparklyr.something", 1)
+  )
+})


### PR DESCRIPTION
Also, add `spark_config` tests.