### PR TITLE
rename columns argument of sdf_reparition to partition_by

### DIFF
--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -700,10 +700,10 @@ sdf_broadcast <- function(x) {
 #' @template roxlate-ml-x
 #'
 #' @param partitions number of partitions
-#' @param columns vector of column names used for partitioning, only supported for Spark 2.0+
+#' @param partition_by vector of column names used for partitioning, only supported for Spark 2.0+
 #'
 #' @export
-sdf_repartition <- function(x, partitions = NULL, columns = NULL) {
+sdf_repartition <- function(x, partitions = NULL, partition_by = NULL) {
   sdf <- spark_dataframe(x)
   sc <- spark_connection(sdf)
 
@@ -711,15 +711,15 @@ sdf_repartition <- function(x, partitions = NULL, columns = NULL) {
     ensure_scalar_integer()
 
   if (spark_version(sc) >= "2.0.0") {
-    columns <- as.list(columns) %>%
+    partition_by <- as.list(partition_by) %>%
       lapply(ensure_scalar_character)
 
     return(
-      invoke_static(sc, "sparklyr.Repartition", "repartition", sdf, partitions, columns) %>%
+      invoke_static(sc, "sparklyr.Repartition", "repartition", sdf, partitions, partition_by) %>%
         sdf_register()
     )
   } else {
-    if (!is.null(columns))
+    if (!is.null(partition_by))
       stop("partitioning by columns only supported for Spark 2.0.0 and later")
 
     invoke(sdf, "repartition", partitions) %>%

--- a/man/sdf_repartition.Rd
+++ b/man/sdf_repartition.Rd
@@ -4,7 +4,7 @@
 \alias{sdf_repartition}
 \title{Repartition a Spark DataFrame}
 \usage{
-sdf_repartition(x, partitions = NULL, columns = NULL)
+sdf_repartition(x, partitions = NULL, partition_by = NULL)
 }
 \arguments{
 \item{x}{An object coercable to a Spark DataFrame (typically, a
@@ -12,7 +12,7 @@ sdf_repartition(x, partitions = NULL, columns = NULL)
 
 \item{partitions}{number of partitions}
 
-\item{columns}{vector of column names used for partitioning, only supported for Spark 2.0+}
+\item{partition_by}{vector of column names used for partitioning, only supported for Spark 2.0+}
 }
 \description{
 Repartition a Spark DataFrame

--- a/tests/testthat/test-partitioning.R
+++ b/tests/testthat/test-partitioning.R
@@ -9,7 +9,7 @@ test_that("sdf_repartition works", {
                4L)
 
   expect_equal(iris_tbl %>%
-                 sdf_repartition(columns = c("Species", "Petal_Width")) %>%
+                 sdf_repartition(partition_by = c("Species", "Petal_Width")) %>%
                  sdf_query_plan() %>%
                  dplyr::first() %>%
                  gsub("#[0-9]+", "", ., perl = TRUE),
@@ -17,7 +17,7 @@ test_that("sdf_repartition works", {
                  )
 
   expect_equal(iris_tbl %>%
-                 sdf_repartition(5L, columns = c("Species", "Petal_Width")) %>%
+                 sdf_repartition(5L, partition_by = c("Species", "Petal_Width")) %>%
                  sdf_query_plan() %>%
                  dplyr::first() %>%
                  gsub("#[0-9]+", "", ., perl = TRUE),
@@ -27,7 +27,7 @@ test_that("sdf_repartition works", {
 test_that("'sdf_partition' -- 'partitions' argument should take numeric (#735)", {
   iris_tbl <- testthat_tbl("iris")
   expect_equal(iris_tbl %>%
-                 sdf_repartition(6, columns = "Species") %>%
+                 sdf_repartition(6, partition_by = "Species") %>%
                  sdf_num_partitions(),
                6)
 })


### PR DESCRIPTION
...to align argument names with other functions e.g. `spark_write_*`.