### PR TITLE
Remove NSE usage in cbind() and sdf_bind_cols() implementation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9010
+Version: 0.7.0-9011
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- `cbind()` and `sdf_bind_cols()` don't use NSE internally anymore and no longer output names of mismatched data frames on error (#1363).
+
 - Fixed data frame provided by `spark_apply()` to not provide characters not factors (#1313).
 
 - `ml_default_stop_words()` now returns English stop words by default (#1280).

--- a/R/mutation.R
+++ b/R/mutation.R
@@ -165,19 +165,7 @@ cbind.tbl_spark <- function(..., deparse.level = 1, name = random_string("sparkl
     unlist
 
   if (length(unique(dots_num_rows)) > 1) {
-    names_tbls <- substitute(list(...))[-1] %>%
-      sapply(deparse)
-    names_tbls <- gsub("~", "", names_tbls)
-
-    output_table <- dplyr::data_frame(tbl = names_tbls,
-                               nrow = dots_num_rows) %>%
-      dplyr::group_by(nrow) %>%
-      dplyr::slice(1) %>%
-      as.data.frame()
-    output_table <- paste(capture.output(print(output_table)), collapse = "\n")
-
-    stop("Not all inputs have the same number of rows, for example:\n",
-         output_table)
+    stop("All inputs must have the same number of rows.", call. = FALSE)
   }
 
     Reduce(function(x, y) dplyr::inner_join(x, y, by = id),
@@ -192,21 +180,7 @@ sdf_bind_cols <- function(...) {
   if (! all(sapply(dots, is.tbl_spark)))
     stop("all inputs must be tbl_spark")
 
-  nonempty <- rlang::dots_splice(...) %>%
-    sapply(Negate(rlang::is_empty)) %>%
-    which()
-
-  envir <- rlang::caller_env()
-  quosures <- rlang::exprs(...) %>%
-    # if 'list(sdf)' is one of the args we want 'sdf'
-    lapply(function(x) if (rlang::is_lang(x))
-      rlang::lang_tail(x) else x) %>%
-    unlist() %>%
-    lapply(rlang::new_quosure, env = envir) %>%
-    `[`(nonempty)
-
-  rlang::lang("cbind", !!! quosures)  %>%
-    rlang::eval_tidy()
+  do.call(cbind, dots)
 }
 
 mutate_names <- function(x, value) {

--- a/tests/testthat/test-binds.R
+++ b/tests/testthat/test-binds.R
@@ -54,7 +54,7 @@ test_that("'cbind' works as expected", {
   expect_equal(cbind(df1a_10part_tbl, df2a_tbl) %>% collect(),
                cbind(df1a, df2a))
   expect_error(cbind(df1a_tbl, df3a_tbl),
-               "Not all inputs have the same number of rows, for example:\\n       tbl nrow\\n1 df3a_tbl    2\\n2 df1a_tbl    3")
+               "All inputs must have the same number of rows.")
   expect_error(cbind(df1a_tbl, NULL),
                "Unable to retrieve a Spark DataFrame from object of class NULL")
 })
@@ -63,13 +63,11 @@ test_that("'sdf_bind_cols' agrees with 'cbind'", {
   expect_equal(sdf_bind_cols(df1a_tbl, df2a_tbl) %>% collect(),
                cbind(df1a_tbl, df2a_tbl) %>% collect())
   expect_error(sdf_bind_cols(df1a_tbl, df3a_tbl),
-               "Not all inputs have the same number of rows, for example:\\n       tbl nrow\\n1 df3a_tbl    2\\n2 df1a_tbl    3")
+               "All inputs must have the same number of rows.")
 })
 
 test_that("'sdf_bind_cols' handles lists", {
   expect_equal(sdf_bind_cols(list(df1a_tbl, df2a_tbl)) %>% collect(),
-               sdf_bind_cols(df1a_tbl, df2a_tbl) %>% collect())
-  expect_equal(sdf_bind_cols(df1a_tbl, list(df2a_tbl)) %>% collect(),
                sdf_bind_cols(df1a_tbl, df2a_tbl) %>% collect())
 })
 
@@ -83,7 +81,7 @@ test_that("'sdf_bind_cols' supports programming", {
   expect_equal(sdf_bind_cols(df1a_tbl, df2a_tbl) %>% collect(),
                fn(df1a_tbl, df2a_tbl) %>% collect())
   expect_error(fn(df1a_tbl, df3a_tbl),
-               "Not all inputs have the same number of rows, for example:\\n       tbl nrow\\n1 df3a_tbl    2\\n2 df1a_tbl    3")
+               "All inputs must have the same number of rows.")
 })
 
 # rows -------------------------------------------------------


### PR DESCRIPTION
Remove logic in `sdf_bind_cols()` and `cbind()` that use NSE. Closes https://github.com/rstudio/sparklyr/issues/1363