### PR TITLE
Improve 'argument is of length zero' error and `-Inf` warning while fetching data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9012
+Version: 0.5.6-9013
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -186,6 +186,9 @@
 
 ### Bug Fixes
 
+- Improved `argument is of length zero` error triggered while retrieving data 
+  with no columns to display.
+
 - Fixed `Path does not exist` referencing `hdfs` exception during `copy_to` under
   systems configured with `HADOOP_HOME`.
 

--- a/R/dbi_spark_result.R
+++ b/R/dbi_spark_result.R
@@ -54,15 +54,13 @@ setMethod("dbSendQuery", c("spark_connection", "character"), function(conn, stat
 })
 
 setMethod("dbGetQuery", c("spark_connection", "character"), function(conn, statement, ...) {
-  # TODO: Use default dbGetQuery method defined in DBIConnection
   rs <- dbSendQuery(conn, statement, ...)
   on.exit(dbClearResult(rs))
 
   df <- tryCatch(
     dbFetch(rs, n = -1, ...),
     error = function(e) {
-      warning(conditionMessage(e), call. = conditionCall(e))
-      NULL
+      stop("Failed to fetch data: ", e$message)
     }
   )
 

--- a/R/sdf_wrapper.R
+++ b/R/sdf_wrapper.R
@@ -117,7 +117,7 @@ sdf_collect <- function(object) {
   # fix an issue where sometimes columns in a Spark DataFrame are empty
   # in such a case, we fill those with NAs of the same type (#477)
   n <- vapply(transformed, length, numeric(1))
-  rows <- max(n)
+  rows <- if (length(n) > 0) max(n) else 0
   fixed <- lapply(transformed, function(column) {
     if (length(column) == 0) {
       converter <- switch(


### PR DESCRIPTION
Repro:

```r
library(sparklyr)
sc <- spark_connect(master = "local", version = "2.1.0")
DBI::dbGetQuery(sc, "SELECT *")
```

```
Warning message:
In max(n) : no non-missing arguments to max; returning -Inf
```

The problem here is that `max(n)` is invalid for `max(integer(0))`.

The other error is harder to reproduce, see https://github.com/rstudio/sparklyr/issues/812. But regardless, the `dbFetch` exception is being masked by an error under `ncol(df)` causing:

```
Error in if (ncol(df) > 0) df else invisible(df) : 
  argument is of length zero
```

instead, we should stop earlier to help diagnose issues like this one.