### PR TITLE
Use protocol to avoid path does not exist exception and fix #525

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9007
+Version: 0.5.6-9008
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -173,6 +173,9 @@
 
 ### Bug Fixes
 
+- Fixed `Path does not exist` referencing `hdfs` exception during `copy_to` under
+  systems configured with `HADOOP_HOME`.
+
 - Fixed session crash after "No status is returned" error by terminating
   invalid connection and added support to print log trace during this error.
 

--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -23,9 +23,13 @@ spark_serialize_csv_file <- function(sc, df, columns, repartition) {
     write.csv(df, tempfile, row.names = FALSE, na = "")
   }
 
-  df <- spark_csv_read(sc, tempfile, csvOptions = list(
-    header = "true"
-  ), columns = columns)
+  df <- spark_csv_read(
+    sc,
+    paste("file:///", tempfile, sep = ""),
+    csvOptions = list(
+      header = "true"
+    ),
+    columns = columns)
 
   if (repartition > 0) {
     df <- invoke(df, "repartition", as.integer(repartition))

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -22,10 +22,13 @@ shell_connection <- function(master,
 
   # for local mode we support SPARK_HOME via locally installed versions and version overrides SPARK_HOME
   if (spark_master_is_local(master)) {
-    installInfo <- spark_install_find(version, hadoop_version, latest = FALSE, connecting = TRUE)
-    if (is.null(version))
-      message("* Using Spark: ", installInfo$sparkVersion)
-    spark_home <- installInfo$sparkVersionDir
+    if (!nzchar(spark_home) || !is.null(version)) {
+      installInfo <- spark_install_find(version, hadoop_version, latest = FALSE, connecting = TRUE)
+      spark_home <- installInfo$sparkVersionDir
+
+      if (is.null(version))
+        message("* Using Spark: ", installInfo$sparkVersionDir)
+    }
   }
 
   # start with blank environment variables


### PR DESCRIPTION
Fix for https://github.com/rstudio/sparklyr/issues/525 which was causing  `Path does not exist` exception during `copy_to` under systems configured with `HADOOP_HOME`.

Big thanks to @Wfore0990 for providing a docker image to repro this!

The problem is that, in some configurations, Spark adopts the `hdfs://` protocol as the default, fix is to explicitly call out the local file system.