### PR TITLE
Improve errors for `metric` under `ml_classification_eval()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9008
+Version: 0.7.0-9009
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Improved documentation and error cases for `metric` argument in
+  `ml_classification_eval()` and `ml_binary_classification_eval()`.
+
 - Fix to `spark_install()` to use the `/logs` subfolder to store local
   `log4j` logs.
 

--- a/R/ml_classification_evaluators.R
+++ b/R/ml_classification_evaluators.R
@@ -7,7 +7,7 @@
 #' @param predicted_tbl_spark The result of running sdf_predict
 #' @param label Name of column string specifying which column contains the true, indexed labels (ie 0 / 1)
 #' @param score Name of column contains the scored probability of a success (ie 1)
-#' @param metric The classification metric -  one of: areaUnderRoc (default) or areaUnderPR
+#' @param metric The classification metric - one of: areaUnderRoc (default) or areaUnderPR (not available in Spark 2.X)
 #'
 #' @return  area under the specified curve
 #' @export
@@ -16,6 +16,14 @@
 ml_binary_classification_eval <- function(predicted_tbl_spark, label, score, metric = "areaUnderROC"){
   df <- spark_dataframe(predicted_tbl_spark)
   sc <- spark_connection(df)
+
+  spark_metrics <- list(
+    "2.0" = c("areaUnderROC")
+  )
+
+  if (spark_version(sc) >= "2.0.0" && !metric %in% spark_metrics[["2.0"]]) {
+    stop("Metric ", metric, " is unsupported in Spark 2.X")
+  }
 
   envir <- new.env(parent = emptyenv())
 
@@ -38,7 +46,8 @@ ml_binary_classification_eval <- function(predicted_tbl_spark, label, score, met
 #' @param predicted_tbl_spark A tbl_spark object that contains a columns with predicted labels
 #' @param label Name of the column that contains the true, indexed label. Support for binary and multi-class labels, column should be of double type (use as.double)
 #' @param predicted_lbl Name of the column that contains the predicted label NOT the scored probability. Support for binary and multi-class labels, column should be of double type (use as.double)
-#' @param metric A classification metric, one of: f1 (default), precision, recall, weightedPrecision, weightedRecall, accuracy
+#' @param metric A classification metric, for Spark 1.6: f1 (default), precision, recall, weightedPrecision, weightedRecall or accuracy;
+#'   for Spark 2.X: f1 (default), weightedPrecision, weightedRecall or accuracy
 #'
 #' @return see \code{metric}
 #'
@@ -48,6 +57,16 @@ ml_binary_classification_eval <- function(predicted_tbl_spark, label, score, met
 ml_classification_eval <- function(predicted_tbl_spark, label, predicted_lbl, metric = "f1"){
   df <- spark_dataframe(predicted_tbl_spark)
   sc <- spark_connection(df)
+
+  spark_metric = list(
+    "1.6" = c("f1", "precision", "recall", "weightedPrecision", "weightedRecall"),
+    "2.0" = c("f1", "weightedPrecision", "weightedRecall", "accuracy")
+  )
+
+  if (spark_version(sc) >= "2.0.0" && !metric %in% spark_metric[["2.0"]] ||
+      spark_version(sc) <  "2.0.0" && !metric %in% spark_metric[["1.6"]]) {
+    stop("Metric ", metric, " is unsupported in Spark ", spark_version(sc))
+  }
 
   res <- invoke_new(sc, "org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator") %>%
     invoke("setLabelCol", label) %>%

--- a/man/ml_binary_classification_eval.Rd
+++ b/man/ml_binary_classification_eval.Rd
@@ -14,7 +14,7 @@ ml_binary_classification_eval(predicted_tbl_spark, label, score,
 
 \item{score}{Name of column contains the scored probability of a success (ie 1)}
 
-\item{metric}{The classification metric -  one of: areaUnderRoc (default) or areaUnderPR}
+\item{metric}{The classification metric - one of: areaUnderRoc (default) or areaUnderPR (not available in Spark 2.X)}
 }
 \value{
 area under the specified curve

--- a/man/ml_classification_eval.Rd
+++ b/man/ml_classification_eval.Rd
@@ -14,7 +14,8 @@ ml_classification_eval(predicted_tbl_spark, label, predicted_lbl,
 
 \item{predicted_lbl}{Name of the column that contains the predicted label NOT the scored probability. Support for binary and multi-class labels, column should be of double type (use as.double)}
 
-\item{metric}{A classification metric, one of: f1 (default), precision, recall, weightedPrecision, weightedRecall, accuracy}
+\item{metric}{A classification metric, for Spark 1.6: f1 (default), precision, recall, weightedPrecision, weightedRecall or accuracy;
+for Spark 2.X: f1 (default), weightedPrecision, weightedRecall or accuracy}
 }
 \value{
 see \code{metric}

--- a/tests/testthat/test-ml-classification-eval.R
+++ b/tests/testthat/test-ml-classification-eval.R
@@ -1,0 +1,15 @@
+context("classification eval")
+sc <- testthat_spark_connection()
+
+iris_tbl <- testthat_tbl("iris")
+
+test_that("basic classification evaluation works", {
+  setosa_tbl <- iris_tbl %>% mutate(Is_Setosa = ifelse(Species == "setosa", 1, 0))
+
+  ml_fit <- ml_logistic_regression(setosa_tbl, Is_Setosa ~ .)
+  ml_pred <- sdf_predict(ml_fit, setosa_tbl)
+  ml_pred <- mutate(ml_pred, actual = ifelse(Species == "setosa", 1, 0))
+  accuracy <- ml_classification_eval(ml_pred, "actual", "prediction", "accuracy")
+
+  expect_equal(accuracy, 1)
+})


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/355