### PR TITLE
Add support under 'yarn-cluster' to wait for available resources

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9102
+Version: 0.7.0-9103
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9101
+Version: 0.7.0-9102
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added support for `sparklyr.yarn.cluster.accepted.timeout` under `yarn-cluster`
+  to allow users to wait for resources under cluster with high waiting times.
+
 - Implemented workaround to support in `spark_write_table()` for
   `mode = 'append'`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Added support for HTTPS for `yarn-cluster` which is acticated by setting
+  `yarn.http.policy` to `HTTPS_ONLY` in `yarn-site.xml`.
+
 - Added support for `sparklyr.yarn.cluster.accepted.timeout` under `yarn-cluster`
   to allow users to wait for resources under cluster with high waiting times.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # Sparklyr 0.7 (UNRELEASED)
 
-- Added support for HTTPS for `yarn-cluster` which is acticated by setting
+- Added support for HTTPS for `yarn-cluster` which is activated by setting
   `yarn.http.policy` to `HTTPS_ONLY` in `yarn-site.xml`.
 
 - Added support for `sparklyr.yarn.cluster.accepted.timeout` under `yarn-cluster`

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -37,8 +37,6 @@ spark_yarn_cluster_get_app_id <- function(config, start_time, rm_webapp) {
   appLookupUseUser <- spark_config_value(config, "sparklyr.yarn.cluster.lookup.byname", !is.null(appLoookupUser))
 
   resourceManagerQuery <- paste0(
-    "http",
-    "://",
     rm_webapp,
     "/ws/v1/cluster/apps?startedTimeBegin=",
     start_time,
@@ -89,8 +87,6 @@ spark_yarn_cluster_get_app_id <- function(config, start_time, rm_webapp) {
 
 spark_yarn_cluster_get_app_property <- function(rm_webapp, appId, property, errorMessage = "") {
   resourceManagerQuery <- paste0(
-    "http",
-    "://",
     rm_webapp,
     "/ws/v1/cluster/apps/",
     appId
@@ -117,8 +113,6 @@ spark_yarn_cluster_while_app <- function(rm_webapp, appId, waitSeconds, conditio
   commandStart <- Sys.time()
 
   resourceManagerQuery <- paste0(
-    "http",
-    "://",
     rm_webapp,
     "/ws/v1/cluster/apps/",
     appId
@@ -137,8 +131,6 @@ spark_yarn_cluster_while_app <- function(rm_webapp, appId, waitSeconds, conditio
 
 spark_yarn_cluster_resource_manager_is_online <- function(rm_webapp) {
   rmQuery <- paste0(
-    "http",
-    "://",
     rm_webapp,
     "/ws/v1/cluster/info"
   )
@@ -217,12 +209,23 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
   mainRMWebappValue
 }
 
+spark_yarn_cluster_get_protocol <- function() {
+  useHttpsValue <- spark_yarn_cluster_get_conf_property("yarn.http.policy")
+
+  if (length(useHttpsValue) > 0 && toupper(useHttpsValue) == "HTTPS_ONLY")
+    "https"
+  else
+    "http"
+}
+
 spark_yarn_cluster_get_gateway <- function(config, start_time) {
   resourceManagerWebapp <- spark_yarn_cluster_get_resource_manager_webapp()
 
   if (length(resourceManagerWebapp) == 0) {
     stop("Yarn Cluster mode uses `yarn.resourcemanager.webapp.address` but is not present in yarn-site.xml")
   }
+
+  resourceManagerWebapp <- paste0(spark_yarn_cluster_get_protocol(), "://", resourceManagerWebapp)
 
   appId <- spark_yarn_cluster_get_app_id(
     config,

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -99,11 +99,7 @@ spark_yarn_cluster_get_app_property <- function(rm_webapp, appId, property) {
   resourceManagerResponce <- httr::GET(resourceManagerQuery)
   yarnApp <- httr::content(resourceManagerResponce)
 
-  if (property %in% names(yarnApp)) {
-    propertyValue <- yarnApp[[property]]
-  }
-
-  if (length(propertyValue) == 0) {
+  if (!"app" %in% names(yarnApp) || !property %in% names(yarnApp$app)) {
     withr::with_options(list(
       warning.length = 8000
     ), {
@@ -114,7 +110,7 @@ spark_yarn_cluster_get_app_property <- function(rm_webapp, appId, property) {
     })
   }
 
-  propertyValue
+  yarnApp$app[[property]]
 }
 
 spark_yarn_cluster_resource_manager_is_online <- function(rm_webapp) {

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -76,7 +76,8 @@ spark_yarn_cluster_get_app_property <- function(config, start_time, rm_webapp, p
     ), {
       stop(
         "Failed to retrieve new sparklyr yarn application from ",
-        resourceManagerQuery, " after ", format(Sys.time() - commandStart, digits = 1), ", last result: ",
+        resourceManagerQuery, " after ", format(Sys.time() - commandStart, digits = 1),
+        ", check yarn.resourcemanager.webapp.address under yarn-site.xml. Last result: ",
         yarnApps
       )
     })
@@ -160,7 +161,6 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
       }
       else {
         mainRMWebappValue <- paste(sub(":[0-9]+$", "", mainRMValue), 8088, sep = ":")
-        warning("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml, using default port: ", mainRMWebappValue)
       }
     }
   }

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -241,7 +241,7 @@ spark_yarn_cluster_get_gateway <- function(config, start_time) {
     appId,
     "state")
 
-  if (currentState %in% c("NEW", "NEW_SAVING", "SUBMITTED")) {
+  if (toupper(currentState) %in% c("NEW", "NEW_SAVING", "SUBMITTED")) {
     stop(
       "Yarn application ", appId, " and state ", currentState, " ",
       "was not accepted after ", waitAcceptedSeconds, " seconds. ",
@@ -250,7 +250,7 @@ spark_yarn_cluster_get_gateway <- function(config, start_time) {
     )
   }
 
-  if (tolower(currentState) != "accepted") {
+  if (toupper(currentState) != "ACCEPTED") {
     stop(
       "Yarn submission changed to state '", currentState, "' while 'accpted' ",
       "state was expected for app: ", appId

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -241,9 +241,10 @@ spark_yarn_cluster_get_gateway <- function(config, start_time) {
     appId,
     "state")
 
-  if (is.null(currentState)) {
+  if (currentState %in% c("NEW", "NEW_SAVING", "SUBMITTED")) {
     stop(
-      "Yarn application was not accepted after ", waitAcceptedSeconds, " seconds. ",
+      "Yarn application ", appId, " and state ", currentState, " ",
+      "was not accepted after ", waitAcceptedSeconds, " seconds. ",
       "Please check that the cluster has enough available resources or increase ",
       "the wait time by changing 'config$sparklyr.yarn.cluster.accepted.timeout'."
     )

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -159,8 +159,8 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
         stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
       }
       else {
-        mainRMWebapp <- paste(sub(":[0-9]+$", "", mainRMValue), 8088, sep = ":")
-        warning("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml, using default port: ", mainRMWebapp)
+        mainRMWebappValue <- paste(sub(":[0-9]+$", "", mainRMValue), 8088, sep = ":")
+        warning("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml, using default port: ", mainRMWebappValue)
       }
     }
   }

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -149,7 +149,20 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
   mainRMWebappValue <- spark_yarn_cluster_get_conf_property(mainRMWebapp)
 
   if (is.null(mainRMWebappValue)) {
-    stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
+    if (rmHighAvailability) {
+      stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
+    }
+    else {
+      mainRM <- "yarn.resourcemanager.address"
+      mainRMValue <- spark_yarn_cluster_get_conf_property(mainRM)
+      if (is.null(mainRMValue)) {
+        stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
+      }
+      else {
+        mainRMWebapp <- paste(sub(":[0-9]+$", "", mainRMValue), 8088, sep = ":")
+        warning("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml, using default port: ", mainRMWebapp)
+      }
+    }
   }
 
   mainRMWebappValue

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -148,14 +148,14 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
 
   mainRMWebappValue <- spark_yarn_cluster_get_conf_property(mainRMWebapp)
 
-  if (is.null(mainRMWebappValue)) {
+  if (length(mainRMWebappValue) == 0) {
     if (rmHighAvailability) {
       stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
     }
     else {
       mainRM <- "yarn.resourcemanager.address"
       mainRMValue <- spark_yarn_cluster_get_conf_property(mainRM)
-      if (is.null(mainRMValue)) {
+      if (length(mainRMValue) == 0) {
         stop("Failed to retrieve ", mainRMWebapp, " from yarn-site.xml")
       }
       else {

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -130,7 +130,7 @@ spark_yarn_cluster_while_app <- function(rm_webapp, appId, waitSeconds, conditio
 
     if (!condition(yarnResponse$app)) break;
 
-    sleepTime <- ifelse(commandStart - waitSeconds > 60, 30, 1)
+    sleepTime <- ifelse(Sys.time() - commandStart > 60, 30, 1)
     Sys.sleep(sleepTime)
   }
 }
@@ -266,7 +266,7 @@ spark_yarn_cluster_get_gateway <- function(config, start_time) {
     appId,
     waitHostAddressSeconds,
     function(app) {
-      "amHostHttpAddress" %in% names(app)
+      !"amHostHttpAddress" %in% names(app)
     })
 
   amHostHttpAddress <- spark_yarn_cluster_get_app_property(


### PR DESCRIPTION
A couple `yarn-cluster` improvements that are blocking usage of this feature under some clusters.

### ACCEPTED State

See https://github.com/rstudio/sparklyr/issues/1033/ 

Currently, 'yarn-cluster' only supports `sparklyr.yarn.cluster.start.timeout` as a setting to control how long to wait to establish a connection to Yarn and retrieve the running application.

However, for busy clusters, it is currently not possible to wait until the resources become available. 

This information is available under `state` in the Yarn app. Therefore, added support for `sparklyr.yarn.cluster.accepted.timeout` which can be configured to wait for indefinite amounts of time for cluster resources to become available.

### HTTPS Support

See https://github.com/rstudio/sparklyr/issues/1054/

This PR adds support for HTTPS for `yarn-cluster` which is activated by setting `yarn.http.policy` to `HTTPS_ONLY` in `yarn-site.xml`.

### Other Improvements

Additionally, this PR also adds support to make `yarn-cluster` work without additional `yarn-site.xml` config changes under Amazon EMR.