### PR TITLE
Spark ML compatibility for 2.0.0

### DIFF
--- a/R/ml_classification_logistic_regression.R
+++ b/R/ml_classification_logistic_regression.R
@@ -190,9 +190,9 @@ new_ml_logistic_regression_model <- function(jobj) {
   new_ml_prediction_model(
     jobj,
     coefficients = if (is_multinomial) NULL else read_spark_vector(jobj, "coefficients"),
-    coefficient_matrix = read_spark_matrix(jobj, "coefficientMatrix"),
+    coefficient_matrix = try_null(read_spark_matrix(jobj, "coefficientMatrix")),
     intercept = if (is_multinomial) NULL else invoke(jobj, "intercept"),
-    intercept_vector = read_spark_vector(jobj, "interceptVector"),
+    intercept_vector = try_null(read_spark_vector(jobj, "interceptVector")),
     num_classes = invoke(jobj, "numClasses"),
     num_features = invoke(jobj, "numFeatures"),
     features_col = invoke(jobj, "getFeaturesCol"),

--- a/R/ml_classification_logistic_regression.R
+++ b/R/ml_classification_logistic_regression.R
@@ -66,14 +66,14 @@ ml_logistic_regression.spark_connection <- function(
     prediction_col = prediction_col, probability_col = probability_col,
     raw_prediction_col = raw_prediction_col
   ) %>%
-    invoke("setFamily", family) %>%
     invoke("setFitIntercept", fit_intercept) %>%
     invoke("setElasticNetParam", elastic_net_param) %>%
     invoke("setRegParam", reg_param) %>%
     invoke("setMaxIter", max_iter) %>%
     invoke("setThreshold", threshold) %>%
-    invoke("setAggregationDepth", aggregation_depth) %>%
-    invoke("setTol", tol)
+    invoke("setTol", tol) %>%
+    jobj_set_param("setFamily", family, "auto", "2.1.0") %>%
+    jobj_set_param("setAggregationDepth", aggregation_depth, 2L, "2.1.0")
 
   if (!rlang::is_null(thresholds))
     jobj <- invoke(jobj, "setThresholds", thresholds)
@@ -209,7 +209,9 @@ new_ml_summary_logistic_regression_model <- function(jobj) {
   new_ml_summary(
     jobj,
     area_under_roc = invoke(jobj, "areaUnderROC"),
-    f_measure_by_threshold = invoke(jobj, "fMeasureByThreshold") %>% collect(),
+    f_measure_by_threshold = invoke(jobj, "fMeasureByThreshold") %>%
+      invoke("withColumnRenamed", "F-Measure", "F_Measure") %>%
+      collect(),
     features_col = invoke(jobj, "featuresCol"),
     label_col = invoke(jobj, "labelCol"),
     objective_history = invoke(jobj, "objectiveHistory"),

--- a/R/ml_classification_logistic_regression.R
+++ b/R/ml_classification_logistic_regression.R
@@ -7,7 +7,7 @@
 #' @template roxlate-ml-linear-regression-params
 #' @template roxlate-ml-predictor-params
 #' @template roxlate-ml-probabilistic-classifier-params
-#' @param family Param for the name of family which is a description of the label distribution to be used in the model. Supported options: "auto", "binomial", and "multinomial."
+#' @param family (Spark 2.1.0+) Param for the name of family which is a description of the label distribution to be used in the model. Supported options: "auto", "binomial", and "multinomial."
 #' @template roxlate-ml-elastic-net-param
 #' @param threshold in binary classification prediction, in range [0, 1].
 #' @template roxlate-ml-aggregation-depth

--- a/R/ml_classification_naive_bayes.R
+++ b/R/ml_classification_naive_bayes.R
@@ -9,8 +9,7 @@
 #' @param model_type The model type. Supported options: \code{"multinomial"}
 #'   and \code{"bernoulli"}. (default = \code{multinomial})
 #' @param smoothing The (Laplace) smoothing parameter. Defaults to zero.
-#' @param weight_col Weight column name. If this is not set or empty, we treat all instance
-#'   weights as 1.0.
+#' @param weight_col (Spark 2.1.0+) Weight column name. If this is not set or empty, we treat all instance weights as 1.0.
 #' @export
 ml_naive_bayes <- function(
   x,

--- a/R/ml_classification_naive_bayes.R
+++ b/R/ml_classification_naive_bayes.R
@@ -57,7 +57,7 @@ ml_naive_bayes.spark_connection <- function(
     jobj <- invoke(jobj, "setThresholds", thresholds)
 
   if (!rlang::is_null(weight_col))
-    jobj <- invoke(jobj, "setWeightCol", weight_col)
+    jobj <- jobj_set_param(jobj, "setWeightCol", weight_col, NULL, "2.1.0")
 
   new_ml_naive_bayes(jobj)
 }

--- a/R/ml_clustering_bisecting_kmeans.R
+++ b/R/ml_clustering_bisecting_kmeans.R
@@ -105,9 +105,10 @@ new_ml_bisecting_kmeans <- function(jobj) {
 
 new_ml_bisecting_kmeans_model <- function(jobj) {
 
-  summary <- if (invoke(jobj, "hasSummary"))
+  has_summary <- tryCatch(invoke(jobj, "hasSummary"),
+                          error = function(e) FALSE)
+  summary <- if (has_summary)
     new_ml_summary_bisecting_kmeans_model(invoke(jobj, "summary"))
-  else NULL
 
   new_ml_clustering_model(
     jobj,

--- a/R/ml_feature_quantile_discretizer_bucketizer.R
+++ b/R/ml_feature_quantile_discretizer_bucketizer.R
@@ -26,7 +26,7 @@ ft_bucketizer.spark_connection <- function(
   jobj <- ml_new_transformer(x, "org.apache.spark.ml.feature.Bucketizer",
                              input_col, output_col, uid) %>%
     invoke("setSplits", splits) %>%
-    invoke("setHandleInvalid", handle_invalid)
+    jobj_set_param("setHandleInvalid", handle_invalid, "error", "2.1.0")
 
   new_ml_bucketizer(jobj)
 }
@@ -121,7 +121,7 @@ ft_quantile_discretizer.spark_connection <- function(
   ml_ratify_args()
   estimator <- ml_new_transformer(x, "org.apache.spark.ml.feature.QuantileDiscretizer",
                                   input_col, output_col, uid) %>%
-    invoke("setHandleInvalid", handle_invalid) %>%
+    jobj_set_param("setHandleInvalid", handle_invalid, "error", "2.1.0") %>%
     invoke("setNumBuckets", num_buckets) %>%
     invoke("setRelativeError", relative_error) %>%
     new_ml_quantile_discretizer()

--- a/R/ml_feature_r_formula.R
+++ b/R/ml_feature_r_formula.R
@@ -40,7 +40,7 @@
 #'
 #' @param formula R formula as a character string or a formula. Formula objects are
 #'   converted to character strings directly and the environment is not captured.
-#' @param force_index_label Force to index label whether it is numeric or
+#' @param force_index_label (Spark 2.1.0+) Force to index label whether it is numeric or
 #'   string type. Usually we index label only when it is string type. If
 #'   the formula was used by classification algorithms, we can force to index
 #'   label even it is numeric type by setting this param with true.
@@ -63,9 +63,9 @@ ft_r_formula.spark_connection <- function(
 
   estimator <- invoke_new(x, "org.apache.spark.ml.feature.RFormula", uid) %>%
     invoke("setFeaturesCol", features_col) %>%
-    invoke("setForceIndexLabel", force_index_label) %>%
     invoke("setFormula", formula) %>%
     invoke("setLabelCol", label_col) %>%
+    jobj_set_param("setForceIndexLabel", force_index_label, FALSE, "2.1.0") %>%
     new_ml_r_formula()
 
   if (is.null(dataset))

--- a/R/ml_feature_string_indexer.R
+++ b/R/ml_feature_string_indexer.R
@@ -29,7 +29,7 @@ ft_string_indexer.spark_connection <- function(
 
   estimator <- ml_new_transformer(x, "org.apache.spark.ml.feature.StringIndexer",
                                   input_col, output_col, uid) %>%
-    invoke("setHandleInvalid", handle_invalid) %>%
+    jobj_set_param("setHandleInvalid", handle_invalid, "error", "2.1.0") %>%
     new_ml_string_indexer()
 
   if (is.null(dataset))

--- a/R/ml_model_utils.R
+++ b/R/ml_model_utils.R
@@ -24,9 +24,13 @@ ml_generate_ml_model <- function(x, predictor, formula, features_col = "features
                                  constructor) {
   sc <- spark_connection(x)
   classification <- identical(type, "classification")
-  r_formula <- ft_r_formula(sc, formula, features_col, label_col,
+  r_formula <- if (spark_version(sc) >= "2.1.0")
+    ft_r_formula(sc, formula, features_col, label_col,
                             force_index_label = if (classification) TRUE else FALSE,
                             dataset = x)
+  else
+    ft_r_formula(sc, formula, features_col, label_col, dataset = x)
+
   pipeline <- ml_pipeline(r_formula, predictor)
   pipeline_model <- pipeline %>%
     ml_fit(x)

--- a/R/ml_regression_aft_survival_regression.R
+++ b/R/ml_regression_aft_survival_regression.R
@@ -59,7 +59,7 @@ ml_aft_survival_regression.spark_connection <- function(
     invoke("setCensorCol", censor_col) %>%
     invoke("setFitIntercept", fit_intercept) %>%
     invoke("setQuantileProbabilities", quantile_probabilities) %>%
-    invoke("setAggregationDepth", aggregation_depth)
+    jobj_set_param("setAggregationDepth", aggregation_depth, 2L, "2.1.0")
 
   if (!rlang::is_null(quantiles_col))
     jobj <- invoke(jobj, "setQuantilesCol", quantiles_col)

--- a/R/ml_utils.R
+++ b/R/ml_utils.R
@@ -81,3 +81,20 @@ read_spark_matrix <- function(jobj, field = NULL) {
 ml_short_type <- function(x) {
   jobj_class(spark_jobj(x))[1]
 }
+
+jobj_set_param <- function(jobj, method, param, default, min_version) {
+  ver <- jobj %>%
+    spark_connection() %>%
+    spark_version()
+
+  if (ver < min_version) {
+    if (!identical(param, default))
+      stop(paste0("Param '", deparse(substitute(param)),
+                  "' is only available for Spark ", min_version, " and later"))
+    else
+      jobj
+  } else {
+    jobj %>%
+      invoke(method, param)
+  }
+}

--- a/man-roxygen/roxlate-ml-aggregation-depth.R
+++ b/man-roxygen/roxlate-ml-aggregation-depth.R
@@ -1,1 +1,1 @@
-#' @param aggregation_depth Suggested depth for treeAggregate (>= 2).
+#' @param aggregation_depth (Spark 2.1.0+) Suggested depth for treeAggregate (>= 2).

--- a/man-roxygen/roxlate-ml-feature-handle-invalid.R
+++ b/man-roxygen/roxlate-ml-feature-handle-invalid.R
@@ -1,3 +1,3 @@
-#' @param handle_invalid Param for how to handle invalid entries. Options are
+#' @param handle_invalid (Spark 2.1.0+) Param for how to handle invalid entries. Options are
 #'   'skip' (filter out rows with invalid values), 'error' (throw an error), or
 #'   'keep' (keep invalid values in a special additional bucket). Default: "error"

--- a/man/ft_bucketizer.Rd
+++ b/man/ft_bucketizer.Rd
@@ -16,7 +16,7 @@ ft_bucketizer(x, input_col, output_col, splits, handle_invalid = "error",
 
 \item{splits}{A numeric vector of cutpoints, indicating the bucket boundaries.}
 
-\item{handle_invalid}{Param for how to handle invalid entries. Options are
+\item{handle_invalid}{(Spark 2.1.0+) Param for how to handle invalid entries. Options are
 'skip' (filter out rows with invalid values), 'error' (throw an error), or
 'keep' (keep invalid values in a special additional bucket). Default: "error"}
 

--- a/man/ft_quantile_discretizer.Rd
+++ b/man/ft_quantile_discretizer.Rd
@@ -15,7 +15,7 @@ ft_quantile_discretizer(x, input_col, output_col, handle_invalid = "error",
 
 \item{output_col}{The name of the output column.}
 
-\item{handle_invalid}{Param for how to handle invalid entries. Options are
+\item{handle_invalid}{(Spark 2.1.0+) Param for how to handle invalid entries. Options are
 'skip' (filter out rows with invalid values), 'error' (throw an error), or
 'keep' (keep invalid values in a special additional bucket). Default: "error"}
 

--- a/man/ft_r_formula.Rd
+++ b/man/ft_r_formula.Rd
@@ -18,7 +18,7 @@ converted to character strings directly and the environment is not captured.}
 
 \item{label_col}{Label column name. The column should be a numeric column. Usually this column is output by \code{\link{ft_r_formula}}.}
 
-\item{force_index_label}{Force to index label whether it is numeric or
+\item{force_index_label}{(Spark 2.1.0+) Force to index label whether it is numeric or
 string type. Usually we index label only when it is string type. If
 the formula was used by classification algorithms, we can force to index
 label even it is numeric type by setting this param with true.

--- a/man/ft_string_indexer.Rd
+++ b/man/ft_string_indexer.Rd
@@ -14,7 +14,7 @@ ft_string_indexer(x, input_col, output_col, handle_invalid = "error",
 
 \item{output_col}{The name of the output column.}
 
-\item{handle_invalid}{Param for how to handle invalid entries. Options are
+\item{handle_invalid}{(Spark 2.1.0+) Param for how to handle invalid entries. Options are
 'skip' (filter out rows with invalid values), 'error' (throw an error), or
 'keep' (keep invalid values in a special additional bucket). Default: "error"}
 

--- a/man/ml_aft_survival_regression.Rd
+++ b/man/ml_aft_survival_regression.Rd
@@ -35,7 +35,7 @@ ml_survival_regression(x, formula = NULL, censor_col = "censor",
 
 \item{tol}{Param for the convergence tolerance for iterative algorithms.}
 
-\item{aggregation_depth}{Suggested depth for treeAggregate (>= 2).}
+\item{aggregation_depth}{(Spark 2.1.0+) Suggested depth for treeAggregate (>= 2).}
 
 \item{quantiles_col}{Quantiles column name. This column will output quantiles of corresponding quantileProbabilities if it is set.}
 

--- a/man/ml_linear_svc.Rd
+++ b/man/ml_linear_svc.Rd
@@ -30,7 +30,7 @@ ml_linear_svc(x, formula = NULL, fit_intercept = TRUE, reg_param = 0,
 
 \item{threshold}{in binary classification prediction, in range [0, 1].}
 
-\item{aggregation_depth}{Suggested depth for treeAggregate (>= 2).}
+\item{aggregation_depth}{(Spark 2.1.0+) Suggested depth for treeAggregate (>= 2).}
 
 \item{features_col}{Features column name, as a length-one character vector. The column should be single vector column of numeric values. Usually this column is output by \code{\link{ft_r_formula}}.}
 

--- a/man/ml_logistic_regression.Rd
+++ b/man/ml_logistic_regression.Rd
@@ -33,13 +33,13 @@ ml_logistic_regression(x, formula = NULL, fit_intercept = TRUE,
 
 \item{weight_col}{The name of the column to use as weights for the model fit.}
 
-\item{aggregation_depth}{Suggested depth for treeAggregate (>= 2).}
+\item{aggregation_depth}{(Spark 2.1.0+) Suggested depth for treeAggregate (>= 2).}
 
 \item{features_col}{Features column name, as a length-one character vector. The column should be single vector column of numeric values. Usually this column is output by \code{\link{ft_r_formula}}.}
 
 \item{label_col}{Label column name. The column should be a numeric column. Usually this column is output by \code{\link{ft_r_formula}}.}
 
-\item{family}{Param for the name of family which is a description of the label distribution to be used in the model. Supported options: "auto", "binomial", and "multinomial."}
+\item{family}{(Spark 2.1.0+) Param for the name of family which is a description of the label distribution to be used in the model. Supported options: "auto", "binomial", and "multinomial."}
 
 \item{prediction_col}{Prediction column name.}
 

--- a/man/ml_naive_bayes.Rd
+++ b/man/ml_naive_bayes.Rd
@@ -23,8 +23,7 @@ and \code{"bernoulli"}. (default = \code{multinomial})}
 
 \item{thresholds}{Thresholds in multi-class classification to adjust the probability of predicting each class. Array must have length equal to the number of classes, with values > 0 excepting that at most one value may be 0. The class with largest value \code{p/t} is predicted, where \code{p} is the original probability of that class and \code{t} is the class's threshold.}
 
-\item{weight_col}{Weight column name. If this is not set or empty, we treat all instance
-weights as 1.0.}
+\item{weight_col}{(Spark 2.1.0+) Weight column name. If this is not set or empty, we treat all instance weights as 1.0.}
 
 \item{features_col}{Features column name, as a length-one character vector. The column should be single vector column of numeric values. Usually this column is output by \code{\link{ft_r_formula}}.}
 

--- a/man/spark_write_source.Rd
+++ b/man/spark_write_source.Rd
@@ -4,13 +4,11 @@
 \alias{spark_write_source}
 \title{Writes a Spark DataFrame into a generic source}
 \usage{
-spark_write_source(x, name, source, mode = NULL, options = list(),
+spark_write_source(x, source, mode = NULL, options = list(),
   partition_by = NULL, ...)
 }
 \arguments{
 \item{x}{A Spark DataFrame or dplyr operation}
-
-\item{name}{The name to assign to the newly generated table.}
 
 \item{source}{A data source capable of reading data.}
 
@@ -26,6 +24,8 @@ spark_write_source(x, name, source, mode = NULL, options = list(),
 \item{partition_by}{A \code{character} vector. Partitions the output by the given columns on the file system.}
 
 \item{...}{Optional arguments; currently unused.}
+
+\item{name}{The name to assign to the newly generated table.}
 }
 \description{
 Writes a Spark DataFrame into a generic source.

--- a/tests/testthat/test-ml-classification-logistic-regression.R
+++ b/tests/testthat/test-ml-classification-logistic-regression.R
@@ -160,18 +160,19 @@ test_that("ml_logistic_regression parameter setting/getting works", {
   args <- list(
     x = sc,
     elastic_net_param = 0.1,
-    family = "binomial",
     features_col = "fcol",
     fit_intercept = FALSE,
     label_col = "lcol",
     max_iter = 50L,
     threshold = 0.4,
-    aggregation_depth = 3,
     tol = 1e-05,
     weight_col = "wcol",
     prediction_col = "pcol",
     probability_col = "probcol",
     raw_prediction_col = "rpcol")
+
+  if (spark_version(sc) >= "2.1.0")
+    args <- c(args, aggregation_depth = 3, family = "binomial")
 
   lr <- do.call(ml_logistic_regression, args)
 
@@ -188,12 +189,16 @@ test_that("logistic regression default params are correct", {
   args <- get_default_args(ml_logistic_regression,
                            c("x", "uid", "...", "thresholds", "weight_col"))
 
+  if (spark_version(sc) < "2.1.0")
+    args <- rlang::modify(args, aggregation_depth = NULL)
+
   expect_equal(
     ml_params(lr, names(args)),
     args)
 })
 
 test_that("we can fit multinomial models", {
+  if (spark_version(sc) < "2.1.0") skip("multinomial models not supported < 2.1.0")
   test_requires("nnet", "dplyr")
 
   n <- 200

--- a/tests/testthat/test-ml-classification-logistic-regression.R
+++ b/tests/testthat/test-ml-classification-logistic-regression.R
@@ -190,7 +190,7 @@ test_that("logistic regression default params are correct", {
                            c("x", "uid", "...", "thresholds", "weight_col"))
 
   if (spark_version(sc) < "2.1.0")
-    args <- rlang::modify(args, aggregation_depth = NULL)
+    args <- rlang::modify(args, aggregation_depth = NULL, family = NULL)
 
   expect_equal(
     ml_params(lr, names(args)),

--- a/tests/testthat/test-ml-classification-naive-bayes.R
+++ b/tests/testthat/test-ml-classification-naive-bayes.R
@@ -6,9 +6,10 @@ test_that("ml_naive_bayes() parses params correctly", {
   args <- list(
     x = sc, label_col = "col", features_col = "fcol", prediction_col = "pcol",
     probability_col = "prcol", raw_prediction_col = "rpcol",
-    model_type = "bernoulli", smoothing = 0.6, thresholds = c(0.2, 0.4, 0.6),
-    weight_col = "wcol"
+    model_type = "bernoulli", smoothing = 0.6, thresholds = c(0.2, 0.4, 0.6)
   )
+  if (spark_version(sc) >= "2.1.0")
+    args <- c(args, weight_col = "wcol")
   nb <- do.call(ml_naive_bayes, args)
   expect_equal(ml_params(nb, names(args)[-1]), args[-1])
 })

--- a/tests/testthat/test-ml-feature-estimator-transformers.R
+++ b/tests/testthat/test-ml-feature-estimator-transformers.R
@@ -50,16 +50,20 @@ test_that("ft_count_vectorizer() works", {
 })
 
 test_that("ft_string_indexer works", {
-  si <- ft_string_indexer(
-    sc, "in", "out", handle_invalid = "skip"
-  )
 
-  expect_equal(ml_params(si, list(
-    "input_col", "output_col", "handle_invalid"
-  )),
-  list(input_col = "in",
-       output_col = "out",
-       handle_invalid = "skip"))
+  args <- list(
+    x = sc,
+    input_col = "in",
+    output_col = "out")
+
+  if (spark_version(sc) >= "2.1.0")
+    args <- c(args, handle_invalid = "skip")
+
+  si <- do.call(ft_string_indexer, args)
+
+  expect_equal(
+    ml_params(si, names(args)[-1]),
+    args[-1])
 
   expect_true(is_ml_estimator(si))
 })
@@ -80,15 +84,19 @@ test_that("ft_quantile_discretizer works", {
   expect_identical(result, c(2, 2, 1, 1, 0))
   expect_identical(result2, c(2, 2, 1, 1, 0))
 
-  qd <- ft_quantile_discretizer(
-    sc, "hour", "result", handle_invalid = "skip",
-    num_buckets = 3L, relative_error = 0.01)
-  expect_equal(ml_params(qd, list(
-    "input_col", "output_col", "handle_invalid", "num_buckets", "relative_error"
-  )),
-  list(input_col = "hour",
-       output_col = "result",
-       handle_invalid = "skip",
-       num_buckets = 3L,
-       relative_error = 0.01))
+  args <- list(
+    x = sc,
+    input_col = "hour",
+    output_col = "result",
+    num_buckets = 3L,
+    relative_error = 0.01)
+
+  if (spark_version(sc) >= "2.1.0")
+    args <- c(args, handle_invalid = "skip")
+
+  qd <- do.call(ft_quantile_discretizer, args)
+
+  expect_equal(
+    ml_params(qd, names(args)[-1]),
+    args[-1])
 })

--- a/tests/testthat/test-ml-feature-r-formula.R
+++ b/tests/testthat/test-ml-feature-r-formula.R
@@ -30,19 +30,20 @@ test_that("r formula works as expected", {
   expect_equal(pull(df1, label), pull(df2, label))
   expect_equal(pull(df1, label), pull(df3, label))
 
-  rf <- ft_r_formula(
-    sc, "Sepal_Length ~ Petal_Width + Species", features_col = "x",
-    label_col = "y", force_index_label = TRUE)
+  args <- list(
+    x = sc,
+    formula = "Sepal_Length ~ Petal_Width + Species",
+    features_col = "x",
+    label_col = "y")
+
+  if (spark_version(sc) >= "2.1.0")
+    args <- c(args, force_index_label = TRUE)
+
+  rf <- do.call(ft_r_formula, args)
 
   expect_equal(
-    ml_params(rf, list(
-      "formula", "features_col", "label_col", "force_index_label"
-    )),
-    list(formula = "Sepal_Length ~ Petal_Width + Species",
-         features_col = "x",
-         label_col = "y",
-         force_index_label = TRUE)
-  )
+    ml_params(rf, names(args)[-1]),
+    args[-1])
 })
 
 test_that("ft_r_formula takes formula", {

--- a/tests/testthat/test-ml-regression-survival-regression.R
+++ b/tests/testthat/test-ml-regression-survival-regression.R
@@ -7,9 +7,12 @@ test_that("ml_aft_survival_regression param setting", {
     x = sc, censor_col = "ccol",
     quantile_probabilities = c(0.01, 0.25, 0.5, 0.75, 0.95),
     fit_intercept = FALSE, max_iter = 50, tol = 1e-04,
-    aggregation_depth = 3, quantiles_col = "qcol",
+    quantiles_col = "qcol",
     label_col = "col", features_col = "fcol", prediction_col = "pcol"
   )
+  if (spark_version(sc) >= "2.1.0")
+    args <- c(args, aggregation_depth = 3)
+
   ovr <- do.call(ml_aft_survival_regression, args)
   expect_equal(ml_params(ovr, names(args)[-1]), args[-1])
 })
@@ -21,8 +24,12 @@ test_that("ml_aft_survival_regression() default params are correct", {
     ml_stage(1)
 
   args <- get_default_args(ml_aft_survival_regression,
-                           c("x", "uid", "...", "quantiles_col")) %>%
-    lapply(eval)
+                           c("x", "uid", "...", "quantiles_col"))
+
+  if (spark_version(sc) < "2.1.0")
+    args <- rlang::modify(args, aggregation_depth = NULL, family = NULL)
+
+  args <- lapply(Filter(length, args), eval)
 
   expect_equal(
     within(ml_params(predictor, names(args)),

--- a/tests/testthat/test-ml-regression-survival-regression.R
+++ b/tests/testthat/test-ml-regression-survival-regression.R
@@ -62,7 +62,8 @@ test_that("ml_aft_survival_regression() works properly", {
   aft_model <- ml_aft_survival_regression(training_tbl, label ~ V1 + V2, features_col = "feat")
   expect_equal(coef(aft_model),
                structure(c(2.63808989630564, -0.496304411053117, 0.198452172529228
-               ), .Names = c("(Intercept)", "V1", "V2")))
+               ), .Names = c("(Intercept)", "V1", "V2")),
+               tolerance = 1e-05)
   output <- capture.output(aft_model)
   expect_identical(output[3], "Formula: label ~ V1 + V2")
 })

--- a/tests/testthat/test-ml-tuning.R
+++ b/tests/testthat/test-ml-tuning.R
@@ -57,7 +57,8 @@ test_that("ml_cross_validator() works correctly", {
   )
 })
 
-test_that("we can cross validate a logistic regression", {
+test_that("we can cross validate a logistic regression with xval", {
+  if (spark_version(sc) < "2.1.0") skip("multinomial logistic regression not supported")
   iris_tbl <- testthat_tbl("iris")
 
   pipeline <- ml_pipeline(sc) %>%
@@ -85,6 +86,7 @@ test_that("we can cross validate a logistic regression", {
 })
 
 test_that("we can train a regression with train-validation-split", {
+  if (spark_version(sc) < "2.1.0") skip("multinomial logistic regression not supported")
   iris_tbl <- testthat_tbl("iris")
 
   pipeline <- ml_pipeline(sc) %>%


### PR DESCRIPTION
Changes for Spark ML backwards compatibility to version 2.0.0.

- Implement internal `jobj_set_param()` that checks for version before `invoke("setParam", param)` and apply to relevant methods/params.
- Wrap some newly introduced model object members with `try_null()`.
- Fix internal `ml_generate_ml_model()` to account for the fact that `setForceIndexLabel` was unavailable for `RFormula` prior to 2.1.0. (https://github.com/rstudio/sparklyr/issues/1113)
- Annotate 2.1.0+ parameters in roxygen docs.

Will send a follow-up PR for 1.6.x compatibility.