### PR TITLE
hive operators for regex matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,7 +105,7 @@
 ### Broom
   
 - Implemented `tidy()`, `augment()`, and `glance()` from tidyverse/broom for
-  `ml_model_generalized_linear_regression()` and `ml_model_linear_regression()`
+  `ml_model_generalized_linear_regression` and `ml_model_linear_regression`
   models.
   
 ### R Compatibility

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,9 @@
 
 ### dplyr
 
+- Support for Hive built-in operators `%like%`, `%rlike%`, and
+  `%regexp%` for matching regular expressions in `filter()` and `mutate()`.
+
 - Support for dplyr (>= 0.6) which among many improvements, increases
   performance in some queries by making use of a new query optimizer.
 

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -68,7 +68,10 @@ sql_translate_env.spark_connection <- function(con) {
       or = function(x, y) dbplyr::build_sql(x, " or ", y),
       and = function(x, y) dbplyr::build_sql(x, " and ", y),
       pmin = function(...) build_sql_if_compare(..., con = con, compare = "<="),
-      pmax = function(...) build_sql_if_compare(..., con = con, compare = ">=")
+      pmax = function(...) build_sql_if_compare(..., con = con, compare = ">="),
+      `%like%` = function(x, y) dbplyr::build_sql(x, " like ", y),
+      `%rlike%` = function(x, y) dbplyr::build_sql(x, " rlike ", y),
+      `%regexp%`  = function(x, y) dbplyr::build_sql(x, " regexp ", y)
     ),
 
     aggregate = dbplyr::sql_translator(

--- a/tests/testthat/test-dplyr-hive-operators.R
+++ b/tests/testthat/test-dplyr-hive-operators.R
@@ -1,0 +1,45 @@
+context("hive operators")
+
+sc <- testthat_spark_connection()
+
+test_that("regex relational operators work", {
+  test_requires("dplyr")
+
+  hello <- data_frame(hello = c("hello my friend",
+                                "hello my dog",
+                                "hello my cat"))
+  hello_tbl <- testthat_tbl("hello")
+
+  expect_equal(hello_tbl %>%
+                 filter(hello %like% "%cat%") %>%
+                 collect(),
+               hello %>%
+                 filter(grepl("cat", hello))
+  )
+
+  products <- data_frame(
+    product_id = 1:3,
+    product_description = c("fruit", "Fruit", "milk"))
+
+  products_tbl <- testthat_tbl("products")
+
+  expect_equal(
+    products_tbl %>%
+      mutate(category = ifelse(product_description %rlike% "F|fruit",
+                               "produce", "dairy")) %>%
+      collect(),
+    products %>%
+      mutate(category = ifelse(grepl("F|fruit", product_description),
+                               "produce", "dairy"))
+  )
+
+  expect_equal(
+    products_tbl %>%
+      mutate(category = ifelse(product_description %regexp% "F|fruit",
+                               "produce", "dairy")) %>%
+      collect(),
+    products %>%
+      mutate(category = ifelse(grepl("F|fruit", product_description),
+                               "produce", "dairy"))
+  )
+})


### PR DESCRIPTION
This change adds `%like%`, `%rlike%`, and `%regexp%` which correspond to `LIKE`, `RLIKE`, and `REGEXP`, respectively, from https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF for regex matching.

Closes #761, closes #329 