### PR TITLE
Enable support for Java 9

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,7 +54,7 @@ validate_java_version <- function(master, spark_home) {
   # transform to usable R version string
   splat <- strsplit(versionLine, "\\s+", perl = TRUE)[[1]]
 
-  splatVersion <- splat[grepl("[0-9]+\\.[0-9]+\\.[0-9]+", splat)]
+  splatVersion <- splat[grepl("9|[0-9]+\\.[0-9]+\\.[0-9]+", splat)]
   if (length(splatVersion) != 1)
     stop("Java version detected but couldn't parse version from: ", versionLine)
 

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -7,6 +7,7 @@ testthat_spark_connection <- function(version = NULL) {
   }
 
   if (nrow(spark_installed_versions()) == 0) {
+    options(sparkinstall.verbose = TRUE)
     spark_install("2.1.0")
   }
 
@@ -21,6 +22,11 @@ testthat_spark_connection <- function(version = NULL) {
 
   if (!connected) {
     config <- spark_config()
+
+    config$sparklyr.sanitize.column.names.verbose <- TRUE
+    config$sparklyr.verbose <- TRUE
+    config$sparklyr.na.ommit.verbose <- TRUE
+    config$sparklyr.na.action.verbose <- TRUE
 
     version <- version %||% Sys.getenv("SPARK_VERSION", unset = "2.1.0")
     setwd(tempdir())

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -23,10 +23,10 @@ testthat_spark_connection <- function(version = NULL) {
   if (!connected) {
     config <- spark_config()
 
-    config$sparklyr.sanitize.column.names.verbose <- TRUE
-    config$sparklyr.verbose <- TRUE
-    config$sparklyr.na.ommit.verbose <- TRUE
-    config$sparklyr.na.action.verbose <- TRUE
+    options(sparklyr.sanitize.column.names.verbose = TRUE)
+    options(sparklyr.verbose = TRUE)
+    options(sparklyr.na.omit.verbose = TRUE)
+    options(sparklyr.na.action.verbose = TRUE)
 
     version <- version %||% Sys.getenv("SPARK_VERSION", unset = "2.1.0")
     setwd(tempdir())


### PR DESCRIPTION
Not entirely supported since Hadoop supports Java 9 until `Hadoop 2.8` and there is no bundled verstion of `Spark + Hadoop 2.8` yet; however, one can install Spar with no Hadoop and then manually install hadoop.