### PR TITLE
For local clusters, check that java exists under JAVA_HOME to fix #801 and #562

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.5.6-9013
+Version: 0.5.6-9014
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -186,6 +186,9 @@
 
 ### Bug Fixes
 
+- When using `spark_connect()` in local clusters, it validates that `java` exists
+  under `JAVA_HOME` to help troubleshoot systems that have an incorrect `JAVA_HOME`.
+
 - Improved `argument is of length zero` error triggered while retrieving data 
   with no columns to display.
 

--- a/R/connection_shinyapp.R
+++ b/R/connection_shinyapp.R
@@ -375,7 +375,8 @@ connection_spark_server <- function(input, output, session) {
       message <- paste(
         "In order to connect to Spark ",
         "your system needs to have Java installed (",
-        "no version of Java was detected).",
+        "no version of Java was detected or installation ",
+        "is invalid).",
         sep = ""
       )
 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -38,7 +38,7 @@ shell_connection <- function(master,
   prepare_windows_environment(spark_home, environment)
 
   # verify that java is available
-  validate_java_version(spark_home)
+  validate_java_version(master, spark_home)
 
   # error if there is no SPARK_HOME
   if (!nzchar(spark_home))

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,11 +2,20 @@ is.installed <- function(package) {
   is.element(package, installed.packages()[,1])
 }
 
-get_java <- function() {
+get_java <- function(throws = FALSE) {
   java_home <- Sys.getenv("JAVA_HOME", unset = NA)
-  if (!is.na(java_home))
+  if (!is.na(java_home)) {
     java <- file.path(java_home, "bin", "java")
-  else
+    if (!file.exists(java)) {
+      if (throws) {
+        stop("Java is required to connect to Spark. ",
+             "JAVA_HOME is set but does not point to a valid version. ",
+             "Please fix JAVA_HOME or reinstall from: ",
+             java_install_url())
+      }
+      java <- ""
+    }
+  } else
     java <- Sys.which("java")
   java
 }
@@ -15,15 +24,16 @@ is_java_available <- function() {
   nzchar(get_java())
 }
 
-validate_java_version <- function(spark_home) {
-  # if somene sets SPARK_HOME, assume Java is available since some systems
+validate_java_version <- function(master, spark_home) {
+  # if someone sets SPARK_HOME and we are not in local more, assume Java
+  # is available since some systems.
   # (e.g. CDH) use versions of java not discoverable through JAVA_HOME.
-  if (!is.null(spark_home) && nchar(spark_home) > 0)
+  if (!spark_master_is_local(master) && !is.null(spark_home) && nchar(spark_home) > 0)
     return(TRUE)
 
   # find the active java executable
-  java <- get_java()
-  if (!nzchar(get_java()))
+  java <- get_java(throws = TRUE)
+  if (!nzchar(java))
     stop("Java is required to connect to Spark. Please download and install Java from ",
          java_install_url())
 


### PR DESCRIPTION
One can set `SPARK_HOME` to some invalid path (maybe this is caused by uninstalling JAVA followed by installing a new version) and run `spark_connect` to find that this fails with not helpful error messages, specially hard to diagnose under windows, see: https://github.com/rstudio/sparklyr/issues/801 and https://github.com/rstudio/sparklyr/issues/562.

While this might not resolve all remaining `spark_connect` issues under windows, is the only issue we were able to fully troubleshoot with users.