### PR TITLE
Add support for `na.omit.cache` option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added support for `na.omit.cache` option that when set to
+  `FALSE` will prevent `na.omit` from caching results when
+  rows are dropped.
+
 - Added support in `spark_connect()` for `yarn-cluster` with
   hight-availability enabled.
   

--- a/R/na_actions.R
+++ b/R/na_actions.R
@@ -59,7 +59,7 @@ na.omit.spark_jobj <- function(object, columns = NULL, ...) {
   }
 
   # using a df created from drop actions reduces performance, see #308.
-  if (identical(n_before, n_after)) {
+  if (identical(n_before, n_after) && getOption("na.omit.cache", TRUE)) {
     sdf_register(object)
   } else {
     result <- sdf_register(dropped)


### PR DESCRIPTION
Potential side effect from caching data in `na.omit` spotted in https://github.com/rstudio/sparklyr/issues/988, at the very least, we should allow users to opt-out from this behavior, see also https://github.com/rstudio/sparklyr/issues/308.