### PR TITLE
adding option to access LongType

### DIFF
--- a/java/spark-1.5.2/sqlutils.scala
+++ b/java/spark-1.5.2/sqlutils.scala
@@ -28,6 +28,7 @@ object SQLUtils {
       case "float" => org.apache.spark.sql.types.FloatType
       case "double" => org.apache.spark.sql.types.DoubleType
       case "numeric" => org.apache.spark.sql.types.DoubleType
+      case "long" => org.apache.spark.sql.types.LongType
       case "character" => org.apache.spark.sql.types.StringType
       case "string" => org.apache.spark.sql.types.StringType
       case "binary" => org.apache.spark.sql.types.BinaryType


### PR DESCRIPTION
`sparklyr` jars built with this change enable using read schemas (see https://github.com/rstudio/sparklyr/pull/1167) with long-encoded data using [`long_type()`](https://github.com/mitre/sparklyr.nested/blob/master/R/data_types.R#L110). This change has no other effect.