### PR TITLE
Fix base64 encoding use as regression from using base64enc package

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -73,7 +73,7 @@ livy_config <- function(config = spark_config(), username = NULL, password = NUL
       config[["sparklyr.livy.headers"]], list(
         Authorization = paste(
           "Basic",
-          base64encode(paste(username, password, sep = ":"))
+          base64encode(charToRaw(paste(username, password, sep = ":")))
         )
       )
     )

--- a/tests/testthat/test-zzz-livy.R
+++ b/tests/testthat/test-zzz-livy.R
@@ -28,6 +28,8 @@ test_that("'livy_config()' works with extended parameters", {
 test_that("'livy_config()' works with authentication", {
   config <- livy_config(username = "foo", password = "bar")
 
-  expect_equal(config$username, "foo")
-  expect_equal(config$username, "bar")
+  expect_equal(
+    config$sparklyr.livy.headers$Authorization,
+    "Basic Zm9vOmJhcg=="
+  )
 })

--- a/tests/testthat/test-zzz-livy.R
+++ b/tests/testthat/test-zzz-livy.R
@@ -24,3 +24,10 @@ test_that("'livy_config()' works with extended parameters", {
 
   expect_equal(as.integer(config$livy.numExecutors), 1)
 })
+
+test_that("'livy_config()' works with authentication", {
+  config <- livy_config(username = "foo", password = "bar")
+
+  expect_equal(config$username, "foo")
+  expect_equal(config$username, "bar")
+})


### PR DESCRIPTION
`livy_config()` was broken, fixed and added test, validated against Azure HDInsight cluster.