### PR TITLE
unify livy_config() custom header args

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -155,12 +155,9 @@
 
 - While connecting to spark from Windows, setting the `sparklyr.verbose` option
   to `TRUE` prints detailed configuration steps.
-  
-- Added `csrf_header` to `livy_config()` to enable connections to Livy servers with
-  CSRF protection enabled.
 
 - Added `custom_headers` to `livy_config()` to add custom headers to the REST call
-  to the Livy Server
+  to the Livy server
   
 ### Compilation
 

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -35,7 +35,7 @@ livy_validate_http_response <- function(message, req) {
 #' @param config Optional base configuration
 #' @param username The username to use in the Authorization header
 #' @param password The password to use in the Authorization header
-#' @param csrf_header Required when the Livy server has CSRF protection enabled. Defaults to \code{TRUE}.
+#' @param custom_headers List of custom headers to append to http requests. Defaults to \code{list("X-Requested-By" = "sparklyr")}.
 #'
 #' @details
 #'
@@ -43,12 +43,12 @@ livy_validate_http_response <- function(message, req) {
 #' for Livy. For instance, \code{"username"} and \code{"password"}
 #' define the basic authentication settings for a Livy session.
 #'
-#' When \code{"csrf_header"} is set to \code{TRUE}, the header \code{"X-Requested-By: sparklyr"}
-#' is added to all HTTP requests.
+#' The default value of \code{"custom_headers"} is set to \code{list("X-Requested-By" = "sparklyr")}
+#' in order to facilitate connection to Livy servers with CSRF protection enabled.
 #'
 #' @return Named list with configuration data
 livy_config <- function(config = spark_config(), username = NULL, password = NULL,
-                        custom_headers = NULL, csrf_header = TRUE) {
+                        custom_headers = list("X-Requested-By" = "sparklyr")) {
   if (!is.null(username) || !is.null(password)) {
     secret <- base64_enc(paste(username, password, sep = ":"))
 
@@ -58,14 +58,6 @@ livy_config <- function(config = spark_config(), username = NULL, password = NUL
           "Basic",
           base64_enc(paste(username, password, sep = ":"))
         )
-      )
-    )
-  }
-
-  if (csrf_header) {
-    config[["sparklyr.livy.headers"]] <- c(
-      config[["sparklyr.livy.headers"]], list(
-        "X-Requested-By" = "sparklyr"
       )
     )
   }

--- a/man/livy_config.Rd
+++ b/man/livy_config.Rd
@@ -5,7 +5,7 @@
 \title{Create a Spark Configuration for Livy}
 \usage{
 livy_config(config = spark_config(), username = NULL, password = NULL,
-  custom_headers = NULL, csrf_header = TRUE)
+  custom_headers = list(`X-Requested-By` = "sparklyr"))
 }
 \arguments{
 \item{config}{Optional base configuration}
@@ -14,9 +14,7 @@ livy_config(config = spark_config(), username = NULL, password = NULL,
 
 \item{password}{The password to use in the Authorization header}
 
-\item{custom_headers}{Optional headers to be provided}
-
-\item{csrf_header}{Required when the Livy server has CSRF protection enabled. Defaults to \code{TRUE}.}
+\item{custom_headers}{List of custom headers to append to http requests. Defaults to \code{list("X-Requested-By" = "sparklyr")}.}
 }
 \value{
 Named list with configuration data
@@ -29,8 +27,6 @@ Extends a Spark \code{"spark_config"} configuration with settings
 for Livy. For instance, \code{"username"} and \code{"password"}
 define the basic authentication settings for a Livy session.
 
-Optional headers can be passed to configuration in \code{"custom_headers"}.
-
-When \code{"csrf_header"} is set to \code{TRUE}, the header \code{"X-Requested-By: sparklyr"}
-is added to all HTTP requests.
+The default value of \code{"custom_headers"} is set to \code{list("X-Requested-By" = "sparklyr")}
+in order to facilitate connection to Livy servers with CSRF protection enabled.
 }


### PR DESCRIPTION
Follow-up to https://github.com/rstudio/sparklyr/pull/834

I misspoke in that PR regarding the requirement for CSRF -- you do indeed need to have "X-Requested-By" as a custom header if CSRF protection is turned on. However, if the user is messing with custom headers anyway it wouldn't be hard to figure it out and we've documented it.