### PR TITLE
Add support for `yarn-cluster` with high availability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9018
+Version: 0.7.0-9019
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added support in `spark_connect()` for `yarn-cluster` with
+  hight-availability enabled.
+  
 - Added support for `spark_connect()` with `master="yarn-cluster"`
   to query YARN resource manager API and retrieve the correct
   container host name.

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -92,8 +92,9 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
     mainRMWebapp <- NULL
     for (rmId in rmHighAvailabilityIds) {
       rmCandidate <- paste0("yarn.resourcemanager.webapp.address.", rmId)
+      rmCandidateValue <- spark_yarn_cluster_get_conf_property(rmCandidate)
 
-      if (spark_yarn_cluster_resource_manager_is_online(rmCandidate)) {
+      if (spark_yarn_cluster_resource_manager_is_online(rmCandidateValue)) {
         mainRMWebapp <- rmCandidate
         break;
       }

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -61,8 +61,25 @@ spark_yarn_cluster_get_app_property <- function(config, start_time, rm_webapp, p
   propertyValue
 }
 
+spark_yarn_cluster_get_resource_manager_webapp() {
+  rmHighAvailabilityId <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.ha.id")
+
+  mainRMWebapp <- "yarn.resourcemanager.webapp.address"
+  if (length(rmHighAvailabilityId) > 0) {
+    mainRMWebapp <- paste(
+      "yarn.resourcemanager.webapp.address.",
+      resourceManagerHighAvailabilityId,
+      sep = ""
+    )
+  }
+
+  mainRMWebapp <- spark_yarn_cluster_get_conf_property(mainRMWebapp)
+
+  mainRMWebapp
+}
+
 spark_yarn_cluster_get_gateway <- function(config, start_time) {
-  resourceManagerWebapp <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.webapp.address")
+  resourceManagerWebapp <- spark_yarn_cluster_get_resource_manager_webapp()
 
   if (length(resourceManagerWebapp) == 0) {
     stop("Yarn Cluster mode uses `yarn.resourcemanager.webapp.address` but is not present in yarn-site.xml")

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -86,7 +86,7 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
 
     rmHighAvailabilityIds <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.ha.rm-ids")
     rmHighAvailabilityIds <- strsplit(rmHighAvailabilityIds, ",")[[1]]
-    rmHighAvailabilityIds <- resourceManagerHighAvailabilityIds[rmHighAvailabilityIds != rmHighAvailabilityId]
+    rmHighAvailabilityIds <- rmHighAvailabilityIds[rmHighAvailabilityIds != rmHighAvailabilityId]
     rmHighAvailabilityIds <- c(rmHighAvailabilityId, rmHighAvailabilityIds)
 
     mainRMWebapp <- NULL

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -62,10 +62,12 @@ spark_yarn_cluster_get_app_property <- function(config, start_time, rm_webapp, p
 }
 
 spark_yarn_cluster_get_resource_manager_webapp() {
-  rmHighAvailabilityId <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.ha.id")
+  rmHighAvailability <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.ha.enabled")
+  rmHighAvailability <- length(rmHighAvailability) > 0 && grepl("TRUE", rmHighAvailability, ignore.case = TRUE)
 
   mainRMWebapp <- "yarn.resourcemanager.webapp.address"
-  if (length(rmHighAvailabilityId) > 0) {
+  if (rmHighAvailability) {
+    rmHighAvailabilityId <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.ha.id")
     mainRMWebapp <- paste(
       "yarn.resourcemanager.webapp.address.",
       resourceManagerHighAvailabilityId,

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -106,11 +106,11 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
 
   mainRMWebappValue <- spark_yarn_cluster_get_conf_property(mainRMWebapp)
 
-  if (is.null(mainRMWebapp)) {
+  if (is.null(mainRMWebappValue)) {
     stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
   }
 
-  mainRMWebapp
+  mainRMWebappValue
 }
 
 spark_yarn_cluster_get_gateway <- function(config, start_time) {


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/903, add support for `yarn-cluster` in high availability configurations.

When a cluster is configured for HA, it may list multiple resource managers instead, the main one is tracked by `yarn.resourcemanager.ha.id` which can then be used to retrieve the actual address with `yarn.resourcemanager.address.<haid>`.

See also: https://www.cloudera.com/documentation/enterprise/5-4-x/topics/cdh_hag_rm_ha_config.html#concept_skx_n1z_vl__table_lbx_g21_wl

Tested a couple scenarios:
1. Basic non-HA in `yarn-cluster`
2. HA with no fallback, main resource manager response and is used.
3. HA with fallback, main resource manager fails to respone.

For reference, config files for (2) and (3) follow:

HA with no fallback:

```xml
<?xml version="1.0" encoding="UTF-8"?>

<!--Autogenerated by Cloudera Manager-->
<configuration>
  <property>
    <name>yarn.acl.enable</name>
    <value>true</value>
  </property>
  <property>
    <name>yarn.admin.acl</name>
    <value>*</value>
  </property>
  <!-- HA Start-->
  <property>
    <name>yarn.resourcemanager.ha.enabled</name>
    <value>true</value>
  </property>
  <property>
    <name>yarn.resourcemanager.ha.rm-ids</name>
    <value>rm1,rm2</value>
  </property>
  <property>
    <name>yarn.resourcemanager.ha.id</name>
    <value>rm1</value>
  </property>
  <!-- HA End -->
  <!-- RM1 Start -->
  <property>
    <name>yarn.resourcemanager.address.rm1</name>
    <value>ip-172-30-1-13.us-west-2.compute.internal:8032</value>
  </property>
  <property>
    <name>yarn.resourcemanager.admin.address.rm1</name>
    <value>ip-172-30-1-13.us-west-2.compute.internal:8033</value>
  </property>
  <property>
    <name>yarn.resourcemanager.scheduler.address.rm1</name>
    <value>ip-172-30-1-13.us-west-2.compute.internal:8030</value>
  </property>
  <property>
    <name>yarn.resourcemanager.resource-tracker.address.rm1</name>
    <value>ip-172-30-1-13.us-west-2.compute.internal:8031</value>
  </property>
  <property>
    <name>yarn.resourcemanager.webapp.address.rm1</name>
    <value>ip-172-30-1-13.us-west-2.compute.internal:8088</value>
  </property>
  <property>
    <name>yarn.resourcemanager.webapp.https.address.rm1</name>
    <value>ip-172-30-1-13.us-west-2.compute.internal:8090</value>
  </property>
  <!-- RM1 End -->
  <!-- RM2 Start -->
  <property>
    <name>yarn.resourcemanager.address.rm2</name>
    <value>bad-ip-172-30-1-13.us-west-2.compute.internal:8032</value>
  </property>
  <property>
    <name>yarn.resourcemanager.admin.address.rm2</name>
    <value>bad-ip-172-30-1-13.us-west-2.compute.internal:8033</value>
  </property>
  <property>
    <name>yarn.resourcemanager.scheduler.address.rm2</name>
    <value>bad-ip-172-30-1-13.us-west-2.compute.internal:8030</value>
  </property>
  <property>
    <name>yarn.resourcemanager.resource-tracker.address.rm1</name>
    <value>bad-ip-172-30-1-13.us-west-2.compute.internal:8031</value>
  </property>
  <property>
    <name>yarn.resourcemanager.webapp.address.rm2</name>
    <value>bad-ip-172-30-1-13.us-west-2.compute.internal:8088</value>
  </property>
  <property>
    <name>yarn.resourcemanager.webapp.https.address.rm2</name>
    <value>bad-ip-172-30-1-13.us-west-2.compute.internal:8090</value>
  </property>
  <!-- RM2 End -->
  <property>
    <name>yarn.resourcemanager.client.thread-count</name>
    <value>50</value>
  </property>
  <property>
    <name>yarn.resourcemanager.scheduler.client.thread-count</name>
    <value>50</value>
  </property>
  <property>
    <name>yarn.resourcemanager.admin.client.thread-count</name>
    <value>1</value>
  </property>
  <property>
    <name>yarn.scheduler.minimum-allocation-mb</name>
    <value>1024</value>
  </property>
  <property>
    <name>yarn.scheduler.increment-allocation-mb</name>
    <value>512</value>
  </property>
  <property>
    <name>yarn.scheduler.maximum-allocation-mb</name>
    <value>65536</value>
  </property>
  <property>
    <name>yarn.scheduler.minimum-allocation-vcores</name>
    <value>1</value>
  </property>
  <property>
    <name>yarn.scheduler.increment-allocation-vcores</name>
    <value>1</value>
  </property>
  <property>
    <name>yarn.scheduler.maximum-allocation-vcores</name>
    <value>32</value>
  </property>
  <property>
    <name>yarn.resourcemanager.amliveliness-monitor.interval-ms</name>
    <value>1000</value>
  </property>
  <property>
    <name>yarn.am.liveness-monitor.expiry-interval-ms</name>
    <value>600000</value>
  </property>
  <property>
    <name>yarn.resourcemanager.am.max-attempts</name>
    <value>2</value>
  </property>
  <property>
    <name>yarn.resourcemanager.container.liveness-monitor.interval-ms</name>
    <value>600000</value>
  </property>
  <property>
    <name>yarn.resourcemanager.nm.liveness-monitor.interval-ms</name>
    <value>1000</value>
  </property>
  <property>
    <name>yarn.nm.liveness-monitor.expiry-interval-ms</name>
    <value>600000</value>
  </property>
  <property>
    <name>yarn.resourcemanager.resource-tracker.client.thread-count</name>
    <value>50</value>
  </property>
  <property>
    <name>yarn.application.classpath</name>
    <value>$HADOOP_CLIENT_CONF_DIR,$HADOOP_CONF_DIR,$HADOOP_COMMON_HOME/*,$HADOOP_COMMON_HOME/lib/*,$HADOOP_HDFS_HOME/*,$HADOOP_HDFS_HOME/lib/*,$HADOOP_YARN_HOME/*,$HADOOP_YARN_HOME/lib/*</value>
  </property>
  <property>
    <name>yarn.resourcemanager.scheduler.class</name>
    <value>org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FairScheduler</value>
  </property>
  <property>
    <name>yarn.resourcemanager.max-completed-applications</name>
    <value>10000</value>
  </property>
  <property>
    <name>yarn.nodemanager.remote-app-log-dir</name>
    <value>/tmp/logs</value>
  </property>
  <property>
    <name>yarn.nodemanager.remote-app-log-dir-suffix</name>
    <value>logs</value>
  </property>
</configuration>
```

(3) is same as (2) but changing:

```xml
  <property>
    <name>yarn.resourcemanager.ha.id</name>
    <value>rm2</value>
  </property>
```