### PR TITLE
Update documentation on s3 integration

### DIFF
--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -27,7 +27,7 @@ spark_csv_options <- function(header,
 #' @param sc A \code{spark_connection}.
 #' @param name The name to assign to the newly generated table.
 #' @param path The path to the file. Needs to be accessible from the cluster.
-#'   Supports the \samp{"hdfs://"}, \samp{"s3n://"} and \samp{"file://"} protocols.
+#'   Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.
 #' @param memory Boolean; should the data be loaded eagerly into memory? (That
 #'   is, should the table be cached?)
 #' @param header Boolean; should the first row of data be used as a header?
@@ -47,12 +47,17 @@ spark_csv_options <- function(header,
 #'   already exists?
 #' @param ... Optional arguments; currently unused.
 #'
-#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3n://}),
+#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3a://}),
 #'   as well as the local file system (\code{file://}).
 #'
-#' If you are reading from a secure S3 bucket be sure that the
-#' \code{AWS_ACCESS_KEY_ID} and \code{AWS_SECRET_ACCESS_KEY} environment
-#' variables are both defined.
+#' If you are reading from a secure S3 bucket be sure to set the following in your spark-defaults.conf
+#' \code{spark.hadoop.fs.s3a.access.key}, \code{spark.hadoop.fs.s3a.secret.key} or any of the methods outlined in the aws-sdk
+#' documentation \href{http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html}{Working with AWS credentials}
+#' In order to work with the newer \code{s3a://} protocol also set the values for \code{spark.hadoop.fs.s3a.impl} and \code{spark.hadoop.fs.s3a.endpoint }.
+#' In addition, to support v4 of the S3 api be sure to pass the \code{-Dcom.amazonaws.services.s3.enableV4} driver options
+#' for the config key \code{spark.driver.extraJavaOptions }
+#' For instructions on how to configure \code{s3n://} check the hadoop documentation:
+#' \href{https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Authentication_properties}{s3n authentication properties}
 #'
 #' When \code{header} is \code{FALSE}, the column names are generated with a
 #' \code{V} prefix; e.g. \code{V1, V2, ...}.
@@ -199,11 +204,17 @@ spark_write_csv.spark_jobj <- function(x,
 #' @param options A list of strings with additional options. See \url{http://spark.apache.org/docs/latest/sql-programming-guide.html#configuration}.
 #' @param schema A (java) read schema. Useful for optimizing read operation on nested data.
 #'
-#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3n://}), as well as
+#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3a://}), as well as
 #'   the local file system (\code{file://}).
 #'
-#' If you are reading from a secure S3 bucket be sure that the \code{AWS_ACCESS_KEY_ID} and
-#'   \code{AWS_SECRET_ACCESS_KEY} environment variables are both defined.
+#' If you are reading from a secure S3 bucket be sure to set the following in your spark-defaults.conf
+#' \code{spark.hadoop.fs.s3a.access.key}, \code{spark.hadoop.fs.s3a.secret.key} or any of the methods outlined in the aws-sdk
+#' documentation \href{http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html}{Working with AWS credentials}
+#' In order to work with the newer \code{s3a://} protocol also set the values for \code{spark.hadoop.fs.s3a.impl} and \code{spark.hadoop.fs.s3a.endpoint }.
+#' In addition, to support v4 of the S3 api be sure to pass the \code{-Dcom.amazonaws.services.s3.enableV4} driver options
+#' for the config key \code{spark.driver.extraJavaOptions }
+#' For instructions on how to configure \code{s3n://} check the hadoop documentation:
+#' \href{https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Authentication_properties}{s3n authentication properties}
 #'
 #'
 #' @family Spark serialization routines
@@ -276,11 +287,17 @@ spark_write_parquet.spark_jobj <- function(x,
 #'
 #' @inheritParams spark_read_csv
 #'
-#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3n://}), as well as
+#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3a://}), as well as
 #'   the local file system (\code{file://}).
 #'
-#' If you are reading from a secure S3 bucket be sure that the \code{AWS_ACCESS_KEY_ID} and
-#'   \code{AWS_SECRET_ACCESS_KEY} environment variables are both defined.
+#' If you are reading from a secure S3 bucket be sure to set the following in your spark-defaults.conf
+#' \code{spark.hadoop.fs.s3a.access.key}, \code{spark.hadoop.fs.s3a.secret.key} or any of the methods outlined in the aws-sdk
+#' documentation \href{http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html}{Working with AWS credentials}
+#' In order to work with the newer \code{s3a://} protocol also set the values for \code{spark.hadoop.fs.s3a.impl} and \code{spark.hadoop.fs.s3a.endpoint }.
+#' In addition, to support v4 of the S3 api be sure to pass the \code{-Dcom.amazonaws.services.s3.enableV4} driver options
+#' for the config key \code{spark.driver.extraJavaOptions }
+#' For instructions on how to configure \code{s3n://} check the hadoop documentation:
+#' \href{https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Authentication_properties}{s3n authentication properties}
 #'
 #'
 #' @family Spark serialization routines
@@ -737,11 +754,17 @@ spark_write_source.spark_jobj <- function(x,
 #'
 #' @inheritParams spark_read_csv
 #'
-#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3n://}), as well as
+#' @details You can read data from HDFS (\code{hdfs://}), S3 (\code{s3a://}), as well as
 #'   the local file system (\code{file://}).
 #'
-#' If you are reading from a secure S3 bucket be sure that the \code{AWS_ACCESS_KEY_ID} and
-#'   \code{AWS_SECRET_ACCESS_KEY} environment variables are both defined.
+#' If you are reading from a secure S3 bucket be sure to set the following in your spark-defaults.conf
+#' \code{spark.hadoop.fs.s3a.access.key}, \code{spark.hadoop.fs.s3a.secret.key} or any of the methods outlined in the aws-sdk
+#' documentation \href{http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html}{Working with AWS credentials}
+#' In order to work with the newer \code{s3a://} protocol also set the values for \code{spark.hadoop.fs.s3a.impl} and \code{spark.hadoop.fs.s3a.endpoint }.
+#' In addition, to support v4 of the S3 api be sure to pass the \code{-Dcom.amazonaws.services.s3.enableV4} driver options
+#' for the config key \code{spark.driver.extraJavaOptions }
+#' For instructions on how to configure \code{s3n://} check the hadoop documentation:
+#' \href{https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/index.html#Authentication_properties}{s3n authentication properties}
 #'
 #' @family Spark serialization routines
 #'


### PR DESCRIPTION
@javierluraschi kindly review.
Updated docs to reflect latest recommendations as per [hadoop  wiki](https://wiki.apache.org/hadoop/AmazonS3) and added some pointers on how to configure spark to keep spark and hadoop config separate from sparklyR.