### PR TITLE
Enable Livy tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
     if [[ $SPARK_VERSION == "2.2.0" ]]; then
       R CMD check --no-build-vignettes --no-manual --no-tests sparklyr*tar.gz
     else
-      R CMD check --no-build-vignettes --no-manual sparklyr*tar.gz
+      travis_wait 30 R CMD check --no-build-vignettes --no-manual sparklyr*tar.gz
     fi
     export SPARKLYR_LOG_FILE=/tmp/sparklyr.log
     if [[ $SPARK_VERSION == "2.2.0" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
 language: r
+
 sudo: false
-cache: packages
+
+cache:
+  packages: true
+  directories:
+    - $HOME/spark
+    - $HOME/.cache/livy
+
 warnings_are_errors: true
 
 jdk:

--- a/tests/testthat/test-zzz-livy.R
+++ b/tests/testthat/test-zzz-livy.R
@@ -2,15 +2,15 @@ context("livy")
 test_requires("dplyr")
 
 test_that("'spark_version()' works under Livy connections", {
-  skip("")
   lc <- testthat_livy_connection()
 
   version <- spark_version(lc)
-  expect_equal(version, numeric_version("2.2.0"))
+  version_expected <- Sys.getenv("SPARK_VERSION", unset = "2.2.0")
+
+  expect_equal(version, numeric_version(version_expected))
 })
 
 test_that("'copy_to()' works under Livy connections", {
-  skip("")
   lc <- testthat_livy_connection()
 
   df <- data.frame(a = c(1, 2), b = c("A", "B"), stringsAsFactors = FALSE)


### PR DESCRIPTION
Attempt to enable Livy tests in Travis which were originally disabled since the Travis machines did not have enough resources to launch Spark, tear it down, Start Livy with Spark, tear it down and relaunch Spark again. Instead, we will try to run Livy once only once after all the other tests are complete.