### PR TITLE
allow numeric `n` in `lead()` for dplyr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added support for numeric arguments for `n` in `lead()` for dplyr.
+
 - Added unsupported error message to `sample_n()` and `sample_frac()`
   when Spark is not 2.0 or higher.
 

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -115,6 +115,14 @@ sql_translate_env.spark_connection <- function(con) {
           order = order
         )
       },
+      lead = function(x, n = 1L, default = NA, order = NULL) {
+        dbplyr::base_win$lead(
+          x = x,
+          n = as.integer(n),
+          default = default,
+          order = order
+        )
+      },
       count = function() dbplyr::win_over(
         dbplyr::sql("count(*)"),
         partition = dbplyr::win_current_group()

--- a/tests/testthat/test-dplyr-lead-lag.R
+++ b/tests/testthat/test-dplyr-lead-lag.R
@@ -1,0 +1,24 @@
+context("lag & lead")
+
+sc <- testthat_spark_connection()
+
+test_that("lead and lag take numeric values for 'n' (#925)", {
+  test_requires("dplyr")
+  example_df <- data_frame(ID = 1:10, Cat = rep(letters[1:5], 2),
+                          Numb = c(3, 10, NA, 5, 1, 6, NA, 4, NA, 8))
+  example_df_tbl <- copy_to(sc, example_df, overwrite = TRUE)
+
+  expect_equal(
+    example_df_tbl %>%
+      arrange(ID) %>%
+      mutate(Numb1 = lag(Numb, 1)) %>%
+      mutate(Numb2 = lead(Cat, 1)) %>%
+      collect() %>%
+      lapply(function(x) ifelse(is.nan(x), NA, x)) %>%
+      as_data_frame(),
+    example_df %>%
+      arrange(ID) %>%
+      mutate(Numb1 = lag(Numb, 1)) %>%
+      mutate(Numb2 = lead(Cat, 1))
+  )
+})


### PR DESCRIPTION
Fixes #925 

Had to hack the test a bit due to serialization issues with `NA`.