### PR TITLE
Avoid using temp folder for spark_apply bootstrap script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9003
+Version: 0.7.0-9004
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- Fixed file not found error in `spark_apply()` while working under low
+  disk space.
+
 - Fixed regression blocking use of `ml_kmeans()` in Spark 1.6.x.
 
 - Fixed regression blocking use of `livy.session.start.timeout` parameter

--- a/java/spark-1.6.0/rscript.scala
+++ b/java/spark-1.6.0/rscript.scala
@@ -84,6 +84,7 @@ class Rscript(logger: Logger) {
 
     processBuilder.redirectErrorStream(true);
     processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+    processBuilder.directory(scratchDir);
 
     logger.log("is starting R process")
     val process: Process = processBuilder.start()

--- a/java/spark-1.6.0/rscript.scala
+++ b/java/spark-1.6.0/rscript.scala
@@ -13,7 +13,7 @@ import ClassUtils._
 import FileUtils._
 
 class Rscript(logger: Logger) {
-  val scratchDir: File = createTempDir
+  val scratchDir: File = new File(SparkFiles.getRootDirectory)
 
   def workerSourceFile(): String = {
     val source = Sources.sources


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/1278, this changes `sparkworker.R` from `/tmp` to the `SparkFiles` directory. This is to prevent issues where `sparkworker.R` was not found due to systems not eagerly clearing the temp folder or with not enough space.