### PR TITLE
Fix regression in shinyapp for empty installs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9011
+Version: 0.7.0-9012
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -68,7 +68,7 @@ spark_default_version <- function() {
     hadoop <- version$hadoopVersion
     # otherwise check available versions and take the default
   } else {
-    versions <- read_spark_versions_json()
+    versions <- spark_versions()
     versions <- subset(versions, versions$default == TRUE & versions$hadoop_default == TRUE)
     version <- versions[1,]
     spark <- version$spark


### PR DESCRIPTION
The shinyapp ui is broken, CRAN is fine, but the problem was that the fix should have been pushed to `spark-install`, I just regenerated sources, which brought back the wrong fix. https://github.com/rstudio/spark-install/pull/31