### PR TITLE
Better error for `sample_n()` and `sample_frac()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9003
+Version: 0.7.0-9004
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added unsupported error message to `sample_n()` and `sample_frac()`
+  when Spark is not 2.0 or higher.
+
 - Fixed `SIGPIPE` error under `spark_connect()` immediately after
   a `spark_disconnect()` operation.
 

--- a/R/dplyr_spark_table.R
+++ b/R/dplyr_spark_table.R
@@ -12,6 +12,9 @@ sample_n.tbl_spark <- function(tbl,
                                replace = FALSE,
                                weight = NULL,
                                .env = parent.frame()) {
+  if (spark_version(spark_connection(tbl)) < "2.0.0")
+      stop("sample_n() is not supported until Spark 2.0 or later")
+
   add_op_single("sample_n", .data = tbl, args = list(
     size = size,
     replace = replace,
@@ -28,6 +31,9 @@ sample_frac.tbl_spark <- function(tbl,
                                   replace = FALSE,
                                   weight = NULL,
                                   .env = parent.frame()) {
+  if (spark_version(spark_connection(tbl)) < "2.0.0")
+    stop("sample_frac() is not supported until Spark 2.0 or later")
+
   add_op_single("sample_frac", .data = tbl, args = list(
     size = size,
     replace = replace,


### PR DESCRIPTION
We attempted to implement workaround for `sample_n()` and `sample_frac()` in `sparklyr 0.5` but performance was not great, improved on `0.6` for Spark 2.0 but a better error is missing for now unsupported command in Spark 1.6. See https://github.com/rstudio/sparklyr/issues/917