### PR TITLE
Fix spark_connect(master = "local") when version isn't set

### DIFF
--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -21,8 +21,10 @@ shell_connection <- function(master,
   config <- shell_connection_validate_config(config)
 
   # for local mode we support SPARK_HOME via locally installed versions and version overrides SPARK_HOME
-  if (spark_master_is_local(master) && !is.null(version)) {
+  if (spark_master_is_local(master)) {
     installInfo <- spark_install_find(version, hadoop_version, latest = FALSE, connecting = TRUE)
+    if (is.null(version))
+      message("* Using Spark: ", installInfo$sparkVersion)
     spark_home <- installInfo$sparkVersionDir
   }
 


### PR DESCRIPTION
This PR fixes an issue introduced by 84e7ce09a1769440bb92bb7196c08db18c943158 where connection in local mode fails when `version` isn't specified.

Current behavior:

```
> sc <- spark_connect(master = "local")
Error in shell_connection(master = master, spark_home = spark_home, app_name = app_name,  : 
                            Failed to connect to Spark (SPARK_HOME is not set). 
```

With patch:

```
> sc <- spark_connect(master = "local")
* Using Spark: 2.0.0
```