### PR TITLE
use base64encode in livy_config()

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -75,7 +75,7 @@ livy_config <- function(config = spark_config(), username = NULL, password = NUL
       config[["sparklyr.livy.headers"]], list(
         Authorization = paste(
           "Basic",
-          base64_enc(paste(username, password, sep = ":"))
+          base64encode(paste(username, password, sep = ":"))
         )
       )
     )


### PR DESCRIPTION
R CMD check caught this since `base64_enc()` wasn't qualified. Making this change to be consistent with https://github.com/rstudio/sparklyr/pull/1203