### PR TITLE
Fix regression due to rlang changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     openssl (>= 0.8),
     rappdirs,
     readr (>= 1.1.0),
-    rlang (>= 0.1.2.9000),
+    rlang (>= 0.1.4),
     rprojroot,
     rstudioapi,
     shiny (>= 1.0.1),
@@ -51,5 +51,3 @@ Suggests:
     nycflights13,
     testthat,
     RCurl
-Remotes:
-    tidyverse/rlang

--- a/R/mutation.R
+++ b/R/mutation.R
@@ -137,7 +137,7 @@ sdf_bind_rows <- function(..., id = NULL) {
     if (!all(rlang::have_name(dots)))
       names(dots) <- as.character(seq_along(dots))
     augmented_dots <- Map(
-      function(x, label) dplyr::mutate(x, !!! sym(id) := label),
+      function(x, label) dplyr::mutate(x, !!sym(id) := label),
       augmented_dots,
       names(dots)
     )
@@ -182,7 +182,7 @@ cbind.tbl_spark <- function(..., deparse.level = 1, name = random_string("sparkl
 
     Reduce(function(x, y) dplyr::inner_join(x, y, by = id),
            dots_with_ids) %>%
-    select(- !!! rlang::sym(id))
+    select(- !!rlang::sym(id))
 }
 
 #' @rdname sdf_bind

--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -363,7 +363,7 @@ sdf_with_sequential_id <- function(x, id = "id", from = 1L) {
 sdf_last_index <- function(x, id = "id") {
 
   sdf <- x %>%
-    dplyr::transmute(!!! sym(id) := as.numeric(!!! sym(id))) %>%
+    dplyr::transmute(!!sym(id) := as.numeric(!!sym(id))) %>%
     spark_dataframe()
   sc <- spark_connection(sdf)
   ensure_scalar_character(id)


### PR DESCRIPTION
- Remove extraneous `!` in unquoting
- Use CRAN `rlang` due to regression in `dots_splice()`