### PR TITLE
Fix dbplyr window function warnings

### DIFF
--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -115,6 +115,11 @@ sql_translate_env.spark_connection <- function(con) {
           order = order
         )
       },
+      count = function() dbplyr::win_over(
+        dbplyr::sql("count(*)"),
+        partition = dbplyr::win_current_group()
+      ),
+      n_distinct = dbplyr::win_absent("distinct"),
       cor = win_recycled_params("corr"),
       cov =  win_recycled_params("covar_samp"),
       sd =  dbplyr::win_recycled("stddev_samp"),

--- a/tests/testthat/test-dplyr-stats.R
+++ b/tests/testthat/test-dplyr-stats.R
@@ -81,3 +81,21 @@ test_that("sumprod works as expected", {
 
   expect_equal(s1, s2)
 })
+
+test_that("count() works in grouped mutate", {
+  test_requires("dplyr")
+  iris_tbl <- testthat_tbl("iris")
+
+  c1 <- iris_tbl %>%
+    group_by(Species) %>%
+    mutate(n = count()) %>%
+    select(Species, n) %>%
+    distinct() %>%
+    collect()
+  c2 <- iris_tbl %>%
+    group_by(Species) %>%
+    count() %>%
+    collect()
+
+  expect_equal(c1, c2)
+})


### PR DESCRIPTION
This change adds `count()` and `n_distinct()` to window function translations to fix `dbplyr` warnings.

Closes #792.