### PR TITLE
Implement `cumprod()` for dplyr operations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9006
+Version: 0.5.6-9007
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,8 @@
 
 ### dplyr
 
+- Support for `cumprod()` to calculate cumulative products.
+
 - Support for `cor()`, `cov()`, `sd()` and `var()` as window functions.
 
 - Support for Hive built-in operators `%like%`, `%rlike%`, and

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -118,7 +118,19 @@ sql_translate_env.spark_connection <- function(con) {
       cor = win_recycled_params("corr"),
       cov =  win_recycled_params("covar_samp"),
       sd =  dbplyr::win_recycled("stddev_samp"),
-      var = dbplyr::win_recycled("var_samp")
+      var = dbplyr::win_recycled("var_samp"),
+      cumprod = function(x) {
+        dbplyr::build_sql(
+          "exp(",
+          dbplyr::win_over(
+            dbplyr::build_sql("sum(log(", x, "))"),
+            partition = dbplyr::win_current_group(),
+            order = dbplyr::win_current_order(),
+            frame = c(-Inf, 0)
+          ),
+          ")"
+        )
+      }
     )
 
   )

--- a/tests/testthat/test-dplyr-stats.R
+++ b/tests/testthat/test-dplyr-stats.R
@@ -65,11 +65,14 @@ test_that("sumprod works as expected", {
   stats <- data.frame(x=1:10)
   stats_tbl <- copy_to(sc, stats, overwrite = TRUE)
 
-  s1 <- stats %>% mutate(
-    cumprod = cumprod(x)
-  )
+  s1 <- stats %>%
+    arrange(x) %>%
+    mutate(
+      cumprod = cumprod(x)
+    )
 
   s2 <- stats_tbl %>%
+    arrange(x) %>%
     mutate(
       cumprod = cumprod(x)
     ) %>%

--- a/tests/testthat/test-dplyr-stats.R
+++ b/tests/testthat/test-dplyr-stats.R
@@ -58,3 +58,23 @@ test_that("cor, cov, sd and var works as expected over groups", {
 
   expect_equal(s1, s2)
 })
+
+test_that("sumprod works as expected", {
+  test_requires("dplyr")
+
+  stats <- data.frame(x=1:10)
+  stats_tbl <- copy_to(sc, stats, overwrite = TRUE)
+
+  s1 <- stats %>% mutate(
+    cumprod = cumprod(x)
+  )
+
+  s2 <- stats_tbl %>%
+    mutate(
+      cumprod = cumprod(x)
+    ) %>%
+    collect() %>%
+    as.data.frame()
+
+  expect_equal(s1, s2)
+})


### PR DESCRIPTION
Implements @kevinykuo suggestion to support for dplyr's `cumprod` using `exp` and `log`, see https://github.com/rstudio/sparklyr/issues/779.