### PR TITLE
enable inputting read schema to optimize reads of nested parquet data

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -374,7 +374,7 @@ spark_data_read_generic <- function(sc, source, fileMethod, readOptions = list()
     columnDefs <- spark_data_build_types(sc, columns)
   }
   if (readSchemaProvided || columnsHaveTypes) {
-    options <<- invoke(options, "schema", columnDefs)
+    options <- invoke(options, "schema", columnDefs)
   }
 
   df <- invoke(options, fileMethod, source)

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -197,6 +197,7 @@ spark_write_csv.spark_jobj <- function(x,
 #'
 #' @inheritParams spark_read_csv
 #' @param options A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.
+#' @param schema A (java) read schema. Useful for optimizing read operation on nested data.
 #'
 #' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3n://}), as well as
 #'   the local file system (\code{file://}).
@@ -216,11 +217,12 @@ spark_read_parquet <- function(sc,
                                memory = TRUE,
                                overwrite = TRUE,
                                columns = NULL,
+                               schema = NULL,
                                ...) {
 
   if (overwrite) spark_remove_table_if_exists(sc, name)
 
-  df <- spark_data_read_generic(sc, list(spark_normalize_path(path)), "parquet", options, columns)
+  df <- spark_data_read_generic(sc, list(spark_normalize_path(path)), "parquet", options, columns, schema)
   spark_partition_register_df(sc, df, name, repartition, memory)
 }
 
@@ -356,8 +358,9 @@ spark_expect_jobj_class <- function(jobj, expectedClassName) {
   }
 }
 
-spark_data_read_generic <- function(sc, source, fileMethod, readOptions = list(), columns = NULL) {
+spark_data_read_generic <- function(sc, source, fileMethod, readOptions = list(), columns = NULL, schema = NULL) {
   columnsHaveTypes <- length(names(columns)) > 0
+  readSchemaProvided <- !is.null(schema)
 
   options <- invoke(hive_context(sc), "read")
 
@@ -365,9 +368,13 @@ spark_data_read_generic <- function(sc, source, fileMethod, readOptions = list()
     options <<- invoke(options, "option", optionName, readOptions[[optionName]])
   })
 
-  if (columnsHaveTypes) {
+  if (readSchemaProvided) {
+    columnDefs <- schema
+  } else if (columnsHaveTypes) {
     columnDefs <- spark_data_build_types(sc, columns)
-    options <- invoke(options, "schema", columnDefs)
+  }
+  if (readSchemaProvided || columnsHaveTypes) {
+    options <<- invoke(options, "schema", columnDefs)
   }
 
   df <- invoke(options, fileMethod, source)

--- a/inst/livy/spark-1.5.2/sqlutils.scala
+++ b/inst/livy/spark-1.5.2/sqlutils.scala
@@ -28,6 +28,7 @@ object SQLUtils {
     dataType match {
       case "byte" => org.apache.spark.sql.types.ByteType
       case "integer" => org.apache.spark.sql.types.IntegerType
+      case "long" => org.apache.spark.sql.types.LongType
       case "float" => org.apache.spark.sql.types.FloatType
       case "double" => org.apache.spark.sql.types.DoubleType
       case "numeric" => org.apache.spark.sql.types.DoubleType

--- a/man/spark_read_parquet.Rd
+++ b/man/spark_read_parquet.Rd
@@ -5,7 +5,7 @@
 \title{Read a Parquet file into a Spark DataFrame}
 \usage{
 spark_read_parquet(sc, name, path, options = list(), repartition = 0,
-  memory = TRUE, overwrite = TRUE, columns = NULL, ...)
+  memory = TRUE, overwrite = TRUE, columns = NULL, schema = NULL, ...)
 }
 \arguments{
 \item{sc}{A \code{spark_connection}.}
@@ -27,6 +27,8 @@ is, should the table be cached?)}
 already exists?}
 
 \item{columns}{A vector of column names or a named vector of column types.}
+
+\item{schema}{A (java) read schema. Useful for optimizing read operation on nested data.}
 
 \item{...}{Optional arguments; currently unused.}
 }
@@ -59,4 +61,3 @@ Other Spark serialization routines: \code{\link{spark_load_table}},
   \code{\link{spark_write_table}},
   \code{\link{spark_write_text}}
 }
-\concept{Spark serialization routines}


### PR DESCRIPTION
Pending https://github.com/apache/spark/pull/16578 spark reads too much data from nested parquet fields. This PR enables users to pass in read schemas (a sub-schema from the full data schema) so that only the nested (and top level) fields of interest are read in. For users with complex nested data this amounts to a huge performance boost.

The `schema` argument can be constructed using the `sparklyr.nested` functions defined here https://mitre.github.io/sparklyr.nested/reference/struct_type.html (which mostly just use the `SQLUtils.getSQLDataType`  from https://github.com/rstudio/sparklyr/blob/master/inst/livy/spark-1.5.2/sqlutils.scala). 

For example, referencing the schema here https://mitre.github.io/sparklyr.nested/index.html then one could input
```
start_point_schema <- struct_type(sc,
    struct_field(sc, 'altitude', double_type(sc), nullable=FALSE)
)
phases_schema <- struct_type(sc,
  struct_field(sc, 'start_point', start_point_schema, FALSE)
)
data_schema <- struct_type(sc,
  c(struct_field(sc, 'primary_key', string_type(sc), FALSE),
    struct_field(sc, 'phase_sequence', string_type(sc), TRUE),
    struct_field(sc, 'phases', phases_schema, TRUE))
)

df <- spark_read_parquet(sc, ..., schema=data_schema)
```

This would result in not reading any of the `phasts$end_point` data and would read only `phases$start_point$altitude`. With most of the data filtered at read, then doing explode operations (e.g., https://mitre.github.io/sparklyr.nested/reference/sdf_explode.html) is not nearly so expensive.