### PR TITLE
Change livy_config_auth to livy_config in README.(Rmd|md)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -348,7 +348,7 @@ livy_service_stop()
 To connect to remote `livy` clusters that support basic authentication connect as:
 
 ```{r eval=FALSE}
-config <- livy_config_auth("<username>", "<password">)
+config <- livy_config(username="<username>", password="<password">)
 sc <- spark_connect(master = "<address>", method = "livy", config = config)
 spark_disconnect(sc)
 ```

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ livy_service_stop()
 To connect to remote `livy` clusters that support basic authentication connect as:
 
 ``` r
-config <- livy_config_auth("<username>", "<password">)
+config <- livy_config(username="<username>", password="<password">)
 sc <- spark_connect(master = "<address>", method = "livy", config = config)
 spark_disconnect(sc)
 ```


### PR DESCRIPTION
## Summary
Change `livy_config_auth()` to `livy_config()` in README.md and README.Rmd because `livy_config_auth()` was already deprecated and re-named into `livy_config()` in this [PR](https://github.com/rstudio/sparklyr/pull/381/files).