### PR TITLE
Explicit local path reference while using copy_to in yarn client to a…

### DIFF
--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -130,7 +130,7 @@ spark_serialize_csv_scala <- function(sc, df, columns, repartition) {
     "sparklyr.Utils",
     "createDataFrameFromCsv",
     spark_context(sc),
-    tempfile,
+    paste("file://", tempfile, sep = ""),
     columns,
     as.integer(if (repartition <= 0) 1 else repartition),
     separator$regexp


### PR DESCRIPTION
…void hdfs path and fix #525 

Yes, I think all we need is the `file://` prefix for https://github.com/rstudio/sparklyr/issues/525, need to test this in `yarn-client` before the merge....