### PR TITLE
Disable code coverage for spark 1.6 tests to avoid duped results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ script:
     R CMD build .
     R CMD check --no-build-vignettes --no-manual --no-tests sparklyr*tar.gz
     export SPARKLYR_LOG_FILE=/tmp/sparklyr.log
-    travis_wait 30 Rscript -e 'covr::codecov()'
+    [[ $SPARK_VERSION == "2.2.0" ]] && travis_wait 30 Rscript -e 'covr::codecov()'
+    [[ $SPARK_VERSION != "2.2.0" ]] && travis_wait 30 Rscript ../.travis.R
 
 after_failure:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,15 @@ env:
 script:
   - |
     R CMD build .
-    R CMD check --no-build-vignettes --no-manual --no-tests sparklyr*tar.gz
+    if [[ $SPARK_VERSION == "2.2.0" ]]; then
+      R CMD check --no-build-vignettes --no-manual --no-tests sparklyr*tar.gz
+    else
+      R CMD check --no-build-vignettes --no-manual sparklyr*tar.gz
+    fi
     export SPARKLYR_LOG_FILE=/tmp/sparklyr.log
-    [[ $SPARK_VERSION == "2.2.0" ]] && travis_wait 30 Rscript -e 'covr::codecov()'
-    [[ $SPARK_VERSION != "2.2.0" ]] && travis_wait 30 Rscript ../.travis.R
+    if [[ $SPARK_VERSION == "2.2.0" ]]; then
+      travis_wait 30 Rscript -e 'covr::codecov()'
+    fi
 
 after_failure:
   - |


### PR DESCRIPTION
Code coverage is running for 1.6 and 2.1 tests in Travis which override each other and depending on which finished last the coverage results change, we will do coverage for 2.1 only instead.