### PR TITLE
Add broom to DESCRIPTION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@
 language: r
 sudo: false
 cache: packages
+r_github_packages:
+ - hadley/devtools

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@
 language: r
 sudo: false
 cache: packages
-r_github_packages:
- - hadley/devtools
+warnings_are_errors: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Depends:
 Imports:
     assertthat,
     base64enc,
+    broom,
     config (>= 0.2),
     DBI (>= 0.6-1),
     dbplyr (>= 0.0.0.9000),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     rprojroot,
     rstudioapi,
     shiny (>= 1.0.1),
-    withr
+    withr,
+    broom
 Remotes:
     tidyverse/dplyr,
     tidyverse/dbplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,9 +40,9 @@ Imports:
     rprojroot,
     rstudioapi,
     shiny (>= 1.0.1),
-    withr,
-    broom
+    withr
 Remotes:
+    tidyverse/broom,
     tidyverse/dplyr,
     tidyverse/dbplyr,
     tidyverse/rlang

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ Imports:
     shiny (>= 1.0.1),
     withr
 Remotes:
-    tidyverse/broom,
     tidyverse/dplyr,
     tidyverse/dbplyr,
     tidyverse/rlang


### PR DESCRIPTION
@kevinykuo I wonder if the order of `broom` is causing this issue. BTW. The problem seems to be that `broom` depends on `dplyr`/`dbplyr` from CRAN not the development versions we are using in `sparklyr`. Lets see if this works...