### PR TITLE
enhancements for ml_random_forest()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # Sparklyr 0.6.1 (UNRELEASED)
 
 - Added to `ml_random_forest()` the following hyperparameter arguments:
-  `min.info.gain`, `col.sample.rate`, `min.rows`, `impurity`, and `thresholds`.
+  `min.info.gain`, `col.sample.rate`, `min.rows`, `impurity`, and `thresholds`. Also added `seed` for reproducibility.
 
 - Added support for Spark 1.6.3 under `spark_install()`
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.6.1 (UNRELEASED)
 
+- Added to `ml_random_forest()` the following hyperparameter arguments:
+  `min.info.gain`, `col.sample.rate`, `min.rows`, `impurity`, and `thresholds`.
+
 - Added support for Spark 1.6.3 under `spark_install()`
 
 - `spark_apply()` now logs the current callstack when it fails.

--- a/R/ml_random_forest.R
+++ b/R/ml_random_forest.R
@@ -64,6 +64,7 @@ ml_random_forest <- function(x,
         # Prior to Spark 2.0.0, random forest does not support arbitrary
         #   column sampling rates. So we map the input to one of the supported
         #   strategies: "onethird", "sqrt", or "log2".
+        k <- length(features)
         strategies <- dplyr::data_frame(strategy = c("onethird", "sqrt", "log2"),
                                         rate = c(1/3, sqrt(k)/k, log2(k)/k)) %>%
           arrange(!! rlang::sym("rate"))

--- a/R/ml_random_forest.R
+++ b/R/ml_random_forest.R
@@ -12,6 +12,7 @@
 #' @template roxlate-ml-decision-trees-min-info-gain
 #' @template roxlate-ml-decision-trees-min-rows
 #' @template roxlate-ml-decision-trees-num-trees
+#' @template roxlate-ml-decision-trees-thresholds
 #' @template roxlate-ml-decision-trees-type
 #' @template roxlate-ml-options
 #' @template roxlate-ml-dots
@@ -29,6 +30,7 @@ ml_random_forest <- function(x,
                              min.info.gain = 0,
                              min.rows = 1L,
                              num.trees = 20L,
+                             thresholds = NULL,
                              type = c("auto", "regression", "classification"),
                              ml.options = ml_options(),
                              ...)
@@ -65,6 +67,7 @@ ml_random_forest <- function(x,
   num.trees <- ensure_scalar_integer(num.trees)
   type <- match.arg(type)
   only.model <- ensure_scalar_boolean(ml.options$only.model)
+  thresholds <- if (!is.null(thresholds)) lapply(thresholds, ensure_scalar_double)
 
   envir <- new.env(parent = emptyenv())
 
@@ -115,6 +118,9 @@ ml_random_forest <- function(x,
     invoke("setMinInstancesPerNode", min.rows) %>%
     invoke("setNumTrees", num.trees)
 
+  if (!is.null(thresholds))
+    model <- invoke(model, "setThresholds", thresholds)
+
   if (is.function(ml.options$model.transform))
     model <- ml.options$model.transform(model)
 
@@ -138,6 +144,7 @@ ml_random_forest <- function(x,
            min.info.gain = min.info.gain,
            min.rows = min.rows,
            num.trees = num.trees,
+           thresholds = unlist(thresholds),
            feature.importances = featureImportances,
            trees = invoke(fit, "trees"),
            data = df,

--- a/R/ml_random_forest.R
+++ b/R/ml_random_forest.R
@@ -7,6 +7,7 @@
 #' @template roxlate-ml-features
 #' @template roxlate-ml-decision-trees-max-bins
 #' @template roxlate-ml-decision-trees-max-depth
+#' @template roxlate-ml-decision-trees-min-info-gain
 #' @template roxlate-ml-decision-trees-num-trees
 #' @template roxlate-ml-decision-trees-type
 #' @template roxlate-ml-options
@@ -20,6 +21,7 @@ ml_random_forest <- function(x,
                              features,
                              max.bins = 32L,
                              max.depth = 5L,
+                             min.info.gain = 0,
                              num.trees = 20L,
                              type = c("auto", "regression", "classification"),
                              ml.options = ml_options(),
@@ -43,6 +45,7 @@ ml_random_forest <- function(x,
 
   max.bins <- ensure_scalar_integer(max.bins)
   max.depth <- ensure_scalar_integer(max.depth)
+  min.info.gain <- ensure_scalar_double(min.info.gain)
   num.trees <- ensure_scalar_integer(num.trees)
   type <- match.arg(type)
   only.model <- ensure_scalar_boolean(ml.options$only.model)
@@ -76,6 +79,7 @@ ml_random_forest <- function(x,
     invoke("setLabelCol", envir$response) %>%
     invoke("setMaxBins", max.bins) %>%
     invoke("setMaxDepth", max.depth) %>%
+    invoke("setMinInfoGain", min.info.gain) %>%
     invoke("setNumTrees", num.trees)
 
   if (is.function(ml.options$model.transform))
@@ -96,6 +100,7 @@ ml_random_forest <- function(x,
            response = response,
            max.bins = max.bins,
            max.depth = max.depth,
+           min.info.gain = min.info.gain,
            num.trees = num.trees,
            feature.importances = featureImportances,
            trees = invoke(fit, "trees"),

--- a/R/ml_random_forest.R
+++ b/R/ml_random_forest.R
@@ -14,6 +14,7 @@
 #' @template roxlate-ml-decision-trees-num-trees
 #' @template roxlate-ml-decision-trees-thresholds
 #' @template roxlate-ml-decision-trees-type
+#' @template roxlate-ml-decision-trees-seed
 #' @template roxlate-ml-options
 #' @template roxlate-ml-dots
 #'
@@ -31,6 +32,7 @@ ml_random_forest <- function(x,
                              min.rows = 1L,
                              num.trees = 20L,
                              thresholds = NULL,
+                             seed = NULL,
                              type = c("auto", "regression", "classification"),
                              ml.options = ml_options(),
                              ...)
@@ -68,6 +70,7 @@ ml_random_forest <- function(x,
   type <- match.arg(type)
   only.model <- ensure_scalar_boolean(ml.options$only.model)
   thresholds <- if (!is.null(thresholds)) lapply(thresholds, ensure_scalar_double)
+  seed <- ensure_scalar_integer(seed, allow.null = TRUE)
 
   envir <- new.env(parent = emptyenv())
 
@@ -121,6 +124,9 @@ ml_random_forest <- function(x,
   if (!is.null(thresholds))
     model <- invoke(model, "setThresholds", thresholds)
 
+  if (!is.null(seed))
+    model <- invoke(model, "setSeed", seed)
+
   if (is.function(ml.options$model.transform))
     model <- ml.options$model.transform(model)
 
@@ -145,6 +151,7 @@ ml_random_forest <- function(x,
            min.rows = min.rows,
            num.trees = num.trees,
            thresholds = unlist(thresholds),
+           seed = seed,
            feature.importances = featureImportances,
            trees = invoke(fit, "trees"),
            data = df,

--- a/man-roxygen/roxlate-ml-decision-trees-col-sample-rate.R
+++ b/man-roxygen/roxlate-ml-decision-trees-col-sample-rate.R
@@ -1,0 +1,2 @@
+#' @param col.sample.rate The sampling rate of features to consider for splits at each tree node.
+#'  Defaults to 1/3 for regression and sqrt(k)/k for classification where k is number of features.

--- a/man-roxygen/roxlate-ml-decision-trees-col-sample-rate.R
+++ b/man-roxygen/roxlate-ml-decision-trees-col-sample-rate.R
@@ -1,2 +1,4 @@
 #' @param col.sample.rate The sampling rate of features to consider for splits at each tree node.
 #'  Defaults to 1/3 for regression and sqrt(k)/k for classification where k is number of features.
+#'  For Spark versions prior to 2.0.0, arbitrary sampling rates are not supported, so the input is
+#'  automatically mapped to one of "onethird", "sqrt", or "log2".

--- a/man-roxygen/roxlate-ml-decision-trees-impurity.R
+++ b/man-roxygen/roxlate-ml-decision-trees-impurity.R
@@ -1,0 +1,3 @@
+#' @param impurity Criterion used for information gain calculation
+#'   One of 'auto', 'gini', 'entropy', or 'variance'. 'auto' defaults to
+#'   'gini' for classification and 'variance' for regression.

--- a/man-roxygen/roxlate-ml-decision-trees-min-info-gain.R
+++ b/man-roxygen/roxlate-ml-decision-trees-min-info-gain.R
@@ -1,0 +1,1 @@
+#' @param min.info.gain Minimum information gain for a split to be considered at a tree node. Should be >= 0, defaults to 0.

--- a/man-roxygen/roxlate-ml-decision-trees-min-rows.R
+++ b/man-roxygen/roxlate-ml-decision-trees-min-rows.R
@@ -1,0 +1,1 @@
+#' @param min.rows Minimum number of instances each child must have after split.

--- a/man-roxygen/roxlate-ml-decision-trees-seed.R
+++ b/man-roxygen/roxlate-ml-decision-trees-seed.R
@@ -1,0 +1,1 @@
+#' @param seed Seed for random numbers.

--- a/man-roxygen/roxlate-ml-decision-trees-thresholds.R
+++ b/man-roxygen/roxlate-ml-decision-trees-thresholds.R
@@ -1,0 +1,5 @@
+#' @param thresholds Thresholds in multi-class classification to adjust
+#' the probability of predicting each class. Vector must have length equal
+#' to the number of classes, with values > 0 excepting that at most one
+#' value may be 0. The class with largest value p/t is predicted, where p
+#' is the original probability of that class and t is the class's threshold.

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -5,8 +5,8 @@
 \title{Spark ML -- Random Forests}
 \usage{
 ml_random_forest(x, response, features, max.bins = 32L, max.depth = 5L,
-  num.trees = 20L, type = c("auto", "regression", "classification"),
-  ml.options = ml_options(), ...)
+  min.info.gain = 0, num.trees = 20L, type = c("auto", "regression",
+  "classification"), ml.options = ml_options(), ...)
 }
 \arguments{
 \item{x}{An object coercable to a Spark DataFrame (typically, a
@@ -28,6 +28,8 @@ each node. More bins give higher granularity.}
 
 \item{max.depth}{Maximum depth of the tree (>= 0); that is, the maximum
 number of nodes separating any leaves from the root of the tree.}
+
+\item{min.info.gain}{Minimum information gain for a split to be considered at a tree node. Should be >= 0, defaults to 0.}
 
 \item{num.trees}{Number of trees to train (>= 1).}
 

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -7,8 +7,8 @@
 ml_random_forest(x, response, features, col.sample.rate = NULL,
   impurity = c("auto", "gini", "entropy", "variance"), max.bins = 32L,
   max.depth = 5L, min.info.gain = 0, min.rows = 1L, num.trees = 20L,
-  thresholds = NULL, type = c("auto", "regression", "classification"),
-  ml.options = ml_options(), ...)
+  thresholds = NULL, seed = NULL, type = c("auto", "regression",
+  "classification"), ml.options = ml_options(), ...)
 }
 \arguments{
 \item{x}{An object coercable to a Spark DataFrame (typically, a
@@ -49,6 +49,8 @@ the probability of predicting each class. Vector must have length equal
 to the number of classes, with values > 0 excepting that at most one
 value may be 0. The class with largest value p/t is predicted, where p
 is the original probability of that class and t is the class's threshold.}
+
+\item{seed}{Seed for random numbers.}
 
 \item{type}{The type of model to fit. \code{"regression"} treats the response
 as a continuous variable, while \code{"classification"} treats the response

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -7,7 +7,7 @@
 ml_random_forest(x, response, features, col.sample.rate = NULL,
   impurity = c("auto", "gini", "entropy", "variance"), max.bins = 32L,
   max.depth = 5L, min.info.gain = 0, min.rows = 1L, num.trees = 20L,
-  type = c("auto", "regression", "classification"),
+  thresholds = NULL, type = c("auto", "regression", "classification"),
   ml.options = ml_options(), ...)
 }
 \arguments{
@@ -43,6 +43,12 @@ number of nodes separating any leaves from the root of the tree.}
 \item{min.rows}{Minimum number of instances each child must have after split.}
 
 \item{num.trees}{Number of trees to train (>= 1).}
+
+\item{thresholds}{Thresholds in multi-class classification to adjust
+the probability of predicting each class. Vector must have length equal
+to the number of classes, with values > 0 excepting that at most one
+value may be 0. The class with largest value p/t is predicted, where p
+is the original probability of that class and t is the class's threshold.}
 
 \item{type}{The type of model to fit. \code{"regression"} treats the response
 as a continuous variable, while \code{"classification"} treats the response

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -25,7 +25,9 @@ The intercept term can be omitted by using \code{- 1} in the model fit.}
 \item{features}{The name of features (terms) to use for the model fit.}
 
 \item{col.sample.rate}{The sampling rate of features to consider for splits at each tree node.
-Defaults to 1/3 for regression and sqrt(k)/k for classification where k is number of features.}
+Defaults to 1/3 for regression and sqrt(k)/k for classification where k is number of features.
+For Spark versions prior to 2.0.0, arbitrary sampling rates are not supported, so the input is
+automatically mapped to one of "onethird", "sqrt", or "log2".}
 
 \item{impurity}{Criterion used for information gain calculation
 One of 'auto', 'gini', 'entropy', or 'variance'. 'auto' defaults to

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -5,8 +5,9 @@
 \title{Spark ML -- Random Forests}
 \usage{
 ml_random_forest(x, response, features, col.sample.rate = NULL,
-  max.bins = 32L, max.depth = 5L, min.info.gain = 0, min.rows = 1L,
-  num.trees = 20L, type = c("auto", "regression", "classification"),
+  impurity = c("auto", "gini", "entropy", "variance"), max.bins = 32L,
+  max.depth = 5L, min.info.gain = 0, min.rows = 1L, num.trees = 20L,
+  type = c("auto", "regression", "classification"),
   ml.options = ml_options(), ...)
 }
 \arguments{
@@ -25,6 +26,10 @@ The intercept term can be omitted by using \code{- 1} in the model fit.}
 
 \item{col.sample.rate}{The sampling rate of features to consider for splits at each tree node.
 Defaults to 1/3 for regression and sqrt(k)/k for classification where k is number of features.}
+
+\item{impurity}{Criterion used for information gain calculation
+One of 'auto', 'gini', 'entropy', or 'variance'. 'auto' defaults to
+'gini' for classification and 'variance' for regression.}
 
 \item{max.bins}{The maximum number of bins used for discretizing
 continuous features and for choosing how to split on features at

--- a/man/ml_random_forest.Rd
+++ b/man/ml_random_forest.Rd
@@ -4,9 +4,10 @@
 \alias{ml_random_forest}
 \title{Spark ML -- Random Forests}
 \usage{
-ml_random_forest(x, response, features, max.bins = 32L, max.depth = 5L,
-  min.info.gain = 0, num.trees = 20L, type = c("auto", "regression",
-  "classification"), ml.options = ml_options(), ...)
+ml_random_forest(x, response, features, col.sample.rate = NULL,
+  max.bins = 32L, max.depth = 5L, min.info.gain = 0, min.rows = 1L,
+  num.trees = 20L, type = c("auto", "regression", "classification"),
+  ml.options = ml_options(), ...)
 }
 \arguments{
 \item{x}{An object coercable to a Spark DataFrame (typically, a
@@ -22,6 +23,9 @@ The intercept term can be omitted by using \code{- 1} in the model fit.}
 
 \item{features}{The name of features (terms) to use for the model fit.}
 
+\item{col.sample.rate}{The sampling rate of features to consider for splits at each tree node.
+Defaults to 1/3 for regression and sqrt(k)/k for classification where k is number of features.}
+
 \item{max.bins}{The maximum number of bins used for discretizing
 continuous features and for choosing how to split on features at
 each node. More bins give higher granularity.}
@@ -30,6 +34,8 @@ each node. More bins give higher granularity.}
 number of nodes separating any leaves from the root of the tree.}
 
 \item{min.info.gain}{Minimum information gain for a split to be considered at a tree node. Should be >= 0, defaults to 0.}
+
+\item{min.rows}{Minimum number of instances each child must have after split.}
 
 \item{num.trees}{Number of trees to train (>= 1).}
 

--- a/tests/testthat/test-ml-random-forest.R
+++ b/tests/testthat/test-ml-random-forest.R
@@ -1,0 +1,64 @@
+context("random forest")
+sc <- testthat_spark_connection()
+
+iris_tbl <- testthat_tbl("iris")
+
+test_that("thresholds parameter behaves as expected", {
+  most_predicted_label <- function(x) x %>%
+    count(prediction) %>%
+    arrange(desc(n)) %>%
+    pull(prediction) %>%
+    first()
+
+  rf_predictions <- iris_tbl %>%
+    ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                     thresholds = c(0, 1, 1)) %>%
+    sdf_predict(iris_tbl)
+  expect_equal(most_predicted_label(rf_predictions), 0)
+
+  rf_predictions <- iris_tbl %>%
+    ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                     thresholds = c(1, 0, 1)) %>%
+    sdf_predict(iris_tbl)
+  expect_equal(most_predicted_label(rf_predictions), 1)
+
+  rf_predictions <- iris_tbl %>%
+    ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                     thresholds = c(1, 1, 0)) %>%
+    sdf_predict(iris_tbl)
+  expect_equal(most_predicted_label(rf_predictions), 2)
+})
+
+test_that("error for thresholds with wrong length", {
+  expect_error(
+    iris_tbl %>%
+      ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                       thresholds = c(0, 1)),
+    "non-matching numClasses and thresholds.length"
+  )
+})
+
+test_that("error for col.sample.rate value out of range", {
+  expect_error(
+    iris_tbl %>%
+      ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                       col.sample.rate = 1.01),
+    "'col.sample.rate' must be in \\(0, 1]"
+  )
+})
+
+test_that("error for bad impurity specification", {
+  expect_error(
+    iris_tbl %>%
+      ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                       impurity = "variance"),
+    "'impurity' must be 'gini' or 'entropy' for classification"
+  )
+
+  expect_error(
+    iris_tbl %>%
+      ml_random_forest(Sepal_Length ~ Sepal_Width, type = "regression",
+                       impurity = "gini"),
+    "'impurity' must be 'variance' for regression"
+  )
+})

--- a/tests/testthat/test-ml-random-forest.R
+++ b/tests/testthat/test-ml-random-forest.R
@@ -14,6 +14,23 @@ test_that("rf runs successfully when all args specified", {
   )
 })
 
+test_that("col.sample.rate maps to correct strategy", {
+  if (spark_version(sc) >= "2.0.0") skip("not applicable to 2.0+")
+  expect_message(
+    iris_tbl %>%
+      ml_random_forest(Species ~ Sepal_Width + Sepal_Length + Petal_Width, type = "classification",
+                       col.sample.rate = 1/3),
+    "Using feature subsetting strategy: onethird"
+  )
+
+  expect_message(
+    iris_tbl %>%
+      ml_random_forest(Species ~ Sepal_Width + Sepal_Length + Petal_Width, type = "classification",
+                       col.sample.rate = 0.001),
+    "Using feature subsetting strategy: log2"
+  )
+})
+
 test_that("thresholds parameter behaves as expected", {
   most_predicted_label <- function(x) x %>%
     count(prediction) %>%
@@ -41,6 +58,7 @@ test_that("thresholds parameter behaves as expected", {
 })
 
 test_that("error for thresholds with wrong length", {
+  if (spark_version(sc) < "2.1.0") skip("threshold length checking implemented in 2.1.0")
   expect_error(
     iris_tbl %>%
       ml_random_forest(Species ~ Sepal_Width, type = "classification",

--- a/tests/testthat/test-ml-random-forest.R
+++ b/tests/testthat/test-ml-random-forest.R
@@ -62,3 +62,21 @@ test_that("error for bad impurity specification", {
     "'impurity' must be 'variance' for regression"
   )
 })
+
+test_that("random seed setting works", {
+  model_string <- function(x) x$.model %>%
+    invoke("toDebugString") %>%
+    strsplit("\n") %>%
+    unlist() %>%
+    tail(-1)
+
+  m1 <- iris_tbl %>%
+    ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                     seed = 42L)
+
+  m2 <- iris_tbl %>%
+    ml_random_forest(Species ~ Sepal_Width, type = "classification",
+                     seed = 42L)
+
+  expect_equal(model_string(m1), model_string(m2))
+})

--- a/tests/testthat/test-ml-random-forest.R
+++ b/tests/testthat/test-ml-random-forest.R
@@ -3,6 +3,17 @@ sc <- testthat_spark_connection()
 
 iris_tbl <- testthat_tbl("iris")
 
+test_that("rf runs successfully when all args specified", {
+  expect_error(
+    iris_tbl %>%
+      ml_random_forest(Species ~ Sepal_Width + Sepal_Length + Petal_Width, type = "classification",
+                       col.sample.rate = 1/3, impurity = "entropy", max.bins = 16L,
+                       max.depth = 3L, min.info.gain = 1e-5, min.rows = 2L,
+                       num.trees = 25L, thresholds = c(1/2, 1/3, 1/4), seed = 42L),
+    NA
+  )
+})
+
 test_that("thresholds parameter behaves as expected", {
   most_predicted_label <- function(x) x %>%
     count(prediction) %>%


### PR DESCRIPTION
This PR adds the following tuning arguments to `ml_random_forest()`:

- `col.sample.rate`: Column sampling rate at each split (*not* per tree.) Spark ML calls this `featureSubsetStrategy` and requires a *string* input, e.g. "onethird", "sqrt", or "n", with `"when n is in the range (0, 1.0], use n * number of features. When n is in the range (1, number of features), use n features"`... which I think is really confusing. In this PR I'm requiring a *double* between 0 and 1. `NULL` defaults to the Spark ML `auto` strategy which equates to `sqrt(k)/k` for classification and `1/3` for regression, where `k` is number of features.

- `impurity`: The measure for info gain calculation at each split. Spark ML supports one of "gini" and "entropy" for classification (defaults to gini) and "variance" for regression. Input validation is included in our implementation.

- `min.info.gain`: Info gain required to split. This is an absolute number and not relative improvement.

- `min.rows`: Minimum number of observations each node must have after split. Spark ML calls this `minInstancesPerNode`, h2o calls this `min_rows` and R randomForest calls it `nodesize`. I like h2o's choice here.

- `thresholds`: This is used in multiclass classification to introduce bias to the predictions. Basically users can pass a vector of numbers (t_1, t_2, ..., t_K) where K is the number of classes, and the probabilities will be adjusted to be (p_1/t_1, p_2/t_2, ..., p_K/t_K), where the p_i's are the raw probabilities. The predicted label would be the one with highest adjusted probability.

- `seed`: Used for column and row sampling.