### PR TITLE
Correct parameter default documentation for ml_naive_bayes()

### DIFF
--- a/R/ml_classification_naive_bayes.R
+++ b/R/ml_classification_naive_bayes.R
@@ -8,7 +8,7 @@
 #' @template roxlate-ml-formula-params
 #' @param model_type The model type. Supported options: \code{"multinomial"}
 #'   and \code{"bernoulli"}. (default = \code{multinomial})
-#' @param smoothing The (Laplace) smoothing parameter. Defaults to zero.
+#' @param smoothing The (Laplace) smoothing parameter. Defaults to 1.
 #' @param weight_col (Spark 2.1.0+) Weight column name. If this is not set or empty, we treat all instance weights as 1.0.
 #' @export
 ml_naive_bayes <- function(

--- a/R/ml_model_utils.R
+++ b/R/ml_model_utils.R
@@ -19,7 +19,7 @@ ml_feature_names_metadata <- function(pipeline_model, dataset, features_col) {
   ml_column_metadata(transformed_tbl, features_col) %>%
     `[[`("attrs") %>%
     dplyr::bind_rows() %>%
-    arrange(!!rlang::sym("idx")) %>%
+    dplyr::arrange(!!rlang::sym("idx")) %>%
     dplyr::pull("name")
 }
 

--- a/man/ml_naive_bayes.Rd
+++ b/man/ml_naive_bayes.Rd
@@ -19,7 +19,7 @@ ml_naive_bayes(x, formula = NULL, model_type = "multinomial",
 \item{model_type}{The model type. Supported options: \code{"multinomial"}
 and \code{"bernoulli"}. (default = \code{multinomial})}
 
-\item{smoothing}{The (Laplace) smoothing parameter. Defaults to zero.}
+\item{smoothing}{The (Laplace) smoothing parameter. Defaults to 1.}
 
 \item{thresholds}{Thresholds in multi-class classification to adjust the probability of predicting each class. Array must have length equal to the number of classes, with values > 0 excepting that at most one value may be 0. The class with largest value \code{p/t} is predicted, where \code{p} is the original probability of that class and \code{t} is the class's threshold.}
 


### PR DESCRIPTION
`smoothing` defaults to 1, not 0. Also added a test.