### PR TITLE
Fix broken h2o under sparklyr with older cran version

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -289,7 +289,7 @@ The RStudio IDE features for sparklyr are available now as part of the [RStudio 
 [rsparkling](https://cran.r-project.org/package=rsparkling) is a CRAN package from [H2O](http://h2o.ai) that extends [sparklyr](http://spark.rstudio.com) to provide an interface into [Sparkling Water](https://github.com/h2oai/sparkling-water). For instance, the following example installs, configures and runs [h2o.glm](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html):
 
 ```{r results='hide', message=FALSE}
-options(rsparkling.sparklingwater.version = "2.1.0")
+options(rsparkling.sparklingwater.version = "2.1.14")
 
 library(rsparkling)
 library(sparklyr)

--- a/README.md
+++ b/README.md
@@ -191,15 +191,12 @@ partitions <- mtcars_tbl %>%
 # fit a linear model to the training dataset
 fit <- partitions$training %>%
   ml_linear_regression(response = "mpg", features = c("wt", "cyl"))
-```
-
-    ## * No rows dropped by 'na.omit' call
-
-``` r
 fit
 ```
 
-    ## Call: ml_linear_regression(., response = "mpg", features = c("wt", "cyl"))
+    ## Call: ml_linear_regression.tbl_spark(., response = "mpg", features = c("wt", "cyl"))  
+    ## 
+    ## Formula: mpg ~ wt + cyl
     ## 
     ## Coefficients:
     ## (Intercept)          wt         cyl 
@@ -211,24 +208,20 @@ For linear regression models produced by Spark, we can use `summary()` to learn 
 summary(fit)
 ```
 
-    ## Call: ml_linear_regression(., response = "mpg", features = c("wt", "cyl"))
+    ## Call: ml_linear_regression.tbl_spark(., response = "mpg", features = c("wt", "cyl"))  
     ## 
-    ## Deviance Residuals::
+    ## Deviance Residuals:
     ##    Min     1Q Median     3Q    Max 
     ## -1.752 -1.134 -0.499  1.296  2.282 
     ## 
     ## Coefficients:
-    ##             Estimate Std. Error t value  Pr(>|t|)    
-    ## (Intercept) 33.49945    3.62256  9.2475 0.0002485 ***
-    ## wt          -2.81846    0.96619 -2.9171 0.0331257 *  
-    ## cyl         -0.92319    0.54639 -1.6896 0.1518998    
-    ## ---
-    ## Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+    ## (Intercept)          wt         cyl 
+    ##   33.499452   -2.818463   -0.923187 
     ## 
     ## R-Squared: 0.8274
     ## Root Mean Squared Error: 1.422
 
-Spark machine learning supports a wide array of algorithms and feature transformations and as illustrated above it's easy to chain these functions together with dplyr pipelines. To learn more see the [machine learning](https://github.com/rstudio/sparklyr/blob/master/docs/articles/mllib.html) section.
+Spark machine learning supports a wide array of algorithms and feature transformations and as illustrated above it's easy to chain these functions together with dplyr pipelines. To learn more see the [machine learning](mllib.html) section.
 
 Reading and Writing Data
 ------------------------
@@ -266,20 +259,20 @@ spark_apply(iris_tbl, function(data) {
 })
 ```
 
-    ## # Source:   table<sparklyr_tmp_117d835ce14f9> [?? x 4]
+    ## # Source:   table<sparklyr_tmp_115c74acb6510> [?? x 4]
     ## # Database: spark_connection
     ##    Sepal_Length Sepal_Width Petal_Length Petal_Width
     ##           <dbl>       <dbl>        <dbl>       <dbl>
-    ##  1     9.983684    8.383684     6.283684    5.083684
-    ##  2     9.783684    7.883684     6.283684    5.083684
-    ##  3     9.583684    8.083684     6.183684    5.083684
-    ##  4     9.483684    7.983684     6.383684    5.083684
-    ##  5     9.883684    8.483684     6.283684    5.083684
-    ##  6    10.283684    8.783684     6.583684    5.283684
-    ##  7     9.483684    8.283684     6.283684    5.183684
-    ##  8     9.883684    8.283684     6.383684    5.083684
-    ##  9     9.283684    7.783684     6.283684    5.083684
-    ## 10     9.783684    7.983684     6.383684    4.983684
+    ##  1     5.336757    3.736757     1.636757   0.4367573
+    ##  2     5.136757    3.236757     1.636757   0.4367573
+    ##  3     4.936757    3.436757     1.536757   0.4367573
+    ##  4     4.836757    3.336757     1.736757   0.4367573
+    ##  5     5.236757    3.836757     1.636757   0.4367573
+    ##  6     5.636757    4.136757     1.936757   0.6367573
+    ##  7     4.836757    3.636757     1.636757   0.5367573
+    ##  8     5.236757    3.636757     1.736757   0.4367573
+    ##  9     4.636757    3.136757     1.636757   0.4367573
+    ## 10     5.136757    3.336757     1.736757   0.3367573
     ## # ... with more rows
 
 You can also group by columns to perform an operation over each group of rows and make use of any package within the closure:
@@ -293,7 +286,7 @@ spark_apply(
 )
 ```
 
-    ## # Source:   table<sparklyr_tmp_117d876fbf859> [?? x 6]
+    ## # Source:   table<sparklyr_tmp_115c73965f30> [?? x 6]
     ## # Database: spark_connection
     ##      Species         term    estimate  std.error  statistic      p.value
     ##        <chr>        <chr>       <dbl>      <dbl>      <dbl>        <dbl>
@@ -361,16 +354,16 @@ You can show the log using the `spark_log` function:
 spark_log(sc, n = 10)
 ```
 
-    ## 17/08/25 12:54:28 INFO DAGScheduler: Submitting 1 missing tasks from ResultStage 72 (/var/folders/vd/krh_y3qd0c5bw8k77lmdtw7r0000gn/T//Rtmps6VbEg/file117d8538598e1.csv MapPartitionsRDD[293] at textFile at NativeMethodAccessorImpl.java:0)
-    ## 17/08/25 12:54:28 INFO TaskSchedulerImpl: Adding task set 72.0 with 1 tasks
-    ## 17/08/25 12:54:28 INFO TaskSetManager: Starting task 0.0 in stage 72.0 (TID 112, localhost, executor driver, partition 0, PROCESS_LOCAL, 6010 bytes)
-    ## 17/08/25 12:54:28 INFO Executor: Running task 0.0 in stage 72.0 (TID 112)
-    ## 17/08/25 12:54:28 INFO HadoopRDD: Input split: file:/var/folders/vd/krh_y3qd0c5bw8k77lmdtw7r0000gn/T/Rtmps6VbEg/file117d8538598e1.csv:0+33313106
-    ## 17/08/25 12:54:28 INFO Executor: Finished task 0.0 in stage 72.0 (TID 112). 1123 bytes result sent to driver
-    ## 17/08/25 12:54:28 INFO TaskSetManager: Finished task 0.0 in stage 72.0 (TID 112) in 114 ms on localhost (executor driver) (1/1)
-    ## 17/08/25 12:54:28 INFO TaskSchedulerImpl: Removed TaskSet 72.0, whose tasks have all completed, from pool 
-    ## 17/08/25 12:54:28 INFO DAGScheduler: ResultStage 72 (count at NativeMethodAccessorImpl.java:0) finished in 0.114 s
-    ## 17/08/25 12:54:28 INFO DAGScheduler: Job 49 finished: count at NativeMethodAccessorImpl.java:0, took 0.117630 s
+    ## 17/11/09 15:55:18 INFO DAGScheduler: Submitting 1 missing tasks from ResultStage 69 (/var/folders/fz/v6wfsg2x1fb1rw4f6r0x4jwm0000gn/T//RtmpyR8oP9/file115c74b94924.csv MapPartitionsRDD[258] at textFile at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0))
+    ## 17/11/09 15:55:18 INFO TaskSchedulerImpl: Adding task set 69.0 with 1 tasks
+    ## 17/11/09 15:55:18 INFO TaskSetManager: Starting task 0.0 in stage 69.0 (TID 140, localhost, executor driver, partition 0, PROCESS_LOCAL, 4904 bytes)
+    ## 17/11/09 15:55:18 INFO Executor: Running task 0.0 in stage 69.0 (TID 140)
+    ## 17/11/09 15:55:18 INFO HadoopRDD: Input split: file:/var/folders/fz/v6wfsg2x1fb1rw4f6r0x4jwm0000gn/T/RtmpyR8oP9/file115c74b94924.csv:0+33313106
+    ## 17/11/09 15:55:18 INFO Executor: Finished task 0.0 in stage 69.0 (TID 140). 832 bytes result sent to driver
+    ## 17/11/09 15:55:18 INFO TaskSetManager: Finished task 0.0 in stage 69.0 (TID 140) in 126 ms on localhost (executor driver) (1/1)
+    ## 17/11/09 15:55:18 INFO TaskSchedulerImpl: Removed TaskSet 69.0, whose tasks have all completed, from pool 
+    ## 17/11/09 15:55:18 INFO DAGScheduler: ResultStage 69 (count at NativeMethodAccessorImpl.java:0) finished in 0.126 s
+    ## 17/11/09 15:55:18 INFO DAGScheduler: Job 47 finished: count at NativeMethodAccessorImpl.java:0, took 0.131380 s
 
 Finally, we disconnect from Spark:
 
@@ -407,7 +400,7 @@ Using H2O
 [rsparkling](https://cran.r-project.org/package=rsparkling) is a CRAN package from [H2O](http://h2o.ai) that extends [sparklyr](http://spark.rstudio.com) to provide an interface into [Sparkling Water](https://github.com/h2oai/sparkling-water). For instance, the following example installs, configures and runs [h2o.glm](http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html):
 
 ``` r
-options(rsparkling.sparklingwater.version = "2.1.0")
+options(rsparkling.sparklingwater.version = "2.1.14")
 
 library(rsparkling)
 library(sparklyr)
@@ -433,7 +426,7 @@ mtcars_glm
     ## ==============
     ## 
     ## H2ORegressionModel: glm
-    ## Model ID:  GLM_model_R_1503683692912_1 
+    ## Model ID:  GLM_model_R_1510271749678_1 
     ## GLM Model: summary
     ##     family     link                              regularization
     ## 1 gaussian identity Elastic Net (alpha = 0.5, lambda = 0.1013 )
@@ -442,7 +435,7 @@ mtcars_glm
     ##   number_of_predictors_total number_of_active_predictors
     ## 1                          2                           2
     ##   number_of_iterations                                training_frame
-    ## 1                    0 frame_rdd_29_970371551cefadb7219d3e25e94a4bc0
+    ## 1                  100 frame_rdd_29_b907d4915799eac74fb1ea60ad594bbf
     ## 
     ## Coefficients: glm coefficients
     ##       names coefficients standardized_coefficients

--- a/docs/articles/guides-h2o.html
+++ b/docs/articles/guides-h2o.html
@@ -42,25 +42,7 @@
   </a>
   <ul class="dropdown-menu" role="menu">
 <li>
-      <a href="../articles/guides-dplyr.html">dplyr</a>
-    </li>
-    <li>
-      <a href="../articles/guides-mllib.html">mllib</a>
-    </li>
-    <li>
-      <a href="../articles/guides-distributed-r.html">Distributed R</a>
-    </li>
-    <li>
-      <a href="../articles/deployment-connections.html">User connection options</a>
-    </li>
-    <li>
-      <a href="../articles/guides-caching.html">Caching</a>
-    </li>
-    <li>
       <a href="../articles/guides-h2o.html">H2O</a>
-    </li>
-    <li>
-      <a href="../articles/guides-extensions.html">Extensions</a>
     </li>
   </ul>
 </li>
@@ -154,7 +136,7 @@
 <p>You can install the <strong>rsparkling</strong> package from CRAN as follows:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">install.packages</span>(<span class="st">"rsparkling"</span>)</code></pre></div>
 <p>Then set the Sparkling Water version for rsparkling.:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">rsparkling.sparklingwater.version =</span> <span class="st">"2.1.0"</span>)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">rsparkling.sparklingwater.version =</span> <span class="st">"2.1.14"</span>)</code></pre></div>
 <p>For Spark <code>2.0.x</code> set <code>rsparkling.sparklingwater.version</code> to <code>2.0.3</code> instead, for Spark <code>1.6.2</code> use <code>1.6.8</code>.</p>
 </div>
 <div id="using-h2o" class="section level2">
@@ -162,8 +144,9 @@
 <a href="#using-h2o" class="anchor"></a>Using H2O</h2>
 <p>Now let’s walk through a simple example to demonstrate the use of H2O’s machine learning algorithms within R. We’ll use <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html">h2o.glm</a> to fit a linear regression model. Using the built-in <code>mtcars</code> dataset, we’ll try to predict a car’s fuel consumption (<code>mpg</code>) based on its weight (<code>wt</code>), and the number of cylinders the engine contains (<code>cyl</code>).</p>
 <p>First, we will initialize a local Spark connection, and copy the <code>mtcars</code> dataset into Spark.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(rsparkling)
-<span class="kw">library</span>(sparklyr)
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(rsparkling)</code></pre></div>
+<pre><code>## Warning: package 'rsparkling' was built under R version 3.4.2</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(sparklyr)
 <span class="kw">library</span>(h2o)
 <span class="kw">library</span>(dplyr)
 
@@ -184,14 +167,8 @@ partitions &lt;-<span class="st"> </span>mtcars_tbl <span class="op">%&gt;%</spa
 <span class="st">  </span><span class="kw"><a href="http://dplyr.tidyverse.org/reference/mutate.html">mutate</a></span>(<span class="dt">cyl8 =</span> cyl <span class="op">==</span><span class="st"> </span><span class="dv">8</span>) <span class="op">%&gt;%</span>
 <span class="st">  </span><span class="kw"><a href="../reference/sdf_partition.html">sdf_partition</a></span>(<span class="dt">training =</span> <span class="fl">0.5</span>, <span class="dt">test =</span> <span class="fl">0.5</span>, <span class="dt">seed =</span> <span class="dv">1099</span>)</code></pre></div>
 <p>Now, we convert our training and test sets into H2O Frames using rsparkling conversion functions. We have already split the data into training and test frames using dplyr.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">training &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/rsparkling/topics/as_h2o_frame">as_h2o_frame</a></span>(sc, partitions<span class="op">$</span>training, <span class="dt">strict_version_check =</span> <span class="ot">FALSE</span>)</code></pre></div>
-<pre><code>## Warning in h2o.clusterInfo(): 
-## Your H2O cluster version is too old (6 months and 25 days)!
-## Please download and install the latest version from http://h2o.ai/download/</code></pre>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">test &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/rsparkling/topics/as_h2o_frame">as_h2o_frame</a></span>(sc, partitions<span class="op">$</span>test, <span class="dt">strict_version_check =</span> <span class="ot">FALSE</span>)</code></pre></div>
-<pre><code>## Warning in h2o.clusterInfo(): 
-## Your H2O cluster version is too old (6 months and 25 days)!
-## Please download and install the latest version from http://h2o.ai/download/</code></pre>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">training &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/rsparkling/topics/as_h2o_frame">as_h2o_frame</a></span>(sc, partitions<span class="op">$</span>training, <span class="dt">strict_version_check =</span> <span class="ot">FALSE</span>)
+test &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/rsparkling/topics/as_h2o_frame">as_h2o_frame</a></span>(sc, partitions<span class="op">$</span>test, <span class="dt">strict_version_check =</span> <span class="ot">FALSE</span>)</code></pre></div>
 <p>Alternatively, we can use the <code><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.splitFrame">h2o.splitFrame()</a></code> function instead of <code><a href="../reference/sdf_partition.html">sdf_partition()</a></code> to partition the data within H2O instead of Spark (e.g. <code>partitions &lt;- h2o.splitFrame(as_h2o_frame(mtcars_tbl), 0.5)</code>)</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># fit a linear model to the training dataset</span>
 glm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.glm">h2o.glm</a></span>(<span class="dt">x =</span> <span class="kw">c</span>(<span class="st">"wt"</span>, <span class="st">"cyl"</span>), 
@@ -204,7 +181,7 @@ glm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdo
 ## ==============
 ## 
 ## H2ORegressionModel: glm
-## Model ID:  GLM_model_R_1503684109678_1 
+## Model ID:  GLM_model_R_1510272550151_1 
 ## GLM Model: summary
 ##     family     link                               regularization
 ## 1 gaussian identity Elastic Net (alpha = 0.5, lambda = 0.05468 )
@@ -212,8 +189,8 @@ glm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdo
 ## 1 nlambda = 100, lambda.max = 5.4682, lambda.min = 0.05468, lambda.1se = -1.0
 ##   number_of_predictors_total number_of_active_predictors
 ## 1                          2                           2
-##   number_of_iterations                               training_frame
-## 1                    0 frame_rdd_32_8d800eecc2806f51fa504de54664e58
+##   number_of_iterations                                training_frame
+## 1                  100 frame_rdd_32_9f8c8e7e26090886a016a3b3bfdf40a2
 ## 
 ## Coefficients: glm coefficients
 ##       names coefficients standardized_coefficients
@@ -490,12 +467,16 @@ iris_tbl</code></pre></div>
                         <span class="dt">x =</span> <span class="dv">1</span><span class="op">:</span><span class="dv">4</span>,
                         <span class="dt">k =</span> <span class="dv">4</span>,
                         <span class="dt">seed =</span> <span class="dv">1</span>)</code></pre></div>
+<pre><code>## Warning in doTryCatch(return(expr), name, parentenv, handler): _train:
+## Dataset used may contain fewer number of rows due to removal of rows with
+## NA/missing values. If this is not desirable, set impute_missing argument in
+## pca call to TRUE/True/true/... depending on the client language.</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">pca_model</code></pre></div>
 <pre><code>## Model Details:
 ## ==============
 ## 
 ## H2ODimReductionModel: pca
-## Model ID:  PCA_model_R_1503684109678_3 
+## Model ID:  PCA_model_R_1510272550151_3 
 ## Importance of components: 
 ##                             pc1      pc2      pc3      pc4
 ## Standard deviation     7.861342 1.455041 0.283531 0.154411
@@ -528,7 +509,7 @@ iris_hf[,y] &lt;-<span class="st"> </span><span class="kw"><a href="http://www.r
                              <span class="dt">seed =</span> <span class="dv">1</span>)</code></pre></div>
 <p>Since we passed a validation frame, the validation metrics will be calculated. We can retrieve individual metrics using functions such as <code><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.mse">h2o.mse(rf_model, valid = TRUE)</a></code>. The confusion matrix can be printed using the following:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.confusionMatrix">h2o.confusionMatrix</a></span>(rf_model, <span class="dt">valid =</span> <span class="ot">TRUE</span>)</code></pre></div>
-<pre><code>## Confusion Matrix: vertical: actual; across: predicted
+<pre><code>## Confusion Matrix: Row labels: Actual class; Column labels: Predicted class
 ##            setosa versicolor virginica  Error     Rate
 ## setosa          7          0         0 0.0000 =  0 / 7
 ## versicolor      0         13         0 0.0000 = 0 / 13
@@ -554,7 +535,7 @@ iris_hf[,y] &lt;-<span class="st"> </span><span class="kw"><a href="http://www.r
                      <span class="dt">seed =</span> <span class="dv">1</span>)</code></pre></div>
 <p>Since this is a multi-class problem, we may be interested in inspecting the confusion matrix on a hold-out set. Since we passed along a <code>validatin_frame</code> at train time, the validation metrics are already computed and we just need to retreive them from the model object.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.confusionMatrix">h2o.confusionMatrix</a></span>(gbm_model, <span class="dt">valid =</span> <span class="ot">TRUE</span>)</code></pre></div>
-<pre><code>## Confusion Matrix: vertical: actual; across: predicted
+<pre><code>## Confusion Matrix: Row labels: Actual class; Column labels: Predicted class
 ##            setosa versicolor virginica  Error     Rate
 ## setosa          7          0         0 0.0000 =  0 / 7
 ## versicolor      0         13         0 0.0000 = 0 / 13
@@ -597,11 +578,11 @@ x &lt;-<span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.performance">h2o.performance</a></span>(dl_fit, <span class="dt">newdata =</span> splits[[<span class="dv">2</span>]])</code></pre></div>
 <pre><code>## H2ORegressionMetrics: deeplearning
 ## 
-## MSE:  279.1715
-## RMSE:  16.70843
-## MAE:  13.18417
-## RMSLE:  1.879956
-## Mean Residual Deviance :  279.1715</code></pre>
+## MSE:  280.7796
+## RMSE:  16.75648
+## MAE:  13.85877
+## RMSLE:  1.968329
+## Mean Residual Deviance :  280.7796</code></pre>
 <p>Note that the above metrics are not reproducible when H2O’s Deep Learning is run on multiple cores, however, the metrics should be fairly stable across repeat runs.</p>
 </div>
 <div id="grid-search" class="section level3">
@@ -728,9 +709,9 @@ gbm_gridperf2 &lt;-<span class="st"> </span><span class="kw"><a href="http://www
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">gbm_gridperf2<span class="op">@</span>summary_table[<span class="dv">1</span>,]</code></pre></div>
 <pre><code>## Hyper-Parameter Search Summary: ordered by increasing mse
 ##   col_sample_rate learn_rate max_depth sample_rate          model_ids
-## 1             0.4       0.01         5         0.5 gbm_grid2_model_31
+## 1             1.0       0.01         3         1.0 gbm_grid2_model_37
 ##                  mse
-## 1 249.34100191149807</code></pre>
+## 1 244.98771263058234</code></pre>
 <p>In the examples above, we generated two different grids, specified by <code>grid_id</code>. The first grid was called <code>grid_id = "gbm_grid1"</code> and the second was called <code>grid_id = "gbm_grid2"</code>. However, if we are using the same dataset &amp; algorithm in two grid searches, it probably makes more sense just to add the results of the second grid search to the first. If you want to add models to an existing grid, rather than create a new one, you simply re-use the same <code>grid_id</code>.</p>
 </div>
 </div>
@@ -791,7 +772,7 @@ gbm_gridperf2 &lt;-<span class="st"> </span><span class="kw"><a href="http://www
 
 
       <footer><div class="copyright">
-  <p>Developed by Javier Luraschi, Kevin Ushey, JJ Allaire,  The Apache Software Foundation.</p>
+  <p>Developed by Javier Luraschi, Kevin Kuo, Kevin Ushey, JJ Allaire,  The Apache Software Foundation.</p>
 </div>
 
 <div class="pkgdown">

--- a/docs/articles/guides-h2o.html
+++ b/docs/articles/guides-h2o.html
@@ -37,19 +37,37 @@
 <li class="dropdown">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
     Guides
-     
+
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" role="menu">
 <li>
+      <a href="../articles/guides-dplyr.html">dplyr</a>
+    </li>
+    <li>
+      <a href="../articles/guides-mllib.html">mllib</a>
+    </li>
+    <li>
+      <a href="../articles/guides-distributed-r.html">Distributed R</a>
+    </li>
+    <li>
+      <a href="../articles/deployment-connections.html">User connection options</a>
+    </li>
+    <li>
+      <a href="../articles/guides-caching.html">Caching</a>
+    </li>
+    <li>
       <a href="../articles/guides-h2o.html">H2O</a>
+    </li>
+    <li>
+      <a href="../articles/guides-extensions.html">Extensions</a>
     </li>
   </ul>
 </li>
 <li class="dropdown">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
     Deployment
-     
+
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" role="menu">
@@ -70,7 +88,7 @@
 <li class="dropdown">
   <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">
     Reference
-     
+
     <span class="caret"></span>
   </a>
   <ul class="dropdown-menu" role="menu">
@@ -93,7 +111,7 @@
 <li>
   <a href="https://github.com/rstudio/sparklyr">
     <span class="fa fa-github"></span>
-     
+
   </a>
 </li>
       </ul>
@@ -104,16 +122,16 @@
 </div>
 <!--/.navbar -->
 
-      
+
       </header><div class="row">
   <div class="col-md-9">
     <div class="page-header toc-ignore">
       <h1>Sparkling Water (H2O) Machine Learning</h1>
-            
+
           </div>
 
-    
-    
+
+
 <div class="contents">
 <div id="overview" class="section level2">
 <h2 class="hasAnchor">
@@ -171,17 +189,17 @@ partitions &lt;-<span class="st"> </span>mtcars_tbl <span class="op">%&gt;%</spa
 test &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/rsparkling/topics/as_h2o_frame">as_h2o_frame</a></span>(sc, partitions<span class="op">$</span>test, <span class="dt">strict_version_check =</span> <span class="ot">FALSE</span>)</code></pre></div>
 <p>Alternatively, we can use the <code><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.splitFrame">h2o.splitFrame()</a></code> function instead of <code><a href="../reference/sdf_partition.html">sdf_partition()</a></code> to partition the data within H2O instead of Spark (e.g. <code>partitions &lt;- h2o.splitFrame(as_h2o_frame(mtcars_tbl), 0.5)</code>)</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># fit a linear model to the training dataset</span>
-glm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.glm">h2o.glm</a></span>(<span class="dt">x =</span> <span class="kw">c</span>(<span class="st">"wt"</span>, <span class="st">"cyl"</span>), 
-                     <span class="dt">y =</span> <span class="st">"mpg"</span>, 
+glm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.glm">h2o.glm</a></span>(<span class="dt">x =</span> <span class="kw">c</span>(<span class="st">"wt"</span>, <span class="st">"cyl"</span>),
+                     <span class="dt">y =</span> <span class="st">"mpg"</span>,
                      <span class="dt">training_frame =</span> training,
                      <span class="dt">lambda_search =</span> <span class="ot">TRUE</span>)</code></pre></div>
 <p>For linear regression models produced by H2O, we can use either <code>print()</code> or <code>summary()</code> to learn a bit more about the quality of our fit. The <code>summary()</code> method returns some extra information about scoring history and variable importance.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">glm_model</code></pre></div>
 <pre><code>## Model Details:
 ## ==============
-## 
+##
 ## H2ORegressionModel: glm
-## Model ID:  GLM_model_R_1510272550151_1 
+## Model ID:  GLM_model_R_1510272550151_1
 ## GLM Model: summary
 ##     family     link                               regularization
 ## 1 gaussian identity Elastic Net (alpha = 0.5, lambda = 0.05468 )
@@ -191,16 +209,16 @@ glm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdo
 ## 1                          2                           2
 ##   number_of_iterations                                training_frame
 ## 1                  100 frame_rdd_32_9f8c8e7e26090886a016a3b3bfdf40a2
-## 
+##
 ## Coefficients: glm coefficients
 ##       names coefficients standardized_coefficients
 ## 1 Intercept    32.997281                 16.625000
 ## 2       cyl    -0.906688                 -1.349195
 ## 3        wt    -2.712562                 -2.282649
-## 
+##
 ## H2ORegressionMetrics: glm
 ## ** Reported on training data. **
-## 
+##
 ## MSE:  2.03293
 ## RMSE:  1.425808
 ## MAE:  1.306314
@@ -440,7 +458,7 @@ iris_tbl</code></pre></div>
 <h3 class="hasAnchor">
 <a href="#k-means-clustering" class="anchor"></a>K-Means Clustering</h3>
 <p>Use H2O’s <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/k-means.html">K-means clustering</a> to partition a dataset into groups. K-means clustering partitions points into <code>k</code> groups, such that the sum of squares from points to the assigned cluster centers is minimized.</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">kmeans_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.kmeans">h2o.kmeans</a></span>(<span class="dt">training_frame =</span> iris_hf, 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">kmeans_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.kmeans">h2o.kmeans</a></span>(<span class="dt">training_frame =</span> iris_hf,
                            <span class="dt">x =</span> <span class="dv">3</span><span class="op">:</span><span class="dv">4</span>,
                            <span class="dt">k =</span> <span class="dv">3</span>,
                            <span class="dt">seed =</span> <span class="dv">1</span>)</code></pre></div>
@@ -453,7 +471,7 @@ iris_tbl</code></pre></div>
 ## 3     4.296154     1.32500</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># print the centroid statistics</span>
 <span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.centroid_stats">h2o.centroid_stats</a></span>(kmeans_model)</code></pre></div>
-<pre><code>## Centroid Statistics: 
+<pre><code>## Centroid Statistics:
 ##   centroid     size within_cluster_sum_of_squares
 ## 1        1 50.00000                       1.41087
 ## 2        2 48.00000                       9.29317
@@ -474,18 +492,18 @@ iris_tbl</code></pre></div>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">pca_model</code></pre></div>
 <pre><code>## Model Details:
 ## ==============
-## 
+##
 ## H2ODimReductionModel: pca
-## Model ID:  PCA_model_R_1510272550151_3 
-## Importance of components: 
+## Model ID:  PCA_model_R_1510272550151_3
+## Importance of components:
 ##                             pc1      pc2      pc3      pc4
 ## Standard deviation     7.861342 1.455041 0.283531 0.154411
 ## Proportion of Variance 0.965303 0.033069 0.001256 0.000372
 ## Cumulative Proportion  0.965303 0.998372 0.999628 1.000000
-## 
-## 
+##
+##
 ## H2ODimReductionMetrics: pca
-## 
+##
 ## No model metrics available for PCA</code></pre>
 </div>
 <div id="random-forest" class="section level3">
@@ -499,7 +517,7 @@ iris_hf[,y] &lt;-<span class="st"> </span><span class="kw"><a href="http://www.r
 <p>We can split the <code>iris_hf</code> H2O Frame into a train and test set (the split defaults to 75/25 train/test).</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">splits &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.splitFrame">h2o.splitFrame</a></span>(iris_hf, <span class="dt">seed =</span> <span class="dv">1</span>)</code></pre></div>
 <p>Then we can train a Random Forest model:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">rf_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.randomForest">h2o.randomForest</a></span>(<span class="dt">x =</span> x, 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">rf_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.randomForest">h2o.randomForest</a></span>(<span class="dt">x =</span> x,
                              <span class="dt">y =</span> y,
                              <span class="dt">training_frame =</span> splits[[<span class="dv">1</span>]],
                              <span class="dt">validation_frame =</span> splits[[<span class="dv">2</span>]],
@@ -524,10 +542,10 @@ iris_hf[,y] &lt;-<span class="st"> </span><span class="kw"><a href="http://www.r
 <a href="#gradient-boosting-machine" class="anchor"></a>Gradient Boosting Machine</h3>
 <p>The <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/gbm.html">Gradient Boosting Machine (GBM)</a> is one of H2O’s most popular algorithms, as it works well on many types of data. We will continue to use the iris dataset as an example for this problem.</p>
 <p>Using the same dataset and <code>x</code> and <code>y</code> from above, we can train a GBM:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">gbm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.gbm">h2o.gbm</a></span>(<span class="dt">x =</span> x, 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">gbm_model &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.gbm">h2o.gbm</a></span>(<span class="dt">x =</span> x,
                      <span class="dt">y =</span> y,
                      <span class="dt">training_frame =</span> splits[[<span class="dv">1</span>]],
-                     <span class="dt">validation_frame =</span> splits[[<span class="dv">2</span>]],                     
+                     <span class="dt">validation_frame =</span> splits[[<span class="dv">2</span>]],
                      <span class="dt">ntrees =</span> <span class="dv">20</span>,
                      <span class="dt">max_depth =</span> <span class="dv">3</span>,
                      <span class="dt">learn_rate =</span> <span class="fl">0.01</span>,
@@ -577,7 +595,7 @@ x &lt;-<span class="st"> </span><span class="kw"><a href="http://dplyr.tidyverse
 <p>Evaluate performance on a test set:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.performance">h2o.performance</a></span>(dl_fit, <span class="dt">newdata =</span> splits[[<span class="dv">2</span>]])</code></pre></div>
 <pre><code>## H2ORegressionMetrics: deeplearning
-## 
+##
 ## MSE:  280.7796
 ## RMSE:  16.75648
 ## MAE:  13.85877
@@ -632,22 +650,22 @@ gbm_grid1 &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdo
                       <span class="dt">hyper_params =</span> gbm_params1)
 
 <span class="co"># Get the grid results, sorted by validation MSE</span>
-gbm_gridperf1 &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.getGrid">h2o.getGrid</a></span>(<span class="dt">grid_id =</span> <span class="st">"gbm_grid1"</span>, 
-                             <span class="dt">sort_by =</span> <span class="st">"mse"</span>, 
+gbm_gridperf1 &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.getGrid">h2o.getGrid</a></span>(<span class="dt">grid_id =</span> <span class="st">"gbm_grid1"</span>,
+                             <span class="dt">sort_by =</span> <span class="st">"mse"</span>,
                              <span class="dt">decreasing =</span> <span class="ot">FALSE</span>)</code></pre></div>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">gbm_gridperf1</code></pre></div>
 <pre><code>## H2O Grid Details
 ## ================
-## 
-## Grid ID: gbm_grid1 
-## Used hyper parameters: 
-##   -  col_sample_rate 
-##   -  learn_rate 
-##   -  max_depth 
-##   -  sample_rate 
-## Number of models: 36 
-## Number of failed models: 0 
-## 
+##
+## Grid ID: gbm_grid1
+## Used hyper parameters:
+##   -  col_sample_rate
+##   -  learn_rate
+##   -  max_depth
+##   -  sample_rate
+## Number of models: 36
+## Number of failed models: 0
+##
 ## Hyper-Parameter Search Summary: ordered by increasing mse
 ##   col_sample_rate learn_rate max_depth sample_rate          model_ids
 ## 1             1.0        0.1         9         1.0 gbm_grid1_model_35
@@ -661,7 +679,7 @@ gbm_gridperf1 &lt;-<span class="st"> </span><span class="kw"><a href="http://www
 ## 3 102.78632321923726
 ## 4  126.4217260351778
 ## 5  149.6066650109763
-## 
+##
 ## ---
 ##    col_sample_rate learn_rate max_depth sample_rate          model_ids
 ## 31             0.5       0.01         3         0.8  gbm_grid1_model_1
@@ -688,7 +706,7 @@ gbm_params2 &lt;-<span class="st"> </span><span class="kw">list</span>(<span cla
                     <span class="dt">max_depth =</span> <span class="kw">seq</span>(<span class="dv">2</span>, <span class="dv">10</span>, <span class="dv">1</span>),
                     <span class="dt">sample_rate =</span> <span class="kw">seq</span>(<span class="fl">0.5</span>, <span class="fl">1.0</span>, <span class="fl">0.1</span>),
                     <span class="dt">col_sample_rate =</span> <span class="kw">seq</span>(<span class="fl">0.1</span>, <span class="fl">1.0</span>, <span class="fl">0.1</span>))
-search_criteria2 &lt;-<span class="st"> </span><span class="kw">list</span>(<span class="dt">strategy =</span> <span class="st">"RandomDiscrete"</span>, 
+search_criteria2 &lt;-<span class="st"> </span><span class="kw">list</span>(<span class="dt">strategy =</span> <span class="st">"RandomDiscrete"</span>,
                          <span class="dt">max_models =</span> <span class="dv">50</span>)
 
 <span class="co"># Train and validate a grid of GBMs</span>
@@ -702,8 +720,8 @@ gbm_grid2 &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdo
                       <span class="dt">search_criteria =</span> search_criteria2)
 
 <span class="co"># Get the grid results, sorted by validation MSE</span>
-gbm_gridperf2 &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.getGrid">h2o.getGrid</a></span>(<span class="dt">grid_id =</span> <span class="st">"gbm_grid2"</span>, 
-                             <span class="dt">sort_by =</span> <span class="st">"mse"</span>, 
+gbm_gridperf2 &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rdocumentation.org/packages/h2o/topics/h2o.getGrid">h2o.getGrid</a></span>(<span class="dt">grid_id =</span> <span class="st">"gbm_grid2"</span>,
+                             <span class="dt">sort_by =</span> <span class="st">"mse"</span>,
                              <span class="dt">decreasing =</span> <span class="ot">FALSE</span>)</code></pre></div>
 <p>To get the best model, as measured by validation MSE, we simply grab the first row of the <code>gbm_gridperf2@summary_table</code> object, since this table is already sorted such that the lowest MSE model is on top.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">gbm_gridperf2<span class="op">@</span>summary_table[<span class="dv">1</span>,]</code></pre></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -271,29 +271,26 @@ partitions &lt;-<span class="st"> </span>mtcars_tbl <span class="op">%&gt;%</spa
 
 <span class="co"># fit a linear model to the training dataset</span>
 fit &lt;-<span class="st"> </span>partitions<span class="op">$</span>training <span class="op">%&gt;%</span>
-<span class="st">  </span><span class="kw"><a href="reference/ml_linear_regression.html">ml_linear_regression</a></span>(<span class="dt">response =</span> <span class="st">"mpg"</span>, <span class="dt">features =</span> <span class="kw">c</span>(<span class="st">"wt"</span>, <span class="st">"cyl"</span>))</code></pre></div>
-<pre><code>## * No rows dropped by 'na.omit' call</code></pre>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">fit</code></pre></div>
-<pre><code>## Call: ml_linear_regression(., response = "mpg", features = c("wt", "cyl"))
+<span class="st">  </span><span class="kw"><a href="reference/ml_linear_regression.html">ml_linear_regression</a></span>(<span class="dt">response =</span> <span class="st">"mpg"</span>, <span class="dt">features =</span> <span class="kw">c</span>(<span class="st">"wt"</span>, <span class="st">"cyl"</span>))
+fit</code></pre></div>
+<pre><code>## Call: ml_linear_regression.tbl_spark(., response = "mpg", features = c("wt", "cyl"))  
+## 
+## Formula: mpg ~ wt + cyl
 ## 
 ## Coefficients:
 ## (Intercept)          wt         cyl 
 ##   33.499452   -2.818463   -0.923187</code></pre>
 <p>For linear regression models produced by Spark, we can use <code>summary()</code> to learn a bit more about the quality of our fit, and the statistical significance of each of our predictors.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">summary</span>(fit)</code></pre></div>
-<pre><code>## Call: ml_linear_regression(., response = "mpg", features = c("wt", "cyl"))
+<pre><code>## Call: ml_linear_regression.tbl_spark(., response = "mpg", features = c("wt", "cyl"))  
 ## 
-## Deviance Residuals::
+## Deviance Residuals:
 ##    Min     1Q Median     3Q    Max 
 ## -1.752 -1.134 -0.499  1.296  2.282 
 ## 
 ## Coefficients:
-##             Estimate Std. Error t value  Pr(&gt;|t|)    
-## (Intercept) 33.49945    3.62256  9.2475 0.0002485 ***
-## wt          -2.81846    0.96619 -2.9171 0.0331257 *  
-## cyl         -0.92319    0.54639 -1.6896 0.1518998    
-## ---
-## Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
+## (Intercept)          wt         cyl 
+##   33.499452   -2.818463   -0.923187 
 ## 
 ## R-Squared: 0.8274
 ## Root Mean Squared Error: 1.422</code></pre>
@@ -327,20 +324,20 @@ iris_json_tbl &lt;-<span class="st"> </span><span class="kw"><a href="reference/
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/spark_apply.html">spark_apply</a></span>(iris_tbl, <span class="cf">function</span>(data) {
   data[<span class="dv">1</span><span class="op">:</span><span class="dv">4</span>] <span class="op">+</span><span class="st"> </span><span class="kw">rgamma</span>(<span class="dv">1</span>,<span class="dv">2</span>)
 })</code></pre></div>
-<pre><code>## # Source:   table&lt;sparklyr_tmp_118fd5007f7aa&gt; [?? x 4]
+<pre><code>## # Source:   table&lt;sparklyr_tmp_118c34f3123d&gt; [?? x 4]
 ## # Database: spark_connection
 ##    Sepal_Length Sepal_Width Petal_Length Petal_Width
 ##           &lt;dbl&gt;       &lt;dbl&gt;        &lt;dbl&gt;       &lt;dbl&gt;
-##  1      7.06982     5.46982      3.36982     2.16982
-##  2      6.86982     4.96982      3.36982     2.16982
-##  3      6.66982     5.16982      3.26982     2.16982
-##  4      6.56982     5.06982      3.46982     2.16982
-##  5      6.96982     5.56982      3.36982     2.16982
-##  6      7.36982     5.86982      3.66982     2.36982
-##  7      6.56982     5.36982      3.36982     2.26982
-##  8      6.96982     5.36982      3.46982     2.16982
-##  9      6.36982     4.86982      3.36982     2.16982
-## 10      6.86982     5.06982      3.46982     2.06982
+##  1     6.882104    5.282104     3.182104    1.982104
+##  2     6.682104    4.782104     3.182104    1.982104
+##  3     6.482104    4.982104     3.082104    1.982104
+##  4     6.382104    4.882104     3.282104    1.982104
+##  5     6.782104    5.382104     3.182104    1.982104
+##  6     7.182104    5.682104     3.482104    2.182104
+##  7     6.382104    5.182104     3.182104    2.082104
+##  8     6.782104    5.182104     3.282104    1.982104
+##  9     6.182104    4.682104     3.182104    1.982104
+## 10     6.682104    4.882104     3.282104    1.882104
 ## # ... with more rows</code></pre>
 <p>You can also group by columns to perform an operation over each group of rows and make use of any package within the closure:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/spark_apply.html">spark_apply</a></span>(
@@ -349,7 +346,7 @@ iris_json_tbl &lt;-<span class="st"> </span><span class="kw"><a href="reference/
   <span class="dt">names =</span> <span class="kw">c</span>(<span class="st">"term"</span>, <span class="st">"estimate"</span>, <span class="st">"std.error"</span>, <span class="st">"statistic"</span>, <span class="st">"p.value"</span>),
   <span class="dt">group_by =</span> <span class="st">"Species"</span>
 )</code></pre></div>
-<pre><code>## # Source:   table&lt;sparklyr_tmp_118fd583f9c2b&gt; [?? x 6]
+<pre><code>## # Source:   table&lt;sparklyr_tmp_118c34a9aa85e&gt; [?? x 6]
 ## # Database: spark_connection
 ##      Species         term    estimate  std.error  statistic      p.value
 ##        &lt;chr&gt;        &lt;chr&gt;       &lt;dbl&gt;      &lt;dbl&gt;      &lt;dbl&gt;        &lt;dbl&gt;
@@ -372,8 +369,8 @@ tempfile &lt;-<span class="st"> </span><span class="kw">tempfile</span>(<span cl
 <span class="co"># define an R interface to Spark line counting</span>
 count_lines &lt;-<span class="st"> </span><span class="cf">function</span>(sc, path) {
   <span class="kw"><a href="reference/spark-api.html">spark_context</a></span>(sc) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">    </span><span class="kw"><a href="http://www.rdocumentation.org/packages/sparklyr/topics/invoke">invoke</a></span>(<span class="st">"textFile"</span>, path, 1L) <span class="op">%&gt;%</span><span class="st"> </span>
-<span class="st">      </span><span class="kw"><a href="http://www.rdocumentation.org/packages/sparklyr/topics/invoke">invoke</a></span>(<span class="st">"count"</span>)
+<span class="st">    </span><span class="kw"><a href="reference/invoke.html">invoke</a></span>(<span class="st">"textFile"</span>, path, 1L) <span class="op">%&gt;%</span><span class="st"> </span>
+<span class="st">      </span><span class="kw"><a href="reference/invoke.html">invoke</a></span>(<span class="st">"count"</span>)
 }
 
 <span class="co"># call spark to count the lines of the CSV</span>
@@ -396,16 +393,16 @@ count_lines &lt;-<span class="st"> </span><span class="cf">function</span>(sc, p
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/spark_web.html">spark_web</a></span>(sc)</code></pre></div>
 <p>You can show the log using the <code>spark_log</code> function:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/spark_log.html">spark_log</a></span>(sc, <span class="dt">n =</span> <span class="dv">10</span>)</code></pre></div>
-<pre><code>## 17/08/25 12:57:40 INFO ContextCleaner: Cleaned accumulator 4349
-## 17/08/25 12:57:40 INFO BlockManagerInfo: Removed broadcast_73_piece0 on 127.0.0.1:50036 in memory (size: 10.0 KB, free: 338.3 MB)
-## 17/08/25 12:57:40 INFO BlockManagerInfo: Removed broadcast_74_piece0 on 127.0.0.1:50036 in memory (size: 3.7 KB, free: 338.3 MB)
-## 17/08/25 12:57:40 INFO ContextCleaner: Cleaned accumulator 4459
-## 17/08/25 12:57:40 INFO ContextCleaner: Cleaned accumulator 4460
-## 17/08/25 12:57:40 INFO Executor: Finished task 0.0 in stage 72.0 (TID 112). 1196 bytes result sent to driver
-## 17/08/25 12:57:40 INFO TaskSetManager: Finished task 0.0 in stage 72.0 (TID 112) in 131 ms on localhost (executor driver) (1/1)
-## 17/08/25 12:57:40 INFO TaskSchedulerImpl: Removed TaskSet 72.0, whose tasks have all completed, from pool 
-## 17/08/25 12:57:40 INFO DAGScheduler: ResultStage 72 (count at NativeMethodAccessorImpl.java:0) finished in 0.131 s
-## 17/08/25 12:57:40 INFO DAGScheduler: Job 49 finished: count at NativeMethodAccessorImpl.java:0, took 0.134441 s</code></pre>
+<pre><code>## 17/11/09 15:58:45 INFO DAGScheduler: Submitting 1 missing tasks from ResultStage 69 (/var/folders/fz/v6wfsg2x1fb1rw4f6r0x4jwm0000gn/T//RtmpHRdREy/file118c36e21fe75.csv MapPartitionsRDD[258] at textFile at NativeMethodAccessorImpl.java:0) (first 15 tasks are for partitions Vector(0))
+## 17/11/09 15:58:45 INFO TaskSchedulerImpl: Adding task set 69.0 with 1 tasks
+## 17/11/09 15:58:45 INFO TaskSetManager: Starting task 0.0 in stage 69.0 (TID 140, localhost, executor driver, partition 0, PROCESS_LOCAL, 4905 bytes)
+## 17/11/09 15:58:45 INFO Executor: Running task 0.0 in stage 69.0 (TID 140)
+## 17/11/09 15:58:45 INFO HadoopRDD: Input split: file:/var/folders/fz/v6wfsg2x1fb1rw4f6r0x4jwm0000gn/T/RtmpHRdREy/file118c36e21fe75.csv:0+33313106
+## 17/11/09 15:58:45 INFO Executor: Finished task 0.0 in stage 69.0 (TID 140). 832 bytes result sent to driver
+## 17/11/09 15:58:45 INFO TaskSetManager: Finished task 0.0 in stage 69.0 (TID 140) in 147 ms on localhost (executor driver) (1/1)
+## 17/11/09 15:58:45 INFO TaskSchedulerImpl: Removed TaskSet 69.0, whose tasks have all completed, from pool 
+## 17/11/09 15:58:45 INFO DAGScheduler: ResultStage 69 (count at NativeMethodAccessorImpl.java:0) finished in 0.148 s
+## 17/11/09 15:58:45 INFO DAGScheduler: Job 47 finished: count at NativeMethodAccessorImpl.java:0, took 0.154719 s</code></pre>
 <p>Finally, we disconnect from Spark:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw"><a href="reference/spark-connections.html">spark_disconnect</a></span>(sc)</code></pre></div>
 </div>
@@ -433,7 +430,7 @@ count_lines &lt;-<span class="st"> </span><span class="cf">function</span>(sc, p
 <h2 class="hasAnchor">
 <a href="#using-h2o" class="anchor"></a>Using H2O</h2>
 <p><a href="https://cran.r-project.org/package=rsparkling">rsparkling</a> is a CRAN package from <a href="http://h2o.ai">H2O</a> that extends <a href="http://spark.rstudio.com">sparklyr</a> to provide an interface into <a href="https://github.com/h2oai/sparkling-water">Sparkling Water</a>. For instance, the following example installs, configures and runs <a href="http://docs.h2o.ai/h2o/latest-stable/h2o-docs/data-science/glm.html">h2o.glm</a>:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">rsparkling.sparklingwater.version =</span> <span class="st">"2.1.0"</span>)
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">rsparkling.sparklingwater.version =</span> <span class="st">"2.1.14"</span>)
 
 <span class="kw">library</span>(rsparkling)
 <span class="kw">library</span>(sparklyr)
@@ -454,7 +451,7 @@ mtcars_glm &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rd
 ## ==============
 ## 
 ## H2ORegressionModel: glm
-## Model ID:  GLM_model_R_1503683883296_1 
+## Model ID:  GLM_model_R_1510271956912_1 
 ## GLM Model: summary
 ##     family     link                              regularization
 ## 1 gaussian identity Elastic Net (alpha = 0.5, lambda = 0.1013 )
@@ -463,7 +460,7 @@ mtcars_glm &lt;-<span class="st"> </span><span class="kw"><a href="http://www.rd
 ##   number_of_predictors_total number_of_active_predictors
 ## 1                          2                           2
 ##   number_of_iterations                                training_frame
-## 1                    0 frame_rdd_29_9b117dc470ba6f8aa3340ee2e18d44eb
+## 1                  100 frame_rdd_29_93f2c165c719dd3c7f9b20bd37394f74
 ## 
 ## Coefficients: glm coefficients
 ##       names coefficients standardized_coefficients
@@ -537,6 +534,7 @@ sc &lt;-<span class="st"> </span><span class="kw"><a href="reference/spark-conne
 <h2>Developers</h2>
 <ul class="list-unstyled">
 <li>Javier Luraschi <br><small class="roles"> Author, maintainer </small> </li>
+<li>Kevin Kuo <br><small class="roles"> Author </small> </li>
 <li>Kevin Ushey <br><small class="roles"> Author </small> </li>
 <li>JJ Allaire <br><small class="roles"> Author </small> </li>
 <li> The Apache Software Foundation <br><small class="roles"> Author, copyright holder </small> </li>
@@ -546,6 +544,7 @@ sc &lt;-<span class="st"> </span><span class="kw"><a href="reference/spark-conne
 <ul class="list-unstyled">
 <li><a href="https://travis-ci.org/rstudio/sparklyr"><img src="https://travis-ci.org/rstudio/sparklyr.svg?branch=master" alt="Build Status"></a></li>
 <li><a href="https://cran.r-project.org/package=sparklyr"><img src="https://www.r-pkg.org/badges/version/sparklyr" alt="CRAN_Status_Badge"></a></li>
+<li><a href="https://codecov.io/gh/rstudio/sparklyr"><img src="https://codecov.io/gh/rstudio/sparklyr/branch/master/graph/badge.svg" alt="codecov"></a></li>
 <li><a href="https://gitter.im/rstudio/sparklyr?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://badges.gitter.im/rstudio/sparklyr.svg" alt="Join the chat at https://gitter.im/rstudio/sparklyr"></a></li>
 </ul>
 </div>
@@ -554,7 +553,7 @@ sc &lt;-<span class="st"> </span><span class="kw"><a href="reference/spark-conne
 
 
       <footer><div class="copyright">
-  <p>Developed by Javier Luraschi, Kevin Ushey, JJ Allaire,  The Apache Software Foundation.</p>
+  <p>Developed by Javier Luraschi, Kevin Kuo, Kevin Ushey, JJ Allaire,  The Apache Software Foundation.</p>
 </div>
 
 <div class="pkgdown">

--- a/vignettes/guides-h2o.Rmd
+++ b/vignettes/guides-h2o.Rmd
@@ -29,7 +29,7 @@ install.packages("rsparkling")
 Then set the Sparkling Water version for rsparkling.:
 
 ```{r}
-options(rsparkling.sparklingwater.version = "2.1.0")
+options(rsparkling.sparklingwater.version = "2.1.14")
 ```
 
 For Spark `2.0.x` set `rsparkling.sparklingwater.version` to `2.0.3` instead, for Spark `1.6.2` use `1.6.8`.


### PR DESCRIPTION
README and docs are broken due to new version of H2O package in CRAN.

With old readme...

```
training <- as_h2o_frame(sc, partitions$training, strict_version_check = FALSE)
 Show Traceback
 
 Rerun with Debug
 Error in .h2o.doSafeREST(h2oRestApiVersion = h2oRestApiVersion, urlSuffix = urlSuffix,  : 
  

ERROR MESSAGE:

Resource /3/Capabilities/API not found 
```