### PR TITLE
Allow additional livy session parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,9 @@
   components to extract. Also implemented `sdf_project()` to project datasets using
   the results of `ml_pca()` models.
 
+- Added support for additional livy session creation parameters using
+  the `livy_config()` function.
+
 # Sparklyr 0.6.1 (UNRELEASED)
 
 - Fixed error in `spark_apply()` that may triggered when multiple CPUs

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -143,8 +143,7 @@ spark_connect <- function(master = "local",
                             app_name,
                             version,
                             hadoop_version ,
-                            extensions,
-                            ...)
+                            extensions)
   } else if (method == "gateway") {
     scon <- gateway_connection(master = master, config = config)
   } else if (method == "databricks") {

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -143,7 +143,8 @@ spark_connect <- function(master = "local",
                             app_name,
                             version,
                             hadoop_version ,
-                            extensions)
+                            extensions,
+                            ...)
   } else if (method == "gateway") {
     scon <- gateway_connection(master = master, config = config)
   } else if (method == "databricks") {

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -32,7 +32,6 @@ livy_validate_http_response <- function(message, req) {
 #'
 #' @importFrom jsonlite base64_enc
 #' @importFrom jsonlite unbox
-#' @importFrom snakecase to_any_case
 #'
 #' @param config Optional base configuration
 #' @param username The username to use in the Authorization header
@@ -63,7 +62,7 @@ livy_validate_http_response <- function(message, req) {
 #'   \item{\code{archives}}{Archives to be used in this session}
 #'   \item{\code{queue}}{The name of the YARN queue to which submitted}
 #'   \item{\code{queue}}{The name of this session}
-#'   \item{\code{heartbeat_timeout_in_second}}{Timeout in seconds to which session be orphaned}
+#'   \item{\code{heartbeat_timeout}}{Timeout in seconds to which session be orphaned}
 #' }
 #'
 #' @return Named list with configuration data
@@ -100,12 +99,30 @@ livy_config <- function(config = spark_config(), username = NULL, password = NUL
     if(!all(valid_params)){
       stop(paste0(names(additional_params[!valid_params]), sep = ", "), " are not valid session parameters. Valid parameters are: ", paste0(allowed_params, sep = ", "))
     }
-    singleValues = c("proxy_user", "driver_memory", "driver_cores", "executor_memory", "executor_cores", "num_executors", "queue", "name", "heartbeat_timeout_in_second")
+    singleValues = c("proxy_user", "driver_memory", "driver_cores", "executor_memory", "executor_cores", "num_executors", "queue", "name", "heartbeat_timeout")
     singleValues <- singleValues[singleValues %in% names(additional_params)]
     additional_params[singleValues] <- lapply(additional_params[singleValues], unbox)
+
+    #snake_case to camelCase mapping
+    params_map <- c(
+      proxy_user = "proxyUser",
+      jars = "jars",
+      py_files = "pyFiles",
+      files = "files",
+      driver_memory = "driverMemory",
+      driver_cores = "driverCores",
+      executor_memory = "executorMemory",
+      executor_cores = "executorCores",
+      num_executors = "numExecutors",
+      archives = "archives",
+      queue = "queue",
+      name = "name",
+      heartbeat_timeout = "heartbeatTimeoutInSecond"
+    )
+
     for(l in names(additional_params)){
       #Parse the params names from snake_case to camelCase
-      config[[paste0("livy.", to_any_case(l, case = "small_camel"))]] <- additional_params[[l]]
+      config[[paste0("livy.", params_map[[l]])]] <- additional_params[[l]]
     }
   }
   config

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -176,7 +176,7 @@ livy_create_session <- function(master, config) {
   )
 
   session_params <- connection_config(list(master = master, config = config), "livy.", NULL)
-  if(length(session_params) > 0) data <- append(data, session_params)sdf
+  if(length(session_params) > 0) data <- append(data, session_params)
 
   req <- POST(paste(master, "sessions", sep = "/"),
               livy_get_httr_headers(config, list(

--- a/man/livy_config.Rd
+++ b/man/livy_config.Rd
@@ -5,7 +5,7 @@
 \title{Create a Spark Configuration for Livy}
 \usage{
 livy_config(config = spark_config(), username = NULL, password = NULL,
-  custom_headers = list(`X-Requested-By` = "sparklyr"))
+  custom_headers = list(`X-Requested-By` = "sparklyr"), ...)
 }
 \arguments{
 \item{config}{Optional base configuration}
@@ -15,6 +15,8 @@ livy_config(config = spark_config(), username = NULL, password = NULL,
 \item{password}{The password to use in the Authorization header}
 
 \item{custom_headers}{List of custom headers to append to http requests. Defaults to \code{list("X-Requested-By" = "sparklyr")}.}
+
+\item{...}{additional Livy session parameters}
 }
 \value{
 Named list with configuration data
@@ -29,4 +31,21 @@ define the basic authentication settings for a Livy session.
 
 The default value of \code{"custom_headers"} is set to \code{list("X-Requested-By" = "sparklyr")}
 in order to facilitate connection to Livy servers with CSRF protection enabled.
+
+Additional parameters for Livy sessions are:
+\describe{
+  \item{\code{proxy_user}}{User to impersonate when starting the session}
+  \item{\code{jars}}{jars to be used in this session}
+  \item{\code{py_files}}{Python files to be used in this session}
+  \item{\code{files}}{files to be used in this session}
+  \item{\code{driver_memory}}{Amount of memory to use for the driver process}
+  \item{\code{driver_cores}}{Number of cores to use for the driver process}
+  \item{\code{executor_memory}}{Amount of memory to use per executor process}
+  \item{\code{executor_cores}}{Number of cores to use for each executor}
+  \item{\code{num_executors}}{Number of executors to launch for this session}
+  \item{\code{archives}}{Archives to be used in this session}
+  \item{\code{queue}}{The name of the YARN queue to which submitted}
+  \item{\code{queue}}{The name of this session}
+  \item{\code{heartbeat_timeout}}{Timeout in seconds to which session be orphaned}
+}
 }


### PR DESCRIPTION
When creating a Livy session, it allows passing additional parameters, such as setting the proxyUser, numCores, etc. https://github.com/apache/incubator-livy/blob/master/docs/rest-api.md#post-sessions