### PR TITLE
Enable `yarn-cluster` in CDH clusters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9017
+Version: 0.7.0-9018
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added support for `spark_connect()` with `master="yarn-cluster"`
+  to query YARN resource manager API and retrieve the correct
+  container host name.
+
 - Fixed issue in `invoke()` calls while using integer arrays
   that contain `NA` which can be commonly experienced
   while using `spark_apply()`.

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -293,7 +293,7 @@ start_shell <- function(master,
 
     # for yarn-cluster
     if (spark_master_is_yarn_cluster(master) && is.null(config[["sparklyr.gateway.address"]])) {
-      config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway(config, start_time)
+      gatewayAddress <- config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway(config, start_time)
     }
 
     tryCatch({

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -34,10 +34,6 @@ shell_connection <- function(master,
 
   # for yarn-cluster set deploy mode as shell arguments
   if (spark_master_is_yarn_cluster(master)) {
-    if (is.null(config[["sparklyr.gateway.address"]])) {
-      config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway()
-    }
-
     if (is.null(config[["sparklyr.shell.deploy-mode"]])) {
       shell_args <- c(shell_args, "--deploy-mode", "cluster")
     }

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -39,11 +39,11 @@ shell_connection <- function(master,
     }
 
     if (is.null(config[["sparklyr.shell.deploy-mode"]])) {
-      config[["sparklyr.shell.deploy-mode"]] <- "cluster"
+      shell_args <- c(shell_args, "--deploy-mode", "cluster")
     }
 
     if (is.null(config[["sparklyr.shell.master"]])) {
-      config[["sparklyr.shell.master"]] <- "yarn"
+      shell_args <- c(shell_args, "--master", "yarn")
     }
   }
 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -334,7 +334,7 @@ start_shell <- function(master,
   tryCatch({
     # set timeout for socket connection
     timeout <- spark_config_value(config, "sparklyr.backend.timeout", 30 * 24 * 60 * 60)
-    backend <- socketConnection(host = "localhost",
+    backend <- socketConnection(host = gatewayAddress,
                                 port = gatewayInfo$backendPort,
                                 server = FALSE,
                                 blocking = TRUE,

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -297,8 +297,7 @@ start_shell <- function(master,
 
     # for yarn-cluster
     if (spark_master_is_yarn_cluster(master) && is.null(config[["sparklyr.gateway.address"]])) {
-        config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway(config, start_time)
-      }
+      config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway(config, start_time)
     }
 
     tryCatch({

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -1,4 +1,4 @@
-spark_yarn_cluster_get_gateway <- function() {
+spark_yarn_cluster_get_conf_property <- function(property) {
   confDir <- Sys.getenv("YARN_CONF_DIR")
   if (nchar(confDir) == 0) {
 
@@ -16,14 +16,66 @@ spark_yarn_cluster_get_gateway <- function() {
 
   yarnSiteXml <- xml2::read_xml(yarnSite)
 
-  yarnResourceManagerAddress <- xml2::xml_text(xml2::xml_find_all(
-    yarnSiteXml,
-    "//name[.='yarn.resourcemanager.address']/parent::property/value")
+  yarnPropertyValue <- xml2::xml_text(xml2::xml_find_all(
+      yarnSiteXml,
+      paste0("//name[.='", property, "']/parent::property/value")
+    )
   )
 
-  if (length(yarnResourceManagerAddress) == 0) {
-    stop("Yarn Cluster mode uses `yarn.resourcemanager.address` but is not present in yarn-site.xml")
+  yarnPropertyValue
+}
+
+spark_yarn_cluster_get_app_property <- function(config, start_time, rm_webapp, property) {
+  resourceManagerQuery <- paste0(
+    "http",
+    "://",
+    rm_webapp,
+    "/ws/v1/cluster/apps?startedTimeBegin=",
+    start_time,
+    "&applicationType=SPARK"
+  )
+
+  waitSeconds <- spark_config_value(config, "sparklyr.yarn.cluster.start.timeout", 60)
+  commandStart <- Sys.time()
+  propertyValue <- NULL
+
+  while(length(propertyValue) == 0 && commandStart + waitSeconds > Sys.time()) {
+    resourceManagerResponce <- httr::GET(resourceManagerQuery)
+    yarnApps <- httr::content(resourceManagerResponce)
+
+    newSparklyrApps <- Filter(function(e) grepl("sparklyr.*", e[[1]]$name), yarnApps$apps)
+
+    if (length(newSparklyrApps) > 1) {
+      stop("Multiple sparklyr apps submitted at once to this yarn cluster, aborting, please retry")
+    }
+
+    newSparklyrApp <- newSparklyrApps[[1]][[1]]
+    if (property %in% names(newSparklyrApp)) {
+      propertyValue <- newSparklyrApp[[property]]
+    }
+    else {
+      Sys.sleep(1)
+    }
   }
 
-  strsplit(yarnResourceManagerAddress, ":")[[1]][[1]]
+  propertyValue
+}
+
+spark_yarn_cluster_get_gateway <- function(config, start_time) {
+  resourceManagerWebapp <- spark_yarn_cluster_get_conf_property("yarn.resourcemanager.webapp.address")
+
+  if (length(resourceManagerWebapp) == 0) {
+    stop("Yarn Cluster mode uses `yarn.resourcemanager.webapp.address` but is not present in yarn-site.xml")
+  }
+
+  amHostHttpAddress <- spark_yarn_cluster_get_app_property(
+    config, start_time,
+    resourceManagerWebapp,
+    "amHostHttpAddress")
+
+  if (is.null(amHostHttpAddress)) {
+    stop("Failed to retrieve new sparklyr yarn application from ", resourceManagerWebapp)
+  }
+
+  strsplit(amHostHttpAddress, ":")[[1]][[1]]
 }


### PR DESCRIPTION
Enable `yarn-cluster` in CDH clusters, say running:

```r
library(sparklyr)

Sys.setenv(JAVA_HOME="/usr/lib/jvm/java-7-oracle-cloudera/")
Sys.setenv(SPARK_HOME = '/opt/cloudera/parcels/CDH/lib/spark')
Sys.setenv(YARN_CONF_DIR = '/opt/cloudera/parcels/CDH/lib/spark/conf/yarn-conf')

conf <- spark_config()

sc <- spark_connect(master = "yarn-cluster", 
                    config = conf,
                    version = "1.6.0")
```

The main fix here was to query the YARN API to retrieve the given container host; seems `yarn-cluster` is not required to run on the driver node in all cases and therefore, can't be assumed to run on a particular node with `config$sparklyr.gateway.address`.

References:
- [ResourceManager REST API’s.](https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API)
- [Deployment Modes](https://www.cloudera.com/documentation/enterprise/5-4-x/topics/cdh_ig_running_spark_on_yarn.html#concept_asc_2hr_gs)