### PR TITLE
Make compute cache data inmemory by default to fix #721

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -169,10 +169,13 @@
 
 ### Bug Fixes
 
-- `spark_connect` with `master = "local"` and a given `version` overrides
+- `compute()` now caches data in memory by default. To revert this beavior use
+  `sparklyr.dplyr.compute.nocache` set to `TRUE`.
+
+- `spark_connect()` with `master = "local"` and a given `version` overrides
   `SPARK_HOME` to avoid existing installation mismatches.
 
-- Fixed `spark_connect` under Windows issue when `newInstance0` is present in 
+- Fixed `spark_connect()` under Windows issue when `newInstance0` is present in 
   the logs.
 
 - Fixed collecting `long` type columns when NAs are present (#463).

--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -126,4 +126,8 @@ db_save_query.spark_connection <- function(con, sql, name, temporary = TRUE, ...
 {
   df <- spark_dataframe(con, sql)
   invoke(df, "registerTempTable", name)
+
+  # compute() is expected to preserve the query, cache as the closest mapping.
+  if (!sparklyr_boolean_option("sparklyr.dplyr.compute.nocache"))
+    tbl_cache(con, name)
 }


### PR DESCRIPTION
From investigating https://github.com/rstudio/sparklyr/issues/721... We currently,

```r
library(sparklyr)
library(dplyr)
sc <- spark_connect(master = "local", version = "2.1.0")
iris_tbl <- copy_to(sc, iris)

iris_tbl %>% compute()
```

`compute()` creates a named temporary table for the given query. While this could be useful in some cases, say:

```r
iris_tbl %>% select(Species) %>% compute(name = "iris_species")
tbl(sc, "iris_species")
```

However, there is also an explicit assumption that `compute()`, from dplyr's help:
> compute() stores results in a remote temporary table.

This  was the assumption at least on https://github.com/rstudio/sparklyr/issues/721.

In retrospect, `compute()` is not very interesting as it is implemented today in `sparklyr` since it doesn't take advantage of Spark functions and does not "store results in a remote temporary table".

The proposed change is to cache into memory the result of `compute()` which is a more natural operation from `dplyr` while using `sparklyr`.