### PR TITLE
Allow version to override spark_home for master=local and fix #726

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -166,6 +166,9 @@
 
 ### Bug Fixes
 
+- `spark_connect` with `master = "local"` and a given `version` overrides
+  `SPARK_HOME` to avoid existing installation mismatches.
+
 - Fixed `spark_connect` under Windows issue when `newInstance0` is present in 
   the logs.
 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -20,12 +20,10 @@ shell_connection <- function(master,
   # trigger deprecated warnings
   config <- shell_connection_validate_config(config)
 
-  # for local mode we support SPARK_HOME via locally installed versions
-  if (spark_master_is_local(master)) {
-    if (!nzchar(spark_home)) {
-      installInfo <- spark_install_find(version, hadoop_version, latest = FALSE, connecting = TRUE)
-      spark_home <- installInfo$sparkVersionDir
-    }
+  # for local mode we support SPARK_HOME via locally installed versions and version overrides SPARK_HOME
+  if (spark_master_is_local(master) && !is.null(version)) {
+    installInfo <- spark_install_find(version, hadoop_version, latest = FALSE, connecting = TRUE)
+    spark_home <- installInfo$sparkVersionDir
   }
 
   # start with blank environment variables


### PR DESCRIPTION
Some users have existing Spark installations with SPARK_HOME set that they are unaware of and makes `spark_connect` fail. See https://github.com/rstudio/sparklyr/issues/726.