### PR TITLE
update README to use Spark 2.1

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -34,7 +34,7 @@ You should also install a local version of Spark for development purposes:
 
 ```{r, eval=FALSE}
 library(sparklyr)
-spark_install(version = "1.6.2")
+spark_install(version = "2.1.0")
 ```
 
 To upgrade to the latest version of sparklyr, run the following command and restart your r session:
@@ -287,14 +287,14 @@ The RStudio IDE features for sparklyr are available now as part of the [RStudio 
 [rsparkling](https://cran.r-project.org/package=rsparkling) is a CRAN package from [H2O](http://h2o.ai) that extends [sparklyr](http://spark.rstudio.com) to provide an interface into [Sparkling Water](https://github.com/h2oai/sparkling-water). For instance, the following example installs, configures and runs [h2o.glm](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html):
 
 ```{r results='hide', message=FALSE}
-options(rsparkling.sparklingwater.version = "1.6.8")
+options(rsparkling.sparklingwater.version = "2.1.0")
 
 library(rsparkling)
 library(sparklyr)
 library(dplyr)
 library(h2o)
 
-sc <- spark_connect(master = "local", version = "1.6.2")
+sc <- spark_connect(master = "local", version = "2.1.0")
 mtcars_tbl <- copy_to(sc, mtcars, "mtcars")
 
 mtcars_h2o <- as_h2o_frame(sc, mtcars_tbl, strict_version_check = FALSE)


### PR DESCRIPTION
Keeping up with the times. Also `rsparkling` now supports more than just 1.6.