### PR TITLE
Fix `invoke()` for integer arrays containing NAs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9015
+Version: 0.7.0-9016
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Fixed issue in `invoke()` calls while using integer arrays
+  that contain `NA` which can be commonly experienced
+  while using `spark_apply()`.
+
 - Added `topics.description` under `ml_lda()` result.
 
 - Added support for `ft_stop_words_remover()` to strip out

--- a/R/core_serialize.R
+++ b/R/core_serialize.R
@@ -29,7 +29,7 @@ getSerdeType <- function(object) {
 
       # Check that there are no NAs in character arrays since they are unsupported in scala
       hasCharNAs <- any(sapply(object, function(elem) {
-        (is.factor(elem) || is.character(elem)) && is.na(elem)
+        (is.factor(elem) || is.character(elem) || is.integer(elem)) && is.na(elem)
       }))
 
       if (hasCharNAs) {


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/971

Eventhough found through `spark_apply()`, I was able to reproduce this issue for `invoke()` calls as follows:

```scala
class TestClass() {
  private var result: Array[Row] = Array[Row]()

  def setResultArraySeq(resultParam: Array[Any]) = {
    result = resultParam.map(x => Row.fromSeq(x.asInstanceOf[Array[_]].toSeq))
  }
}
```

```r
all_results <- structure(list(B = c(NA, 1L, NA, 1L, 1L, NA)), 
                          .Names = c("B"), 
                          row.names = c(NA,-6L), 
                          class = c("tbl_df", "tbl", "data.frame"))

all_data <- lapply(1:nrow(all_results), function(i) as.list(all_results[i,]))

tc <- invoke_new(sc, "sparklyr.TestClass")
invoke(tc, "setResultArraySeq", all_data[1])    
```

```
Error: java.io.EOFException
	at java.io.DataInputStream.readInt(DataInputStream.java:392)
	at sparklyr.Serializer$.readInt(serializer.scala:82)
	at sparklyr.Serializer$$anonfun$readIntArr$1.apply(serializer.scala:126)
	at sparklyr.Serializer$$anonfun$readIntArr$1.apply(serializer.scala:126)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	at scala.collection.immutable.Range.foreach(Range.scala:160)
```

The problem is similar to https://github.com/rstudio/sparklyr/issues/774 where we try to encode lists as `Array[]` but only if there are not `NA`s present since Scala does not support them in all data types, the fix was applied to `character`s but `integer` types also fall into this category.

The issue was that since an `NA` was detected while serializing a `integer` array, the serializer would only write the `serdeType` for the `NA` but not a value, which made the contract corrupt for the Scala `deserializer` which assumes one can read an integer array in a single pass.