### PR TITLE
Fix windows connection issue with newinstance0 present in logs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9001
+Version: 0.5.6-9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -166,6 +166,9 @@
 
 ### Bug Fixes
 
+- Fixed `spark_connect` under Windows issue when `newInstance0` is present in 
+  the logs.
+
 - Fixed collecting `long` type columns when NAs are present (#463).
   
 - Fixed backend issue that affects systems where `localhost` does

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -21,7 +21,7 @@ spark_default_app_jar <- function(version) {
 #' @param master Spark cluster url to connect to. Use \code{"local"} to
 #'   connect to a local instance of Spark installed via
 #'   \code{\link{spark_install}}.
-#' @param spark_home The path to a Spark instaFllation. Defaults to the path
+#' @param spark_home The path to a Spark installation. Defaults to the path
 #'   provided by the \code{SPARK_HOME} environment variable. If
 #'   \code{SPARK_HOME} is defined, it will be always be used unless the
 #'   \code{version} parameter is specified to force the use of a locally

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -21,7 +21,7 @@ spark_default_app_jar <- function(version) {
 #' @param master Spark cluster url to connect to. Use \code{"local"} to
 #'   connect to a local instance of Spark installed via
 #'   \code{\link{spark_install}}.
-#' @param spark_home The path to a Spark installation. Defaults to the path
+#' @param spark_home The path to a Spark instaFllation. Defaults to the path
 #'   provided by the \code{SPARK_HOME} environment variable. If
 #'   \code{SPARK_HOME} is defined, it will be always be used unless the
 #'   \code{version} parameter is specified to force the use of a locally

--- a/R/connection_windows.R
+++ b/R/connection_windows.R
@@ -28,7 +28,7 @@ verify_msvcr100 <- function() {
   }
 }
 
-prepare_windows_environment <- function(sparkHome) {
+prepare_windows_environment <- function(sparkHome, environment) {
   verbose <- sparklyr_boolean_option("sparklyr.verbose")
   verboseMessage <- function(...) {
     if (verbose) message(...)
@@ -60,23 +60,10 @@ prepare_windows_environment <- function(sparkHome) {
   }
   verboseMessage("HADOOP_HOME exists under ", hadoopPath)
 
-  if (nchar(Sys.getenv("HADOOP_HOME")) == 0 ||
-      Sys.getenv("HADOOP_HOME") != hadoopPath) {
+  # assign HADOOP_HOME to system2 environment which is more reliable than SETX
+  environment$HADOOP_HOME <- hadoopPath
 
-    if (Sys.getenv("HADOOP_HOME") != hadoopPath) {
-      warning("HADOOP_HOME was already but does not match current Spark installation")
-    } else {
-      verboseMessage("HADOOP_HOME environment variable not set")
-    }
-
-    output <- system2(
-      "SETX", c("HADOOP_HOME", shQuote(hadoopPath)),
-      stdout = if(verbose) TRUE else NULL)
-
-    verboseMessage("HADOOP_HOME environment set with output ", output)
-  } else {
-    verboseMessage("HADOOP_HOME environment was already set to ", Sys.getenv("HADOOP_HOME"))
-  }
+  verboseMessage("HADOOP_HOME environment set with output ", output)
 
   # pre-create the hive temp folder to manage permissions issues
   appUserTempDir <- normalizePath(

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -28,8 +28,11 @@ shell_connection <- function(master,
     }
   }
 
+  # start with blank environment variables
+  environment <- new.env()
+
   # prepare windows environment
-  prepare_windows_environment(spark_home)
+  prepare_windows_environment(spark_home, environment)
 
   # verify that java is available
   validate_java_version(spark_home)
@@ -39,7 +42,6 @@ shell_connection <- function(master,
     stop("Failed to connect to Spark (SPARK_HOME is not set).")
 
   # apply environment variables
-  environment <- list()
   sparkEnvironmentVars <- connection_config(list(config = config, master = master), "spark.env.")
   lapply(names(sparkEnvironmentVars), function(varName) {
     environment[[varName]] <<- sparkEnvironmentVars[[varName]]
@@ -257,7 +259,7 @@ start_shell <- function(master,
     console_log <- spark_config_exists(config, "sparklyr.log.console", FALSE)
 
     # start the shell (w/ specified additional environment variables)
-    env <- unlist(environment)
+    env <- unlist(as.list(environment))
     withr::with_envvar(env, {
       system2(spark_submit_path,
         args = shell_args,


### PR DESCRIPTION
Several users have reported a `newinstance0 ` connection issue under Windows. See #98 #229 #277 #295 #354 #397 #409 #456 #466 #497 #633 #679.

I was able to repro this first time `sparklyr` is used in a new environment or by removing `HADOOP_HOME` and relaunching the RStudio.

This issue was being caused by using `SETX` to set the `HADOOP_HOME`. While this would work the next time the rsession launches (and the same session in some other environments); some other environments and packages, say `plumber`, `Conda`, etc. might not respect the `SETX` setting across rsession and trigger this error consistently.

The fix is to set `HADOOP_HOME` during `spark-submit` being specified through `withr::with_envvar`.

There is some risk of regressing scenarios where `SETX` was actually working appropriately. However, given that this has affected multiple Windows users, I think would be best to simplify this and perform an additional change to bring back `SETX` if we find environments where the new approach does not work correctly.

For those users affected by this error, please retry with `sparklyr 0.5.6-9002` or newer. You can install using `devtools::install_github("rstudio/sparklyr")`.