### PR TITLE
add csrf_header to livy_config()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -153,6 +153,9 @@
 - While connecting to spark from Windows, setting the `sparklyr.verbose` option
   to `TRUE` prints detailed configuration steps.
   
+- Added `csrf_header` to `livy_config()` to enable connections to Livy servers with
+  CSRF protection enabled.
+  
 ### Compilation
 
 - Added support for `jar_dep` in the compilation specification to

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -35,6 +35,7 @@ livy_validate_http_response <- function(message, req) {
 #' @param config Optional base configuration
 #' @param username The username to use in the Authorization header
 #' @param password The password to use in the Authorization header
+#' @param csrf_header Required when the Livy server has CSRF protection enabled. Defaults to \code{FALSE}.
 #'
 #' @details
 #'
@@ -42,8 +43,12 @@ livy_validate_http_response <- function(message, req) {
 #' for Livy. For instance, \code{"username"} and \code{"password"}
 #' define the basic authentication settings for a Livy session.
 #'
+#' When \code{"csrf_header"} is set to \code{TRUE}, the header \code{"X-Requested-By: sparklyr"}
+#' is added to all HTTP requests.
+#'
 #' @return Named list with configuration data
-livy_config <- function(config = spark_config(), username = NULL, password = NULL) {
+livy_config <- function(config = spark_config(), username = NULL, password = NULL,
+                        csrf_header = FALSE) {
   if (!is.null(username) || !is.null(password)) {
     secret <- base64_enc(paste(username, password, sep = ":"))
 
@@ -53,6 +58,14 @@ livy_config <- function(config = spark_config(), username = NULL, password = NUL
           "Basic",
           base64_enc(paste(username, password, sep = ":"))
         )
+      )
+    )
+  }
+
+  if (csrf_header) {
+    config[["sparklyr.livy.headers"]] <- c(
+      config[["sparklyr.livy.headers"]], list(
+        "X-Requested-By" = "sparklyr"
       )
     )
   }
@@ -71,9 +84,9 @@ livy_get_httr_headers <- function(config, headers) {
 #' @importFrom httr GET
 livy_get_json <- function(url, config) {
   req <- GET(url,
-   livy_get_httr_headers(config, list(
-     "Content-Type" = "application/json"
-   ))
+             livy_get_httr_headers(config, list(
+               "Content-Type" = "application/json"
+             ))
   )
 
   livy_validate_http_response("Failed to retrieve livy session", req)
@@ -127,12 +140,12 @@ livy_create_session <- function(master, config) {
   )
 
   req <- POST(paste(master, "sessions", sep = "/"),
-    livy_get_httr_headers(config, list(
-      "Content-Type" = "application/json"
-    )),
-    body = toJSON(
-      data
-    )
+              livy_get_httr_headers(config, list(
+                "Content-Type" = "application/json"
+              )),
+              body = toJSON(
+                data
+              )
   )
 
   livy_validate_http_response("Failed to create livy session", req)
@@ -148,10 +161,10 @@ livy_create_session <- function(master, config) {
 
 livy_destroy_session <- function(sc) {
   req <- DELETE(paste(sc$master, "sessions", sc$sessionId, sep = "/"),
-    livy_get_httr_headers(sc$config, list(
-      "Content-Type" = "application/json"
-    )),
-    body = NULL
+                livy_get_httr_headers(sc$config, list(
+                  "Content-Type" = "application/json"
+                )),
+                body = NULL
   )
 
   livy_validate_http_response("Failed to destroy livy statement", req)
@@ -391,14 +404,14 @@ livy_post_statement <- function(sc, code) {
   livy_log_operation(sc, code)
 
   req <- POST(paste(sc$master, "sessions", sc$sessionId, "statements", sep = "/"),
-    livy_get_httr_headers(sc$config, list(
-      "Content-Type" = "application/json"
-    )),
-    body = toJSON(
-      list(
-        code = unbox(code)
-      )
-    )
+              livy_get_httr_headers(sc$config, list(
+                "Content-Type" = "application/json"
+              )),
+              body = toJSON(
+                list(
+                  code = unbox(code)
+                )
+              )
   )
 
   livy_validate_http_response("Failed to invoke livy statement", req)
@@ -711,11 +724,11 @@ livy_load_scala_sources <- function(sc) {
     tryCatch({
       sources <- paste(readLines(sourceFile), collapse = "\n")
 
-    statement <- livy_statement_new(sources, NULL)
-    livy_invoke_statement(sc, statement)
-  }, error = function(e) {
-    stop("Failed to load ", basename(sourceFile), ": ", e$message)
-  })
+      statement <- livy_statement_new(sources, NULL)
+      livy_invoke_statement(sc, statement)
+    }, error = function(e) {
+      stop("Failed to load ", basename(sourceFile), ": ", e$message)
+    })
   })
 }
 

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -35,7 +35,7 @@ livy_validate_http_response <- function(message, req) {
 #' @param config Optional base configuration
 #' @param username The username to use in the Authorization header
 #' @param password The password to use in the Authorization header
-#' @param csrf_header Required when the Livy server has CSRF protection enabled. Defaults to \code{FALSE}.
+#' @param csrf_header Required when the Livy server has CSRF protection enabled. Defaults to \code{TRUE}.
 #'
 #' @details
 #'
@@ -48,7 +48,7 @@ livy_validate_http_response <- function(message, req) {
 #'
 #' @return Named list with configuration data
 livy_config <- function(config = spark_config(), username = NULL, password = NULL,
-                        csrf_header = FALSE) {
+                        csrf_header = TRUE) {
   if (!is.null(username) || !is.null(password)) {
     secret <- base64_enc(paste(username, password, sep = ":"))
 

--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -127,7 +127,7 @@ connection_config <- function(sc, prefix, not_prefix = list()) {
     if (grepl("\\.remote$", e) && isLocal)
       found <- FALSE
 
-    if (nchar(config[[e]]) == 0)
+    if (all(nchar(config[[e]]) == 0))
       found <- FALSE
 
     found

--- a/man/livy_config.Rd
+++ b/man/livy_config.Rd
@@ -5,7 +5,7 @@
 \title{Create a Spark Configuration for Livy}
 \usage{
 livy_config(config = spark_config(), username = NULL, password = NULL,
-  csrf_header = FALSE)
+  csrf_header = TRUE)
 }
 \arguments{
 \item{config}{Optional base configuration}
@@ -14,7 +14,7 @@ livy_config(config = spark_config(), username = NULL, password = NULL,
 
 \item{password}{The password to use in the Authorization header}
 
-\item{csrf_header}{Required when the Livy server has CSRF protection enabled. Defaults to \code{FALSE}.}
+\item{csrf_header}{Required when the Livy server has CSRF protection enabled. Defaults to \code{TRUE}.}
 }
 \value{
 Named list with configuration data

--- a/man/livy_config.Rd
+++ b/man/livy_config.Rd
@@ -4,7 +4,8 @@
 \alias{livy_config}
 \title{Create a Spark Configuration for Livy}
 \usage{
-livy_config(config = spark_config(), username = NULL, password = NULL)
+livy_config(config = spark_config(), username = NULL, password = NULL,
+  csrf_header = FALSE)
 }
 \arguments{
 \item{config}{Optional base configuration}
@@ -12,6 +13,8 @@ livy_config(config = spark_config(), username = NULL, password = NULL)
 \item{username}{The username to use in the Authorization header}
 
 \item{password}{The password to use in the Authorization header}
+
+\item{csrf_header}{Required when the Livy server has CSRF protection enabled. Defaults to \code{FALSE}.}
 }
 \value{
 Named list with configuration data
@@ -23,4 +26,7 @@ Create a Spark Configuration for Livy
 Extends a Spark \code{"spark_config"} configuration with settings
 for Livy. For instance, \code{"username"} and \code{"password"}
 define the basic authentication settings for a Livy session.
+
+When \code{"csrf_header"} is set to \code{TRUE}, the header \code{"X-Requested-By: sparklyr"}
+is added to all HTTP requests.
 }


### PR DESCRIPTION
This PR adds the `csrf_header` argument to `livy_config()` which allows users to connect to Livy servers with CSRF protection enabled.

In Livy, this function is disabled by default, but when it is enabled, we need to append a custom http-header.

Relevant bits from Livy:
https://github.com/cloudera/livy/blob/2abb8a3d2850c506ffd2b8a210813f1b8353045f/conf/livy.conf.template#L63-L65
https://github.com/cloudera/livy/blob/91058d29846a82b9d006390a6521bcba11bf56bd/server/src/main/scala/com/cloudera/livy/server/CsrfFilter.scala#L26-L49

I've tested this on an HDInsight cluster.

...As I'm writing this, I'm thinking maybe we should just hardcode this in `livy_config()` so users never have to worry about it??