### PR TITLE
correct github link

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -46,7 +46,7 @@ navbar:
           href: news/index.html
   right:
    - icon: fa-github
-     href: https://github.com/rstudio/reticulate
+     href: https://github.com/rstudio/sparklyr
 
 reference:
   - title: "Spark Operations"


### PR DESCRIPTION
The github link was pointing to `reticulate` doc site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/sparklyr/910)
<!-- Reviewable:end -->
