### PR TITLE
Fix `livy.session.start.timeout` under Livy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9001
+Version: 0.7.0-9002
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- Fixed regression blocking use of `livy.session.start.timeout` parameter
+  in Livy connections.
+
 - Added support for `sparklyr.apply.options.rscript.before` to run a custom
   command before launching the R worker role.
 

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -190,7 +190,7 @@ livy_create_session <- function(master, config) {
     conf = livy_config_get(master, config)
   )
 
-  session_params <- connection_config(list(master = master, config = config), "livy.", NULL)
+  session_params <- connection_config(list(master = master, config = config), "livy.", "livy.session.")
   if (length(session_params) > 0) data <- append(data, session_params)
 
   req <- POST(paste(master, "sessions", sep = "/"),


### PR DESCRIPTION
`livy.session.start.timeout` currently not working under Livy, see https://github.com/rstudio/sparklyr/issues/1270