### PR TITLE
Fix input_cols printing for feature transformers

### DIFF
--- a/R/ml_print_utils.R
+++ b/R/ml_print_utils.R
@@ -16,7 +16,9 @@ ml_print_column_name_params <- function(x) {
     names() %>%
     grep("col|cols$", ., value = TRUE)
   for (param in sort(out_names))
-    cat(paste0("  ", param, ": ", ml_param(x, param), "\n"))
+    cat(paste0("  ", param, ": ",
+               paste0(ml_param(x, param), collapse = ", "),
+               "\n"))
 }
 
 ml_print_params <- function(x) {

--- a/tests/testthat/output/print/vector-assembler.txt
+++ b/tests/testthat/output/print/vector-assembler.txt
@@ -1,0 +1,5 @@
+VectorAssembler (Transformer)
+<va> 
+ (Parameters -- Column Names)
+  input_cols: foo, bar
+  output_col: features

--- a/tests/testthat/test-ml-print-methods.R
+++ b/tests/testthat/test-ml-print-methods.R
@@ -40,3 +40,10 @@ test_that("ml_tree_feature_importance() works properly", {
   expect_equal(nrow(rf_importance), 3)
   expect_equal(rf_importance, dt_importance)
 })
+
+test_that("input_cols print correctly", {
+  expect_output_file(
+    print(ft_vector_assembler(sc, c("foo", "bar"), "features", uid = "va")),
+    output_file("print/vector-assembler.txt")
+  )
+})


### PR DESCRIPTION
So that `input_cols` don't get printed on separate lines.