### PR TITLE
`spark_apply()` hangs for 16min when multiple executors run on same node with package distribution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9032
+Version: 0.7.0-9033
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Ushey", role = "aut", email = "kevin@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Fix to `spark_apply()` when package distribution deadlock triggers in 
+  environments where multiple executors run under the same node.
+
 - Added support in `spark_apply()` for specifying  a list of `packages` to
   distribute to each worker node.
 

--- a/R/worker_apply.R
+++ b/R/worker_apply.R
@@ -160,7 +160,7 @@ worker_spark_apply_unbundle <- function(bundle_path, base_path, bundle_name) {
   if (file.exists(lockFile)) {
     worker_log("found that lock file exists, waiting")
     while (file.exists(lockFile)) {
-      Sys.sleep(1000)
+      Sys.sleep(1)
     }
     worker_log("completed lock file wait")
   }


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/1035 and https://stackoverflow.com/posts/46410425/edit - Patch candidate for CRAN.