### PR TITLE
Validate hostname is correct while creating spark context to fix #532

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@
 
 language: r
 sudo: false
+cache: packages

--- a/R/shell_hive.R
+++ b/R/shell_hive.R
@@ -1,4 +1,18 @@
 create_hive_context.spark_shell_connection <- function(sc) {
+  if (spark_version(sc) <= "2.0.1") {
+    # Some systems might have an invalid hostname that Spark <= 2.0.1 fails to handle
+    # gracefully and triggers unexpected errors such as #532. Under these versions,
+    # we proactevely test getLocalHost() to warn users of this problem.
+
+    tryCatch({
+      invoke_static(sc, "java.net.InetAddress", "getLocalHost")
+    }, error = function(err) {
+      warning(
+        "Failed to retrieve localhost, please validate that the hostname is correctly mapped."
+      )
+    })
+  }
+
   if (spark_version(sc) >= "2.0.0")
     create_hive_context_v2(sc)
   else

--- a/R/shell_hive.R
+++ b/R/shell_hive.R
@@ -8,7 +8,8 @@ create_hive_context.spark_shell_connection <- function(sc) {
       invoke_static(sc, "java.net.InetAddress", "getLocalHost")
     }, error = function(err) {
       warning(
-        "Failed to retrieve localhost, please validate that the hostname is correctly mapped."
+        "Failed to retrieve localhost, please validate that the hostname is correctly mapped. ",
+        "Consider running `hostname` and adding that entry to your `/etc/hosts` file."
       )
     })
   }


### PR DESCRIPTION
This PR addresses a configuration issue in Spark <= 2.0.1, while not a problem in `sparklyr`, several `sparklyr` users have reported this problem.

For instance, using EC2+R+Conda+sparklyr triggers this problem:

<img width="865" alt="screen shot 2017-06-14 at 3 16 07 pm" src="https://user-images.githubusercontent.com/3478847/27160902-8a9f0fa6-512c-11e7-84cb-4c60325bb9e2.png">

The logs show that `tachyon.hadoop.TFS` could not be initialized:

```
Caused by: java.lang.NoClassDefFoundError: Could not initialize class tachyon.hadoop.TFS
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
	at java.lang.Class.newInstance(Class.java:383)
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:373)
	... 72 more
”Warning message in create_hive_context_v1(sc):
```

However, one can configure `sparklyr` with:

```
spark_install(version = "1.6.2, logging = "TRACE")
```

which will increase logging, and `spark_log(sc)` will show a full stack trace that looks more like:

```
Error: java.net.UnknownHostException: ip-172-30-0-220: ip-172-30-0-220: Name or service not known
        at java.net.InetAddress.getLocalHost(InetAddress.java:1496)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at sparklyr.Invoke$.invoke(invoke.scala:94)
        at sparklyr.StreamHandler$.handleMethodCall(stream.scala:89)
        at sparklyr.StreamHandler$.read(stream.scala:55)
        at sparklyr.BackendHandler.channelRead0(handler.scala:49)
        at sparklyr.BackendHandler.channelRead0(handler.scala:14)
```

This problem even triggers while running `spark-shell`. However, given that so many users have reported this, is worth to at least warn about by checking this ourselves.

The change introduces a call to `java.net.InetAddress.getLocalHost` which is also used by Spark, Hadoop, and many others pieces of the stack which will fail under this configurations.

The fix is usually to get the hostname say, by running `hostname` and then adding this entry in the `/etc/hosts` file.