### PR TITLE
Update utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -6,6 +6,9 @@ get_java <- function(throws = FALSE) {
   java_home <- Sys.getenv("JAVA_HOME", unset = NA)
   if (!is.na(java_home)) {
     java <- file.path(java_home, "bin", "java")
+    if (identical(.Platform$OS.type, "windows")) {
+      java <- paste0(java, ".exe")
+    }     
     if (!file.exists(java)) {
       if (throws) {
         stop("Java is required to connect to Spark. ",


### PR DESCRIPTION
The java binary on windows is called `java.exe`, so the current code for `get_java()` produces the following error when initializing the Spark context:
```
> sc = spark_connect("local")
   Error in get_java(throws = TRUE) : 
   Java is required to connect to Spark. JAVA_HOME is set but does not point to a valid version. Please fix   
   JAVA_HOME or reinstall from: https://www.java.com/en/
```
FYI:
```
> sessionInfo()
R version 3.3.3 (2017-03-06)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 10 x64 (build 14393)
```