### PR TITLE
Note expected input type

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -128,7 +128,7 @@ spark_read_csv <- function(sc,
 #' @param options A list of strings with additional options.
 #' @param mode A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.
 #'
-#' @param partition_by Partitions the output by the given columns on the file system.
+#' @param partition_by A \code{character} vector. Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines
@@ -227,7 +227,6 @@ spark_read_parquet <- function(sc,
 #'
 #' @inheritParams spark_write_csv
 #' @param options A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.
-#' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines
@@ -303,7 +302,6 @@ spark_read_json <- function(sc,
 #' Object Notation} format.
 #'
 #' @inheritParams spark_write_csv
-#' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines
@@ -493,7 +491,6 @@ spark_load_table <- function(sc,
 #'
 #' @inheritParams spark_write_csv
 #' @param name The name to assign to the newly generated table.
-#' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines
@@ -613,7 +610,6 @@ spark_read_source <- function(sc,
 #'
 #' @inheritParams spark_write_csv
 #' @param name The name to assign to the newly generated table.
-#' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines
@@ -661,7 +657,6 @@ spark_write_jdbc.spark_jobj <- function(x,
 #' @inheritParams spark_write_csv
 #' @param name The name to assign to the newly generated table.
 #' @param source A data source capable of reading data.
-#' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines
@@ -737,7 +732,6 @@ spark_read_text <- function(sc,
 #' Serialize a Spark DataFrame to the plain text format.
 #'
 #' @inheritParams spark_write_csv
-#' @param partition_by Partitions the output by the given columns on the file system.
 #' @param ... Optional arguments; currently unused.
 #'
 #' @family Spark serialization routines

--- a/man/spark_write_csv.Rd
+++ b/man/spark_write_csv.Rd
@@ -30,7 +30,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{mode}{A \code{character} element.  Specifies the behavior when data or table already exists. Supported values include: error, append, overwrite and ignore.  For more details see also \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes} for your version of Spark.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_write_jdbc.Rd
+++ b/man/spark_write_jdbc.Rd
@@ -16,7 +16,7 @@ spark_write_jdbc(x, name, mode = NULL, options = list(),
 
 \item{options}{A list of strings with additional options.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_write_json.Rd
+++ b/man/spark_write_json.Rd
@@ -17,7 +17,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{options}{A list of strings with additional options.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_write_parquet.Rd
+++ b/man/spark_write_parquet.Rd
@@ -17,7 +17,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{options}{A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_write_source.Rd
+++ b/man/spark_write_source.Rd
@@ -18,7 +18,7 @@ spark_write_source(x, name, source, mode = NULL, options = list(),
 
 \item{options}{A list of strings with additional options.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_write_table.Rd
+++ b/man/spark_write_table.Rd
@@ -16,7 +16,7 @@ spark_write_table(x, name, mode = NULL, options = list(),
 
 \item{options}{A list of strings with additional options.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }

--- a/man/spark_write_text.Rd
+++ b/man/spark_write_text.Rd
@@ -17,7 +17,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.}
 
 \item{options}{A list of strings with additional options.}
 
-\item{partition_by}{Partitions the output by the given columns on the file system.}
+\item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
 }


### PR DESCRIPTION
The documentation for input type doesn't specify whether it is NSE or SE.  SE is probably the expected default, but because this package is from Rstudio sometimes one expects NSE.  Regardless, this arg could have been numeric positional or any other number of things.  So, explicit being better than implicit... I've made a minor tweak to the documentation to specify that the value for `partition_by` is expected to be a character vector.