### PR TITLE
replace jsonlite base64_enc by base64encode from package base64enc

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -30,7 +30,7 @@ livy_validate_http_response <- function(message, req) {
 #'
 #' @export
 #'
-#' @importFrom jsonlite base64_enc
+#' @importFrom base64enc base64encode
 #' @importFrom jsonlite unbox
 #'
 #' @param config Optional base configuration
@@ -69,7 +69,7 @@ livy_validate_http_response <- function(message, req) {
 livy_config <- function(config = spark_config(), username = NULL, password = NULL,
                         custom_headers = list("X-Requested-By" = "sparklyr"), ...) {
   if (!is.null(username) || !is.null(password)) {
-    secret <- base64_enc(paste(username, password, sep = ":"))
+    secret <- base64encode(paste(username, password, sep = ":"))
 
     config[["sparklyr.livy.headers"]] <- c(
       config[["sparklyr.livy.headers"]], list(


### PR DESCRIPTION
The problem description can be found in the following issue of the jsonlite package:
https://github.com/jeroen/jsonlite/issues/220

Short: The jsonlite encoder adds \n when the string "username:password" is long.