### PR TITLE
Use latest installed version as default

### DIFF
--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -50,7 +50,7 @@ spark_install_find <- function(version = NULL,
     }
   }
 
-  versions <- versions[with(versions, order(-default, -hadoop_default)), ]
+  versions <- versions[with(versions, order(default, spark, hadoop_default, decreasing = TRUE)), ]
   spark_install_info(as.character(versions[1,]$spark), as.character(versions[1,]$hadoop))
 }
 

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -21,7 +21,13 @@ read_spark_versions_json <- function(file = spark_versions_url()) {
   .globals$sparkVersionsJson
 }
 
+
 #' @rdname spark_install
+#'
+#' @examples
+#'
+#' spark_installed_versions()
+#'
 #' @export
 spark_installed_versions <- function() {
 
@@ -125,7 +131,7 @@ spark_versions <- function(latest = TRUE) {
       newRow$base <- if (NROW(currentRow) > 0) currentRow$base else ""
       newRow$pattern <- if (NROW(currentRow) > 0) currentRow$pattern else ""
       newRow$download <- if (NROW(currentRow) > 0) currentRow$download else ""
-      newRow$default <- identical(currentRow$spark, "1.6.2")
+      newRow$default <- identical(currentRow$spark, "2.1.0")
       newRow$hadoop_default <- if (compareVersion(currentRow$spark, "2.0") >= 0)
           identical(currentRow$hadoop, "2.7")
         else


### PR DESCRIPTION
Makes 2.1.0 the default install for R and use the latest version installed when none specified.

https://github.com/rstudio/spark-install/pull/24