### PR TITLE
`compute()` to trigger refresh in the connection viewer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.7 (UNRELEASE)
 
+- Fix `compute()` to trigger refresh of the connections view.
+
 - Added to `ml_random_forest()` the following hyperparameter arguments:
   `min.info.gain`, `col.sample.rate`, `min.rows`, `impurity`, and `thresholds`. Also added `seed` for reproducibility.
 

--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -125,7 +125,7 @@ print.src_spark <- function(x, ...) {
 db_save_query.spark_connection <- function(con, sql, name, temporary = TRUE, ...)
 {
   df <- spark_dataframe(con, sql)
-  invoke(df, "registerTempTable", name)
+  sdf_register(df, name)
 
   # compute() is expected to preserve the query, cache as the closest mapping.
   if (!sparklyr_boolean_option("sparklyr.dplyr.compute.nocache"))


### PR DESCRIPTION
Triggering `compute()` does not cause a refresh in the connections viewer.