### PR TITLE
Fix ML-related failures for 1.6

### DIFF
--- a/R/ml_clustering_kmeans.R
+++ b/R/ml_clustering_kmeans.R
@@ -95,7 +95,7 @@ ml_kmeans.tbl_spark <- function(
     predictor %>%
       ml_fit(x)
   } else {
-    if (spark_version(x) < "2.0.0")
+    if (spark_version(spark_connection(x)) < "2.0.0")
       stop("ml_kmeans() with formula interface requires Spark 2.0.0+")
     ml_generate_ml_model(x, predictor = predictor, formula = formula, features_col = features_col,
                          type = "clustering", constructor = new_ml_model_kmeans)

--- a/R/ml_clustering_kmeans.R
+++ b/R/ml_clustering_kmeans.R
@@ -1,7 +1,7 @@
 #' Spark ML -- K-Means Clustering
 #'
 #' K-means clustering with support for k-means|| initialization proposed by Bahmani et al.
-#'   Requires Spark 2.0.0 or later.
+#'   Using `ml_kmeans()` with the formula interface requires Spark 2.0+.
 #'
 #' @template roxlate-ml-clustering-algo
 #' @template roxlate-ml-clustering-params
@@ -41,9 +41,6 @@ ml_kmeans.spark_connection <- function(
   features_col = "features",
   prediction_col = "prediction",
   uid = random_string("kmeans_"), ...) {
-
-  if (spark_version(x) < "2.0.0")
-    stop("ml_kmeans() requires Spark 2.0.0+")
 
   ml_ratify_args()
 
@@ -98,6 +95,8 @@ ml_kmeans.tbl_spark <- function(
     predictor %>%
       ml_fit(x)
   } else {
+    if (spark_version(x) < "2.0.0")
+      stop("ml_kmeans() with formula interface requires Spark 2.0.0+")
     ml_generate_ml_model(x, predictor = predictor, formula = formula, features_col = features_col,
                          type = "clustering", constructor = new_ml_model_kmeans)
   }

--- a/R/ml_clustering_kmeans.R
+++ b/R/ml_clustering_kmeans.R
@@ -1,6 +1,7 @@
 #' Spark ML -- K-Means Clustering
 #'
 #' K-means clustering with support for k-means|| initialization proposed by Bahmani et al.
+#'   Requires Spark 2.0.0 or later.
 #'
 #' @template roxlate-ml-clustering-algo
 #' @template roxlate-ml-clustering-params
@@ -40,6 +41,9 @@ ml_kmeans.spark_connection <- function(
   features_col = "features",
   prediction_col = "prediction",
   uid = random_string("kmeans_"), ...) {
+
+  if (spark_version(x) < "2.0.0")
+    stop("ml_kmeans() requires Spark 2.0.0+")
 
   ml_ratify_args()
 

--- a/R/ml_feature_max_abs_scaler.R
+++ b/R/ml_feature_max_abs_scaler.R
@@ -21,6 +21,9 @@ ft_max_abs_scaler.spark_connection <- function(
   dataset = NULL,
   uid = random_string("max_abs_scaler_"), ...) {
 
+  if (spark_version(x) < "2.0.0")
+    stop("ft_max_abs_scaler() requires Spark 2.0.0+")
+
   ml_ratify_args()
 
   estimator <- ml_new_transformer(x, "org.apache.spark.ml.feature.MaxAbsScaler",

--- a/man/ml_kmeans.Rd
+++ b/man/ml_kmeans.Rd
@@ -58,6 +58,7 @@ The object returned depends on the class of \code{x}.
 }
 \description{
 K-means clustering with support for k-means|| initialization proposed by Bahmani et al.
+  Requires Spark 2.0.0 or later.
 }
 \seealso{
 See \url{http://spark.apache.org/docs/latest/ml-clustering.html} for

--- a/man/ml_kmeans.Rd
+++ b/man/ml_kmeans.Rd
@@ -58,7 +58,7 @@ The object returned depends on the class of \code{x}.
 }
 \description{
 K-means clustering with support for k-means|| initialization proposed by Bahmani et al.
-  Requires Spark 2.0.0 or later.
+  Using `ml_kmeans()` with the formula interface requires Spark 2.0+.
 }
 \seealso{
 See \url{http://spark.apache.org/docs/latest/ml-clustering.html} for

--- a/tests/testthat/test-ml-clustering-kmeans.R
+++ b/tests/testthat/test-ml-clustering-kmeans.R
@@ -5,6 +5,7 @@ test_requires("dplyr")
 data(iris)
 
 test_that("ml_kmeans param setting", {
+  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
   args <- list(
     x = sc, k = 9, max_iter = 11, tol = 1e-5,
     init_steps = 3L, init_mode = "random",
@@ -18,7 +19,7 @@ test_that("ml_kmeans param setting", {
 })
 
 test_that("ml_kmeans() default params are correct", {
-
+  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
   predictor <- ml_pipeline(sc) %>%
     ml_kmeans() %>%
     ml_stage(1)
@@ -33,6 +34,7 @@ test_that("ml_kmeans() default params are correct", {
 })
 
 test_that("'ml_kmeans' and 'kmeans' produce similar fits", {
+  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
   skip_on_cran()
 
   if (spark_version(sc) < "2.0.0")
@@ -65,10 +67,7 @@ test_that("'ml_kmeans' and 'kmeans' produce similar fits", {
 })
 
 test_that("'ml_kmeans' supports 'features' argument for backwards compat (#1150)", {
-  skip_on_cran()
-
-  if (spark_version(sc) < "2.0.0")
-    skip("requires Spark 2.0.0")
+  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
 
   iris_tbl <- testthat_tbl("iris")
 
@@ -97,8 +96,7 @@ test_that("'ml_kmeans' supports 'features' argument for backwards compat (#1150)
 })
 
 test_that("ml_model_kmeans can be used with ml_predict()", {
-  if (spark_version(sc) < "2.0.0") skip("ml_model_kmeans() not supported before 2.0.0")
-
+  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
   iris_tbl <- testthat_tbl("iris")
   iris_kmeans <- ml_kmeans(iris_tbl, ~ . - Species, centers = 5)
   expect_equal(ml_predict(iris_kmeans, iris_tbl) %>%

--- a/tests/testthat/test-ml-clustering-kmeans.R
+++ b/tests/testthat/test-ml-clustering-kmeans.R
@@ -5,7 +5,6 @@ test_requires("dplyr")
 data(iris)
 
 test_that("ml_kmeans param setting", {
-  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
   args <- list(
     x = sc, k = 9, max_iter = 11, tol = 1e-5,
     init_steps = 3L, init_mode = "random",
@@ -19,7 +18,6 @@ test_that("ml_kmeans param setting", {
 })
 
 test_that("ml_kmeans() default params are correct", {
-  test_requires_version("2.0.0", "ml_kmeans() requires Spark 2.0.0+")
   predictor <- ml_pipeline(sc) %>%
     ml_kmeans() %>%
     ml_stage(1)

--- a/tests/testthat/test-ml-feature-chisq-selector.R
+++ b/tests/testthat/test-ml-feature-chisq-selector.R
@@ -3,8 +3,7 @@ context("ml feature chisq selector")
 sc <- testthat_spark_connection()
 
 test_that("ft_chisq_select() works properly", {
-  if (spark_version(sc) < "2.0.0") skip("ft_chisq_select() not supported before 2.0.0")
-
+  test_requires_version("2.1.0", "Spark behavior changed (https://issues.apache.org/jira/browse/SPARK-17870)")
   df <- dplyr::tribble(
     ~id, ~V1, ~V2, ~V3, ~V4, ~clicked,
     7,   0,   0,   18,  1,   1,

--- a/tests/testthat/test-ml-feature-max-abs-scaler.R
+++ b/tests/testthat/test-ml-feature-max-abs-scaler.R
@@ -3,8 +3,7 @@ context("ml feature max abs scaler")
 sc <- testthat_spark_connection()
 
 test_that("ft_max_abs_scaler() works properly", {
-  if (spark_version(sc) < "2.0.0") skip("ft_max_abs_scaler() not supported before 2.0.0")
-
+  test_requires_version("2.0.0", "ft_max_abs_scaler requires Spark 2.0.0+")
   df <- data.frame(
     id = 0:2,
     V1 = c(1, 2, 4),


### PR DESCRIPTION
This PR requires Spark 2.0+ for `ml_kmeans()` when used with formula. Although k-means is supported for 1.6, one-sided formulas in `RFormula`, which is used by pipeline constructors when called via `ml_kmeans(tbl, formula)`, isn't supported before 2.0. Users can still include `ml_kmeas` stages in pipelines built by hand.

Closes https://github.com/rstudio/sparklyr/issues/1127