### PR TITLE
Add support for auto-column-names in spark_apply()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9009
+Version: 0.7.0-9010
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- `spark_apply()` now adds generic column names when needed and 
+  validates `f` is a `function`.
+
 - Improved documentation and error cases for `metric` argument in
   `ml_classification_eval()` and `ml_binary_classification_eval()`.
 

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -32,7 +32,12 @@ spark_schema_from_rdd <- function(sc, rdd, column_names) {
     stop("Failed to infer column types, please use explicit types.")
 
   fields <- lapply(seq_along(colTypes), function(idx) {
-    name <- if (is.null(column_names)) as.character(idx) else column_names[[idx]]
+    name <- if (is.null(column_names))
+      as.character(idx)
+    else if (idx <= length(column_names))
+      column_names[[idx]]
+    else
+      paste0("X", idx)
 
     invoke_static(
       sc,
@@ -63,7 +68,8 @@ spark_schema_from_rdd <- function(sc, rdd, column_names) {
 #'   \code{groupN} contain the values of the \code{group_by} values. When
 #'   \code{group_by} is not specified, \code{f} takes only one argument.
 #' @param columns A vector of column names or a named vector of column types for
-#'   the transformed object. Defaults to the names from the original object.
+#'   the transformed object. Defaults to the names from the original object and
+#'   adds indexed column names when not enough columns are specified.
 #' @param memory Boolean; should the table be cached into memory?
 #' @param group_by Column name used to group by data frame partitions.
 #' @param packages Boolean; distribute \code{.libPaths()} packages to nodes?
@@ -78,6 +84,8 @@ spark_apply <- function(x,
                         packages = TRUE,
                         ...) {
   args <- list(...)
+  assert_that(is.function(f))
+
   sc <- spark_connection(x)
   sdf <- spark_dataframe(x)
   sdf_columns <- colnames(x)


### PR DESCRIPTION
```r
sdf_len(sc, 1) %>% spark_apply(function() data.frame(a = 1, b = 2))

# Source:   table<sparklyr_tmp_100066ffeaefc> [?? x 2]
# Database: spark_connection
     id    X2
  <dbl> <dbl>
1     1     2
```

and

```r
spark_apply(list(), "f", 1)
 Error: f is not a function 
```