### PR TITLE
Fix race-condition first time spark_apply() runs with concurrent partitions while unpacking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9010
+Version: 0.7.0-9011
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Fix race-condition first time `spark_apply()` is run when more
+  than one partition runs in a worker and both processes try to
+  unpack the packages bundle at the same time.
+
 - `spark_apply()` now adds generic column names when needed and 
   validates `f` is a `function`.
 


### PR DESCRIPTION
Packages are extracted by the RScript first time `spark_apply()` runs; however, with concurrent partitions, two procs can attempt to unpack at the same time. Fix is to use a `sparklyr.lock` file and wait for one to unpack.