### PR TITLE
In windows, `sparklyr.log.console` is not pushing output to console

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9010
+Version: 0.5.6-9011
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -262,13 +262,16 @@ start_shell <- function(master,
 
     console_log <- spark_config_exists(config, "sparklyr.log.console", FALSE)
 
+    stdout_param <- if (console_log) "" else output_file
+    stderr_param <-if (console_log) "" else output_file
+
     # start the shell (w/ specified additional environment variables)
     env <- unlist(as.list(environment))
     withr::with_envvar(env, {
       system2(spark_submit_path,
         args = shell_args,
-        stdout = if (console_log) "" else output_file,
-        stderr = if (console_log) "" else output_file,
+        stdout = stdout_param,
+        stderr = stderr_param,
         wait = FALSE)
     })
 


### PR DESCRIPTION
Due to NSE, this is not working in windows:

```
sc <- spark_connect(master = "local", version = "2.1.0", config = list(sparklyr.log.console = TRUE))
```

Fix is to set variables to force evaluation.