### PR TITLE
Make spark_web() more reliable under Spark 2.X

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7 (UNRELEASED)
 
+- `spark_web()` is is more reliable under Spark 2.X by making use of a new API
+  to programmatically find the right address.
+
 - Added support in `dbWriteTable()` for `temporary = FALSE` to allow persisting
   table across connections. Changed default value for `temporary` to `TRUE` to match
   `DBI` specification, for compatibility, default value can be reverted back to 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -445,6 +445,18 @@ spark_log.spark_shell_connection <- function(sc, n = 100, filter = NULL, ...) {
 
 #' @export
 spark_web.spark_shell_connection <- function(sc, ...) {
+
+  if (spark_version(sc) >= "2.0.0" &&
+      !spark_context(sc) %>% invoke("uiWebUrl") %>% invoke("isEmpty")) {
+
+    web_url <- spark_context(sc) %>%
+      invoke("uiWebUrl") %>%
+      invoke("get") %>%
+      structure(class = "spark_web_url")
+
+    return(web_url)
+  }
+
   lines <- spark_log(sc, n = 200)
 
   uiLine <- grep("Started SparkUI at ", lines, perl=TRUE, value=TRUE)


### PR DESCRIPTION
Under Spark 2.X, we can now make use of [uiWebUrl](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext) to make `spark_web()` much more reliable.