### PR TITLE
Add support for 'spark_apply()' under 'yarn-cluster'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,5 @@
 # Sparklyr 0.7 (UNRELEASED)
 
-- Added support for HTTPS for `yarn-cluster` which is activated by setting
-  `yarn.http.policy` to `HTTPS_ONLY` in `yarn-site.xml`.
-
-- Added support for `sparklyr.yarn.cluster.accepted.timeout` under `yarn-cluster`
-  to allow users to wait for resources under cluster with high waiting times.
-
 - Implemented workaround to support in `spark_write_table()` for
   `mode = 'append'`.
 
@@ -24,6 +18,14 @@
 - Fixed collection of `DateType` and `TimestampTime` from `character` to 
   proper `Date` and `POSIXct` types.
 
+# Sparklyr 0.6.4
+
+- Added support for HTTPS for `yarn-cluster` which is activated by setting
+  `yarn.http.policy` to `HTTPS_ONLY` in `yarn-site.xml`.
+
+- Added support for `sparklyr.yarn.cluster.accepted.timeout` under `yarn-cluster`
+  to allow users to wait for resources under cluster with high waiting times.
+  
 - Fix to `spark_apply()` when package distribution deadlock triggers in 
   environments where multiple executors run under the same node.
 
@@ -33,7 +35,7 @@
 - Added support in`yarn-cluster` for `sparklyr.yarn.cluster.lookup.prefix`,
   `sparklyr.yarn.cluster.lookup.username` and `sparklyr.yarn.cluster.lookup.byname`
   to control the new application lookup behavior.
-
+  
 # Sparklyr 0.6.3
 
 - Enabled support for Java 9 for clusters configured with 

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -111,11 +111,8 @@ spark_apply_packages_is_bundle <- function(packages) {
 #'   \code{spark_apply_bundle()}.
 #'
 #'   For clusters using Livy or Yarn cluster mode, \code{packages} must
-#'   point to a package bundle path created using \code{spark_apply_bundle()}
-#'   and made available as a Spark file. For Yarn cluster mode, the bundle
-#'   can be registered as a Spark file using \code{config$sparklyr.shell.files}.
-#'   For Livy, this bundle must be copied into the cluster and then made available
-#'   using \code{invoke(spark_context(sc), "addFile", "<path-to-file>")}.
+#'   point to a package bundle created using \code{spark_apply_bundle()}
+#'   and made available as a Spark file using \code{config$sparklyr.shell.files}.
 #'
 #'   For offline clusters where \code{available.packages()} is not available,
 #'   manually download the packages database from

--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -2,9 +2,9 @@ spark_apply_bundle_path <- function() {
   file.path(tempdir(), "packages")
 }
 
-spark_apply_bundle_file <- function(packages = TRUE) {
+spark_apply_bundle_file <- function(packages, base_path) {
   file.path(
-    spark_apply_bundle_path(),
+    base_path,
     if (isTRUE(packages))
       "packages.tar"
     else
@@ -23,14 +23,18 @@ spark_apply_bundle_file <- function(packages = TRUE) {
   )
 }
 
-#' Creates a bundle of dependencies required by \code{spark_apply()}
+#' Create Bundle for Spark Apply
+#'
+#' Creates a bundle of packages for \code{spark_apply()}.
 #'
 #' @param packages List of packages to pack or \code{TRUE} to pack all.
+#' @param base_path Base path used to store the resulting bundle.
 #'
-#' @keywords internal
 #' @export
-spark_apply_bundle <- function(packages = TRUE) {
-  packagesTar <- spark_apply_bundle_file(packages)
+spark_apply_bundle <- function(packages = TRUE, base_path = getwd()) {
+  packages <- if (is.character(packages)) spark_apply_packages(packages) else packages
+
+  packagesTar <- spark_apply_bundle_file(packages, base_path)
 
   if (!dir.exists(spark_apply_bundle_path()))
     dir.create(spark_apply_bundle_path(), recursive = TRUE)

--- a/R/spark_apply_bundle.R
+++ b/R/spark_apply_bundle.R
@@ -49,14 +49,14 @@ spark_apply_bundle <- function(packages = TRUE, base_path = getwd()) {
     } else {
       added_packages <- list()
       lapply(.libPaths(), function(e) {
-        sublib_packages <- lapply(packages, function(p) {
-          if (file.exists(file.path(e, p)) && !p %in% added_packages) {
-            added_packages <<- c(added_packages, p)
-            p
-          }
-        }) %>%
-          Filter(Negate(is.null), .) %>%
-          unlist()
+        sublib_packages <- Filter(
+          Negate(is.null),
+          lapply(packages, function(p) {
+            if (file.exists(file.path(e, p)) && !p %in% added_packages) {
+              added_packages <<- c(added_packages, p)
+              p
+            }
+          })) %>% unlist()
 
         if (length(sublib_packages) > 0) c("-C", e, sublib_packages) else NULL
       }) %>% unlist()

--- a/man/spark_apply.Rd
+++ b/man/spark_apply.Rd
@@ -29,11 +29,8 @@ adds indexed column names when not enough columns are specified.}
   \code{spark_apply_bundle()}.
 
   For clusters using Livy or Yarn cluster mode, \code{packages} must
-  point to a package bundle path created using \code{spark_apply_bundle()}
-  and made available as a Spark file. For Yarn cluster mode, the bundle
-  can be registered as a Spark file using \code{config$sparklyr.shell.files}.
-  For Livy, this bundle must be copied into the cluster and then made available
-  using \code{invoke(spark_context(sc), "addFile", "<path-to-file>")}.
+  point to a package bundle created using \code{spark_apply_bundle()}
+  and made available as a Spark file using \code{config$sparklyr.shell.files}.
 
   For offline clusters where \code{available.packages()} is not available,
   manually download the packages database from

--- a/man/spark_apply.Rd
+++ b/man/spark_apply.Rd
@@ -25,7 +25,15 @@ adds indexed column names when not enough columns are specified.}
 \item{group_by}{Column name used to group by data frame partitions.}
 
 \item{packages}{Boolean to distribute \code{.libPaths()} packages to each node,
-  or a list of packages to distribute.
+  a list of packages to distribute, or a package bundle created with
+  \code{spark_apply_bundle()}.
+
+  For clusters using Livy or Yarn cluster mode, \code{packages} must
+  point to a package bundle path created using \code{spark_apply_bundle()}
+  and made available as a Spark file. For Yarn cluster mode, the bundle
+  can be registered as a Spark file using \code{config$sparklyr.shell.files}.
+  For Livy, this bundle must be copied into the cluster and then made available
+  using \code{invoke(spark_context(sc), "addFile", "<path-to-file>")}.
 
   For offline clusters where \code{available.packages()} is not available,
   manually download the packages database from

--- a/man/spark_apply_bundle.Rd
+++ b/man/spark_apply_bundle.Rd
@@ -2,14 +2,15 @@
 % Please edit documentation in R/spark_apply_bundle.R
 \name{spark_apply_bundle}
 \alias{spark_apply_bundle}
-\title{Creates a bundle of dependencies required by \code{spark_apply()}}
+\title{Create Bundle for Spark Apply}
 \usage{
-spark_apply_bundle(packages = TRUE)
+spark_apply_bundle(packages = TRUE, base_path = getwd())
 }
 \arguments{
 \item{packages}{List of packages to pack or \code{TRUE} to pack all.}
+
+\item{base_path}{Base path used to store the resulting bundle.}
 }
 \description{
-Creates a bundle of dependencies required by \code{spark_apply()}
+Creates a bundle of packages for \code{spark_apply()}.
 }
-\keyword{internal}

--- a/tests/testthat/test-spark-apply-bundle.R
+++ b/tests/testthat/test-spark-apply-bundle.R
@@ -34,8 +34,8 @@ test_that("'spark_apply_packages' uses different names for different packages", 
 })
 
 test_that("'spark_apply_bundle_file' uses different names for different packages", {
-  broom_file <- spark_apply_bundle_file(spark_apply_packages("broom"))
-  tidyr_file <- spark_apply_bundle_file(spark_apply_packages("tidyr"))
+  broom_file <- spark_apply_bundle_file(spark_apply_packages("broom"), tempdir())
+  tidyr_file <- spark_apply_bundle_file(spark_apply_packages("tidyr"), tempdir())
 
   expect_true(broom_file != tidyr_file)
 })


### PR DESCRIPTION
Adds support for `spark_apply()` under `yarn-cluster` using `spark_apply_bundle()` as a helper function to generate the package bundle.

Sample use for `yarn-cluster`:

```r
dplyr_bundle <- spark_apply_bundle("dplyr")

config <- spark_config()
config$sparklyr.shell.files <- dplyr_bundle
sc <- spark_connect(master = "yarn-cluster", config = config)

iris_tbl <- sdf_copy_to(sc, iris)
spark_apply(iris_tbl, function(df) {
    library(dplyr)
    df %>% select(Sepal_Length)
}, packages = dplyr_bundle)
```