### PR TITLE
Add support for `partition_by` under `spark_write_*` functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9008
+Version: 0.5.6-9009
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 
 ### External Data
 
+- Added `partition_by` parameter to `spark_write_csv()`, `spark_write_json()`,
+  `spark_write_table()` and `spark_write_parquet()`.
+
 - Added `spark_read_source()`. This function reads data from a
   Spark data source which can be loaded through an Spark package.
 

--- a/R/data_csv.R
+++ b/R/data_csv.R
@@ -71,7 +71,7 @@ spark_csv_read <- function(sc,
     path)
 }
 
-spark_csv_write <- function(df, path, csvOptions, mode) {
+spark_csv_write <- function(df, path, csvOptions, mode, partition_by) {
   sc <- spark_connection(df)
 
   write <- invoke(df, "write")
@@ -80,6 +80,9 @@ spark_csv_write <- function(df, path, csvOptions, mode) {
   lapply(names(csvOptions), function(csvOptionName) {
     options <<- invoke(options, "option", csvOptionName, csvOptions[[csvOptionName]])
   })
+
+  if (!is.null(partition_by))
+    options <- invoke(options, "partitionBy", as.list(partition_by))
 
   options <- spark_data_apply_mode(options, mode)
 

--- a/man/spark_write_csv.Rd
+++ b/man/spark_write_csv.Rd
@@ -6,7 +6,7 @@
 \usage{
 spark_write_csv(x, path, header = TRUE, delimiter = ",", quote = "\\"",
   escape = "\\\\", charset = "UTF-8", null_value = NULL,
-  options = list(), mode = NULL)
+  options = list(), mode = NULL, partition_by = NULL, ...)
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
@@ -29,6 +29,10 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 \item{options}{A list of strings with additional options.}
 
 \item{mode}{Specifies the behavior when data or table already exists.}
+
+\item{partition_by}{Partitions the output by the given columns on the file system.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Write a Spark DataFrame to a tabular (typically, comma-separated) file.

--- a/man/spark_write_json.Rd
+++ b/man/spark_write_json.Rd
@@ -4,7 +4,8 @@
 \alias{spark_write_json}
 \title{Write a Spark DataFrame to a JSON file}
 \usage{
-spark_write_json(x, path, mode = NULL, options = list())
+spark_write_json(x, path, mode = NULL, options = list(),
+  partition_by = NULL, ...)
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
@@ -15,6 +16,10 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 \item{mode}{Specifies the behavior when data or table already exists.}
 
 \item{options}{A list of strings with additional options.}
+
+\item{partition_by}{Partitions the output by the given columns on the file system.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Serialize a Spark DataFrame to the \href{http://www.json.org/}{JavaScript

--- a/man/spark_write_parquet.Rd
+++ b/man/spark_write_parquet.Rd
@@ -4,7 +4,8 @@
 \alias{spark_write_parquet}
 \title{Write a Spark DataFrame to a Parquet file}
 \usage{
-spark_write_parquet(x, path, mode = NULL, options = list())
+spark_write_parquet(x, path, mode = NULL, options = list(),
+  partition_by = NULL, ...)
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
@@ -15,6 +16,10 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 \item{mode}{Specifies the behavior when data or table already exists.}
 
 \item{options}{A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.}
+
+\item{partition_by}{Partitions the output by the given columns on the file system.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Serialize a Spark DataFrame to the

--- a/man/spark_write_table.Rd
+++ b/man/spark_write_table.Rd
@@ -4,7 +4,8 @@
 \alias{spark_write_table}
 \title{Writes a Spark DataFrame into a Spark table}
 \usage{
-spark_write_table(x, name, mode = NULL, options = list())
+spark_write_table(x, name, mode = NULL, options = list(),
+  partition_by = NULL, ...)
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
@@ -14,6 +15,10 @@ spark_write_table(x, name, mode = NULL, options = list())
 \item{mode}{Specifies the behavior when data or table already exists.}
 
 \item{options}{A list of strings with additional options.}
+
+\item{partition_by}{Partitions the output by the given columns on the file system.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Writes a Spark DataFrame into a Spark table.


### PR DESCRIPTION
Implement support for `partition_by` under `spark_write_*` functions:

> Partitioning is one of the most widely used techniques to optimize physical data layout. It provides a coarse-grained index for skipping unnecessary data reads when queries have predicates on the partitioned columns. In order for partitioning to work well, the number of distinct values in each column should typically be less than tens of thousands.

For instance, `iris` partitioned over `Species`...

<img width="867" alt="screen shot 2017-06-28 at 1 20 43 pm" src="https://user-images.githubusercontent.com/3478847/27658473-02856276-5c05-11e7-8f2b-60bb4a4bcde0.png">