### PR TITLE
Add vocabulary.only to ft_count_vectorizer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,9 @@
   
 ### MLlib
 
+- Added `vocabulary.only` to `ft_count_vectorizer()` to retrieve the 
+  vocabulary with ease.
+
 - GLM type models now support `weights.column` to specify weights in model
   fitting. (#217)
 

--- a/R/ml_feature_transformation.R
+++ b/R/ml_feature_transformation.R
@@ -414,6 +414,7 @@ ft_regex_tokenizer <- function(x,
 #' the document's token count).
 #' @param vocab.size Build a vocabulary that only considers the top
 #' vocab.size terms ordered by term frequency across the corpus.
+#' @param vocabulary.only Boolean; should the vocabulary only be returned?
 #'
 #' @export
 ft_count_vectorizer <- function(x,
@@ -422,16 +423,20 @@ ft_count_vectorizer <- function(x,
                                 min.df = NULL,
                                 min.tf = NULL,
                                 vocab.size = NULL,
+                                vocabulary.only = FALSE,
                                 ...)
 {
   ml_backwards_compatibility_api()
   class <- "org.apache.spark.ml.feature.CountVectorizer"
-  invoke_simple_transformer(x, class, list(
-    setInputCol   = ensure_scalar_character(input.col),
-    setOutputCol  = ensure_scalar_character(output.col),
-    setMinDF      = min.df,
-    setMinTF      = min.tf,
-    setVocabSize  = vocab.size,
-    fit           = spark_dataframe(x)
-  ))
+  result <- invoke_simple_transformer(x, class, list(
+    setInputCol    = ensure_scalar_character(input.col),
+    setOutputCol   = ensure_scalar_character(output.col),
+    setMinDF       = min.df,
+    setMinTF       = min.tf,
+    setVocabSize   = vocab.size,
+    fit            = spark_dataframe(x)
+  ),
+  only.model = vocabulary.only)
+
+  if (vocabulary.only) as.character(invoke(result, "vocabulary")) else result
 }

--- a/R/ml_feature_transformation_utils.R
+++ b/R/ml_feature_transformation_utils.R
@@ -1,4 +1,4 @@
-invoke_simple_transformer <- function(x, class, arguments) {
+invoke_simple_transformer <- function(x, class, arguments, only.model = FALSE) {
   sdf <- spark_dataframe(x)
   sc <- spark_connection(sdf)
 
@@ -12,6 +12,8 @@ invoke_simple_transformer <- function(x, class, arguments) {
     else if (!identical(val, NULL))
       transformer <<- invoke(transformer, key, val)
   })
+
+  if (only.model) return(transformer)
 
   # invoke transformer
   transformed <- invoke(transformer, "transform", sdf)

--- a/man/ft_count_vectorizer.Rd
+++ b/man/ft_count_vectorizer.Rd
@@ -5,7 +5,7 @@
 \title{Feature Tranformation -- CountVectorizer}
 \usage{
 ft_count_vectorizer(x, input.col = NULL, output.col = NULL, min.df = NULL,
-  min.tf = NULL, vocab.size = NULL, ...)
+  min.tf = NULL, vocab.size = NULL, vocabulary.only = FALSE, ...)
 }
 \arguments{
 \item{x}{An object (usually a \code{spark_tbl}) coercable to a Spark DataFrame.}
@@ -29,6 +29,8 @@ the document's token count).}
 
 \item{vocab.size}{Build a vocabulary that only considers the top
 vocab.size terms ordered by term frequency across the corpus.}
+
+\item{vocabulary.only}{Boolean; should the vocabulary only be returned?}
 
 \item{...}{Optional arguments; currently unused.}
 }


### PR DESCRIPTION
Currently, getting the vocabulary from ft_count_vectorizer is hard, now we can:

```r
library(janeaustenr)
library(sparklyr)
library(dplyr)

sc <- spark_connect(master = "local")

austen_books <- austen_books()
books_tbl <- sdf_copy_to(sc, austen_books, overwrite = TRUE)
first_tbl <- books_tbl %>% filter(nchar(text) > 0) %>% head(2)

first_tbl %>%
  ft_tokenizer("text", "tokens") %>%
  ft_count_vectorizer("tokens", "features", vocabulary.only = TRUE) %>%
  paste(collapse = ",")
```

```
[1] "jane,sense,austen,by,sensibility,and"
```

Followed by the usual:

```r
first_tbl %>%
  ft_tokenizer("text", "tokens") %>%
  ft_count_vectorizer("tokens", "features") %>%
  ml_lda("features", k = 4)
```

```
Topics Matrix:
          [,1]      [,2]      [,3]      [,4]
[1,] 0.8996952 0.8569472 1.1249431 0.9366354
[2,] 0.9815788 1.1721218 1.0795771 0.9990090
[3,] 1.1738678 0.8600233 0.9864862 0.9573433
[4,] 0.8951603 1.0730703 0.9562389 0.8899160
[5,] 1.0528748 1.0291708 1.0699833 0.8731401
[6,] 1.1857015 1.0441299 1.0987713 1.1247573

Estimated Document Concentration:
[1] 13.52071 13.52172 13.52060 13.51963
```