### PR TITLE
Add support for columns parameter in spark_read_* functions to fix #799

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 
 ### External Data
 
+- Added `columns` parameter to `spark_read_*()` functions to load data with
+  named columns or explicit column types.
+
 - Added `partition_by` parameter to `spark_write_csv()`, `spark_write_json()`,
   `spark_write_table()` and `spark_write_parquet()`.
 

--- a/man/spark_read_csv.Rd
+++ b/man/spark_read_csv.Rd
@@ -7,7 +7,7 @@
 spark_read_csv(sc, name, path, header = TRUE, columns = NULL,
   infer_schema = TRUE, delimiter = ",", quote = "\\"", escape = "\\\\",
   charset = "UTF-8", null_value = NULL, options = list(),
-  repartition = 0, memory = TRUE, overwrite = TRUE)
+  repartition = 0, memory = TRUE, overwrite = TRUE, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -45,6 +45,8 @@ is, should the table be cached?)}
 
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Read a tabular data file into a Spark DataFrame.

--- a/man/spark_read_jdbc.Rd
+++ b/man/spark_read_jdbc.Rd
@@ -5,7 +5,7 @@
 \title{Read from JDBC connection into a Spark DataFrame.}
 \usage{
 spark_read_jdbc(sc, name, options = list(), repartition = 0,
-  memory = TRUE, overwrite = TRUE)
+  memory = TRUE, overwrite = TRUE, columns = NULL, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -22,6 +22,10 @@ is, should the table be cached?)}
 
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
+
+\item{columns}{A vector of column names or a named vector of column types.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Read from JDBC connection into a Spark DataFrame.

--- a/man/spark_read_json.Rd
+++ b/man/spark_read_json.Rd
@@ -5,7 +5,7 @@
 \title{Read a JSON file into a Spark DataFrame}
 \usage{
 spark_read_json(sc, name, path, options = list(), repartition = 0,
-  memory = TRUE, overwrite = TRUE)
+  memory = TRUE, overwrite = TRUE, columns = NULL, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -25,6 +25,10 @@ is, should the table be cached?)}
 
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
+
+\item{columns}{A vector of column names or a named vector of column types.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Read a table serialized in the \href{http://www.json.org/}{JavaScript

--- a/man/spark_read_parquet.Rd
+++ b/man/spark_read_parquet.Rd
@@ -5,7 +5,7 @@
 \title{Read a Parquet file into a Spark DataFrame}
 \usage{
 spark_read_parquet(sc, name, path, options = list(), repartition = 0,
-  memory = TRUE, overwrite = TRUE)
+  memory = TRUE, overwrite = TRUE, columns = NULL, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -25,6 +25,10 @@ is, should the table be cached?)}
 
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
+
+\item{columns}{A vector of column names or a named vector of column types.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Read a \href{https://parquet.apache.org/}{Parquet} file into a Spark

--- a/man/spark_read_source.Rd
+++ b/man/spark_read_source.Rd
@@ -5,7 +5,7 @@
 \title{Read from a generic source into a Spark DataFrame.}
 \usage{
 spark_read_source(sc, name, source, options = list(), repartition = 0,
-  memory = TRUE, overwrite = TRUE)
+  memory = TRUE, overwrite = TRUE, columns = NULL, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -24,6 +24,10 @@ is, should the table be cached?)}
 
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
+
+\item{columns}{A vector of column names or a named vector of column types.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Read from a generic source into a Spark DataFrame.

--- a/man/spark_read_table.Rd
+++ b/man/spark_read_table.Rd
@@ -5,7 +5,7 @@
 \title{Reads from a Spark Table into a Spark DataFrame.}
 \usage{
 spark_read_table(sc, name, options = list(), repartition = 0,
-  memory = TRUE, overwrite = TRUE)
+  memory = TRUE, overwrite = TRUE, columns = NULL, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -22,6 +22,10 @@ is, should the table be cached?)}
 
 \item{overwrite}{Boolean; overwrite the table with the given name if it
 already exists?}
+
+\item{columns}{A vector of column names or a named vector of column types.}
+
+\item{...}{Optional arguments; currently unused.}
 }
 \description{
 Reads from a Spark Table into a Spark DataFrame.

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -18,13 +18,14 @@ test_that("spark_read_csv() succeeds when column contains similar non-ascii", {
 })
 
 test_that("spark_read_json() can load data using column names", {
-  json <- file("test.json", "w+", encoding = "latin1")
+  json <- file("test.json", "w+")
   cat("{\"Sepal_Length\":5.1,\"Species\":\"setosa\", \"Other\": { \"a\": 1, \"b\": \"x\"}}\n", file = json)
   cat("{\"Sepal_Length\":4.9,\"Species\":\"setosa\", \"Other\": { \"a\": 2, \"b\": \"y\"}}\n", file = json)
   close(json)
 
   df <- spark_read_json(
-    sc,name = "iris_json_named",
+    sc,
+    name = "iris_json_named",
     path = "test.json",
     columns = c("a", "b", "c")
   )
@@ -35,13 +36,14 @@ test_that("spark_read_json() can load data using column names", {
 })
 
 test_that("spark_read_json() can load data using column types", {
-  json <- file("test.json", "w+", encoding = "latin1")
+  json <- file("test.json", "w+")
   cat("{\"Sepal_Length\":5.1,\"Species\":\"setosa\", \"Other\": { \"a\": 1, \"b\": \"x\"}}\n", file = json)
   cat("{\"Sepal_Length\":4.9,\"Species\":\"setosa\", \"Other\": { \"a\": 2, \"b\": \"y\"}}\n", file = json)
   close(json)
 
   df <- spark_read_json(
-    sc,name = "iris_json_typed",
+    sc,
+    name = "iris_json_typed",
     path = "test.json",
     columns = list("Sepal_Length" = "character", "Species" = "character", "Other" = "struct<a:integer,b:character>")
   ) %>% collect()
@@ -51,4 +53,20 @@ test_that("spark_read_json() can load data using column types", {
   expect_true(is.list(df$Other))
 
   file.remove("test.json")
+})
+
+test_that("spark_read_csv() can read long decimals", {
+  csv <- file("test.csv", "w+")
+  cat("decimal\n1\n12312312312312300000000000000", file = csv)
+  close(csv)
+
+  df <- spark_read_csv(
+    sc,
+    name = "test_big_decimals",
+    path = "test.csv"
+  )
+
+  expect_equal(nrow(df), 2)
+
+  file.remove("test.csv")
 })

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -13,4 +13,42 @@ test_that("spark_read_csv() succeeds when column contains similar non-ascii", {
   expect_true(
     all(dplyr::tbl_vars(df) == c("Municipio", "var", "var_1_0")),
     info = "success reading non-ascii similar columns from csv")
+
+  file.remove("test.csv")
+})
+
+test_that("spark_read_json() can load data using column names", {
+  json <- file("test.json", "w+", encoding = "latin1")
+  cat("{\"Sepal_Length\":5.1,\"Species\":\"setosa\", \"Other\": { \"a\": 1, \"b\": \"x\"}}\n", file = json)
+  cat("{\"Sepal_Length\":4.9,\"Species\":\"setosa\", \"Other\": { \"a\": 2, \"b\": \"y\"}}\n", file = json)
+  close(json)
+
+  df <- spark_read_json(
+    sc,name = "iris_json_named",
+    path = "test.json",
+    columns = c("a", "b", "c")
+  )
+
+  testthat::expect_equal(colnames(df), c("a", "b", "c"))
+
+  file.remove("test.json")
+})
+
+test_that("spark_read_json() can load data using column types", {
+  json <- file("test.json", "w+", encoding = "latin1")
+  cat("{\"Sepal_Length\":5.1,\"Species\":\"setosa\", \"Other\": { \"a\": 1, \"b\": \"x\"}}\n", file = json)
+  cat("{\"Sepal_Length\":4.9,\"Species\":\"setosa\", \"Other\": { \"a\": 2, \"b\": \"y\"}}\n", file = json)
+  close(json)
+
+  df <- spark_read_json(
+    sc,name = "iris_json_typed",
+    path = "test.json",
+    columns = list("Sepal_Length" = "character", "Species" = "character", "Other" = "struct<a:integer,b:character>")
+  ) %>% collect()
+
+  expect_true(is.character(df$Sepal_Length))
+  expect_true(is.character(df$Species))
+  expect_true(is.list(df$Other))
+
+  file.remove("test.json")
 })

--- a/tests/testthat/test.csv
+++ b/tests/testthat/test.csv
@@ -1,2 +1,0 @@
-Município;var;var 1.0
-1233;1;2


### PR DESCRIPTION
Similar to `spark_read_csv()`, add support for `columns` on the other `spark_read_*()` functions, for instance:

```r
spark_read_json(
    sc,name = "iris_json_named",
    path = "test.json",
    columns = c("a", "b", "c")
  )
```

or

```r
spark_read_json(
    sc,name = "iris_json_typed",
    path = "test.json",
    columns = list("Sepal_Length" = "character", "Species" = "character", "Other" = "struct<a:integer,b:character>")
  )
```