### PR TITLE
No need to constantly refresh connection viewer for temp tables

### DIFF
--- a/R/connection_viewer.R
+++ b/R/connection_viewer.R
@@ -142,6 +142,9 @@ on_connection_closed <- function(scon) {
 }
 
 on_connection_updated <- function(scon, hint) {
+  # avoid updating temp tables that are filtered out
+  if (!grepl("^sparklyr_tmp_", hint)) return();
+
   viewer <- external_viewer()
   if (!is.null(viewer))
     viewer$connectionUpdated(type = "Spark", host = to_host(scon), hint = hint)


### PR DESCRIPTION
Minor fix to avoid aggressive research of the connections contract.