### PR TITLE
Fix for connect dialog with proxies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.6.4-9900
+Version: 0.6.4-9901
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- Fixed error in the Spark connection dialog for clusters using a proxy.
+
 - Improved support for Spark 2.X under Cloudera clusters by prioritizing
 use of `spark2-submit` over `spark-submit`.
 

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -9,12 +9,32 @@ spark_versions_url <- function() {
 }
 
 #' @importFrom jsonlite fromJSON
-read_spark_versions_json <- function(file = spark_versions_url()) {
-
+read_spark_versions_json <- function(latest = TRUE) {
   # see if we have a cached version
   if (!exists("sparkVersionsJson", envir = .globals))
   {
-    versionsJson <- fromJSON(file, simplifyDataFrame = TRUE)
+    # This function might be called during a custom configuration and the package
+    # will not be available at that time; allow overriding with environment variable
+    packagePathEnv <- Sys.getenv("R_SPARKINSTALL_INSTALL_INFO_PATH", unset = NA)
+    packagePath <- if (!is.na(packagePathEnv))
+      packagePathEnv
+    else
+      system.file(file.path("extdata", "versions.json"), package = packageName())
+
+    versionsJson <- NULL
+    if (latest) {
+      versionsJson <- tryCatch({
+        suppressWarnings(
+          fromJSON(spark_versions_url(), simplifyDataFrame = TRUE)
+        )
+      }, error = function(e) {
+      })
+    }
+
+    if (is.null(versionsJson)) {
+      versionsJson <- fromJSON(packagePath, simplifyDataFrame = TRUE)
+    }
+
     assign("sparkVersionsJson", versionsJson, envir = .globals)
   }
 
@@ -53,7 +73,7 @@ spark_installed_versions <- function() {
 #' @rdname spark_install
 #' @export
 spark_available_versions <- function() {
-  versions <- read_spark_versions_json()
+  versions <- read_spark_versions_json(latest = TRUE)
   versions <- versions[versions$spark >= "1.6.0", 1:2]
   versions$install <- paste0("spark_install(version = \"",
                              versions$spark, "\", ",
@@ -70,28 +90,7 @@ spark_available_versions <- function() {
 #' @export
 spark_versions <- function(latest = TRUE) {
 
-  # This function might be called during a custom configuration and the package
-  # will not be available at that time; allow overriding with environment variable
-  packagePathEnv <- Sys.getenv("R_SPARKINSTALL_INSTALL_INFO_PATH", unset = NA)
-  packagePath <- if (!is.na(packagePathEnv))
-    packagePathEnv
-  else
-    system.file(file.path("extdata", "versions.json"), package = packageName())
-
-  downloadData <- NULL
-  if (latest) {
-    tryCatch({
-      suppressWarnings(
-        downloadData <- read_spark_versions_json()
-      )
-    }, error = function(e) {
-    })
-  }
-
-  if (is.null(downloadData) || is.null(downloadData$spark)) {
-    downloadData <- read_spark_versions_json(packagePath)
-  }
-
+  downloadData <- read_spark_versions_json(latest)
   downloadData$installed <- rep(FALSE, NROW(downloadData))
 
   downloadData$download <- paste(


### PR DESCRIPTION
For clusters that have a proxy and are using the RStudio Spark connections dialog, it could trigger an error if Shiny evaluates one of the reactive dependents on the version in a different order. The issue was that there was a code path that was not handling offline connections that the shiny app might hit.