### PR TITLE
Update documentation of the mode param for spark_write_*()

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -126,7 +126,8 @@ spark_read_csv <- function(sc,
 #' @param charset The character set, defaults to \code{"UTF-8"}.
 #' @param null_value The character to use for default values, defaults to \code{NULL}.
 #' @param options A list of strings with additional options.
-#' @param mode Specifies the behavior when data or table already exists.
+#' @param mode A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.
+#'
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
@@ -225,7 +226,6 @@ spark_read_parquet <- function(sc,
 #' \href{https://parquet.apache.org/}{Parquet} format.
 #'
 #' @inheritParams spark_write_csv
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param options A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
@@ -303,7 +303,6 @@ spark_read_json <- function(sc,
 #' Object Notation} format.
 #'
 #' @inheritParams spark_write_csv
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
@@ -494,7 +493,6 @@ spark_load_table <- function(sc,
 #'
 #' @inheritParams spark_write_csv
 #' @param name The name to assign to the newly generated table.
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
@@ -515,7 +513,6 @@ spark_write_table <- function(x,
 #' Saves a Spark DataFrame and as a Spark table.
 #'
 #' @inheritParams spark_write_csv
-#' @param mode Specifies the behavior when data or table already exists.
 #'
 #' @family Spark serialization routines
 #'
@@ -616,7 +613,6 @@ spark_read_source <- function(sc,
 #'
 #' @inheritParams spark_write_csv
 #' @param name The name to assign to the newly generated table.
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
@@ -665,7 +661,6 @@ spark_write_jdbc.spark_jobj <- function(x,
 #' @inheritParams spark_write_csv
 #' @param name The name to assign to the newly generated table.
 #' @param source A data source capable of reading data.
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
@@ -742,7 +737,6 @@ spark_read_text <- function(sc,
 #' Serialize a Spark DataFrame to the plain text format.
 #'
 #' @inheritParams spark_write_csv
-#' @param mode Specifies the behavior when data or table already exists.
 #' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'

--- a/man/spark_save_table.Rd
+++ b/man/spark_save_table.Rd
@@ -12,7 +12,7 @@ spark_save_table(x, path, mode = NULL, options = list())
 \item{path}{The path to the file. Needs to be accessible from the cluster.
 Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
 }
@@ -36,3 +36,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_csv.Rd
+++ b/man/spark_write_csv.Rd
@@ -28,7 +28,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{options}{A list of strings with additional options.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{partition_by}{Partitions the output by the given columns on the file system.}
 
@@ -54,3 +54,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_jdbc.Rd
+++ b/man/spark_write_jdbc.Rd
@@ -12,7 +12,7 @@ spark_write_jdbc(x, name, mode = NULL, options = list(),
 
 \item{name}{The name to assign to the newly generated table.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
 
@@ -40,3 +40,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_json.Rd
+++ b/man/spark_write_json.Rd
@@ -13,7 +13,7 @@ spark_write_json(x, path, mode = NULL, options = list(),
 \item{path}{The path to the file. Needs to be accessible from the cluster.
 Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
 
@@ -42,3 +42,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_parquet.Rd
+++ b/man/spark_write_parquet.Rd
@@ -13,7 +13,7 @@ spark_write_parquet(x, path, mode = NULL, options = list(),
 \item{path}{The path to the file. Needs to be accessible from the cluster.
 Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.}
 
@@ -42,3 +42,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_source.Rd
+++ b/man/spark_write_source.Rd
@@ -14,7 +14,7 @@ spark_write_source(x, name, source, mode = NULL, options = list(),
 
 \item{source}{A data source capable of reading data.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
 
@@ -42,3 +42,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_table.Rd
+++ b/man/spark_write_table.Rd
@@ -12,7 +12,7 @@ spark_write_table(x, name, mode = NULL, options = list(),
 
 \item{name}{The name to assign to the newly generated table.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
 
@@ -40,3 +40,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_source}},
   \code{\link{spark_write_text}}
 }
+\concept{Spark serialization routines}

--- a/man/spark_write_text.Rd
+++ b/man/spark_write_text.Rd
@@ -13,7 +13,7 @@ spark_write_text(x, path, mode = NULL, options = list(),
 \item{path}{The path to the file. Needs to be accessible from the cluster.
 Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
-\item{mode}{Specifies the behavior when data or table already exists.}
+\item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
 \item{options}{A list of strings with additional options.}
 
@@ -41,3 +41,4 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_source}},
   \code{\link{spark_write_table}}
 }
+\concept{Spark serialization routines}


### PR DESCRIPTION
This PR closes https://github.com/rstudio/sparklyr/issues/1005.

Changes:

* Eliminate the per-function documentation of the mode param. Instead define it with the rest of the spark_write_csv params and inherit it.
* Update documentation of mode param to include possible values as well as a link to the relevant Spark documentation.