### PR TITLE
Update sample_n error comment for Spark < 2.x

### DIFF
--- a/R/dplyr_spark_table.R
+++ b/R/dplyr_spark_table.R
@@ -13,7 +13,7 @@ sample_n.tbl_spark <- function(tbl,
                                weight = NULL,
                                .env = parent.frame()) {
   if (spark_version(spark_connection(tbl)) < "2.0.0")
-      stop("sample_n() is not supported until Spark 2.0 or later")
+      stop("sample_n() is not supported until Spark 2.0 or later. Use sdf_sample instead.")
 
   add_op_single("sample_n", .data = tbl, args = list(
     size = size,
@@ -32,7 +32,7 @@ sample_frac.tbl_spark <- function(tbl,
                                   weight = NULL,
                                   .env = parent.frame()) {
   if (spark_version(spark_connection(tbl)) < "2.0.0")
-    stop("sample_frac() is not supported until Spark 2.0 or later")
+    stop("sample_frac() is not supported until Spark 2.0 or later.")
 
   add_op_single("sample_frac", .data = tbl, args = list(
     size = size,


### PR DESCRIPTION
I noticed that with Spark < 2.x the function sdf_sample will work. So this could be a more useful suggestion for the user.