### PR TITLE
`spark_write_table` with `mode = 'append'` requires a workaround to work properly in Hive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9100
+Version: 0.7.0-9101
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Implemented workaround to support in `spark_write_table()` for
+  `mode = 'append'`.
+
 - Various ML improvements, including support for pipelines, additional algorithms,
   hyper-parameter tuning, and better model persistence.
 

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -540,7 +540,9 @@ spark_write_table.tbl_spark <- function(x,
       "Upgrade to Spark 2.X or use this function in a non-local Spark cluster.")
   }
 
-  spark_data_write_generic(sqlResult, name, "saveAsTable", mode, options, partition_by)
+  fileMethod <- ifelse(mode == "append", "insertInto", "saveAsTable")
+
+  spark_data_write_generic(sqlResult, name, fileMethod, mode, options, partition_by)
 }
 
 #' @export


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/992, `spark_write_table` with `mode = 'append'` requires a workaround to work properly in Hive: https://stackoverflow.com/questions/44538968/spark2-1-0-insert-data-into-hive-error