### PR TITLE
spark_install related usability improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9012
+Version: 0.7.0-9013
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),
@@ -43,6 +43,7 @@ Imports:
     rprojroot,
     rstudioapi,
     shiny (>= 1.0.1),
+    tibble,
     withr,
     xml2
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- `spark_available_versions()` was changed to only return available Spark versions, Hadoop versions
+  can be still retrieved using `hadoop = TRUE`.
+
+- `spark_installed_versions()` was changed to retrieve the full path to the installation folder.
+
 - Fixed serialization issues most commonly hit while using `spark_apply()` with NAs (#1365, #1366).
 
 - `cbind()` and `sdf_bind_cols()` don't use NSE internally anymore and no longer output names of mismatched data frames on error (#1363).

--- a/R/connection_shinyapp.R
+++ b/R/connection_shinyapp.R
@@ -47,7 +47,7 @@ rsApiWritePreference <- function(name, value) {
 
 spark_ui_avaliable_versions <- function() {
   tryCatch({
-    spark_available_versions(hadoop = TRUE)
+    spark_available_versions(show_hadoop = TRUE)
   }, error = function(e) {
     warning(e)
     spark_installed_versions()[,c("spark","hadoop")]

--- a/R/connection_shinyapp.R
+++ b/R/connection_shinyapp.R
@@ -47,7 +47,7 @@ rsApiWritePreference <- function(name, value) {
 
 spark_ui_avaliable_versions <- function() {
   tryCatch({
-    spark_available_versions()[,c("spark","hadoop")]
+    spark_available_versions(hadoop = TRUE)
   }, error = function(e) {
     warning(e)
     spark_installed_versions()[,c("spark","hadoop")]

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -63,22 +63,29 @@ spark_installed_versions <- function() {
   })
   versions <- data.frame(spark = spark,
                          hadoop = hadoop,
-                         dir = dir,
+                         dir = file.path(spark_install_dir(), dir),
                          stringsAsFactors = FALSE)
 
   versions
 }
 
-
+#' @param show_hadoop Show Hadoop distributions?
+#'
 #' @rdname spark_install
+#'
 #' @export
-spark_available_versions <- function() {
+spark_available_versions <- function(show_hadoop = FALSE) {
   versions <- read_spark_versions_json(latest = TRUE)
   versions <- versions[versions$spark >= "1.6.0", 1:2]
-  versions$install <- paste0("spark_install(version = \"",
-                             versions$spark, "\", ",
-                             "hadoop_version = \"", versions$hadoop,
-                             "\")")
+  selection <- if (show_hadoop) c("spark", "hadoop") else "spark"
+
+  versions <- versions %>%
+    dplyr::arrange(desc(spark), desc(hadoop)) %>%
+    subset(select = selection) %>%
+    unique()
+
+  rownames(versions) <- 1:nrow(versions)
+
   versions
 }
 

--- a/R/install_tools.R
+++ b/R/install_tools.R
@@ -3,6 +3,7 @@
 #' See: https://github.com/rstudio/spark-install
 #'
 #' @param project_path The path to the sparkinstall project
+#' @keywords internal
 spark_install_sync <- function(project_path) {
   sources <- c(
     "R/install.R",

--- a/man/spark_install.Rd
+++ b/man/spark_install.Rd
@@ -24,7 +24,7 @@ spark_install_tar(tarfile)
 
 spark_installed_versions()
 
-spark_available_versions()
+spark_available_versions(show_hadoop = FALSE)
 }
 \arguments{
 \item{version}{Version of Spark to install. See \code{spark_available_versions} for a list of supported versions}
@@ -45,6 +45,8 @@ spark_available_versions()
 
 \item{tarfile}{Path to TAR file conforming to the pattern spark-###-bin-(hadoop)?### where ###
 reference spark and hadoop versions respectively.}
+
+\item{show_hadoop}{Show Hadoop distributions?}
 }
 \value{
 List with information about the installed version.

--- a/man/spark_install_sync.Rd
+++ b/man/spark_install_sync.Rd
@@ -12,3 +12,4 @@ spark_install_sync(project_path)
 \description{
 See: https://github.com/rstudio/spark-install
 }
+\keyword{internal}


### PR DESCRIPTION
Minor changes to `spark_available_versions()` and `spark_installed_versions()` that make them much more usable, I believe. Most users focus only on installing/uninstalling spark versions since the hadoop version really doesn't play a role in local installations; more advanced users can still use `show_hadoop = TRUE` to get the previous behavior.

## Before

```r
spark_available_versions()
```

```
> spark_available_versions()
   spark hadoop                                                   install
5  1.6.3    2.6  spark_install(version = "1.6.3", hadoop_version = "2.6")
6  1.6.3    2.4  spark_install(version = "1.6.3", hadoop_version = "2.4")
7  1.6.3    2.3  spark_install(version = "1.6.3", hadoop_version = "2.3")
8  1.6.3   cdh4 spark_install(version = "1.6.3", hadoop_version = "cdh4")
9  1.6.2    2.6  spark_install(version = "1.6.2", hadoop_version = "2.6")
10 1.6.2    2.4  spark_install(version = "1.6.2", hadoop_version = "2.4")
11 1.6.2    2.3  spark_install(version = "1.6.2", hadoop_version = "2.3")
12 1.6.2   cdh4 spark_install(version = "1.6.2", hadoop_version = "cdh4")
13 1.6.1    2.6  spark_install(version = "1.6.1", hadoop_version = "2.6")
14 1.6.1    2.4  spark_install(version = "1.6.1", hadoop_version = "2.4")
15 1.6.1    2.3  spark_install(version = "1.6.1", hadoop_version = "2.3")
16 1.6.1   cdh4 spark_install(version = "1.6.1", hadoop_version = "cdh4")
17 1.6.0    2.6  spark_install(version = "1.6.0", hadoop_version = "2.6")
18 1.6.0    2.4  spark_install(version = "1.6.0", hadoop_version = "2.4")
19 1.6.0    2.3  spark_install(version = "1.6.0", hadoop_version = "2.3")
20 1.6.0   cdh4 spark_install(version = "1.6.0", hadoop_version = "cdh4")
21 2.0.0    2.7  spark_install(version = "2.0.0", hadoop_version = "2.7")
22 2.0.0    2.6  spark_install(version = "2.0.0", hadoop_version = "2.6")
23 2.0.0    2.4  spark_install(version = "2.0.0", hadoop_version = "2.4")
24 2.0.0    2.3  spark_install(version = "2.0.0", hadoop_version = "2.3")
25 2.0.1    2.7  spark_install(version = "2.0.1", hadoop_version = "2.7")
26 2.0.1    2.6  spark_install(version = "2.0.1", hadoop_version = "2.6")
27 2.0.1    2.4  spark_install(version = "2.0.1", hadoop_version = "2.4")
28 2.0.1    2.3  spark_install(version = "2.0.1", hadoop_version = "2.3")
29 2.0.2    2.7  spark_install(version = "2.0.2", hadoop_version = "2.7")
30 2.0.2    2.6  spark_install(version = "2.0.2", hadoop_version = "2.6")
31 2.0.2    2.4  spark_install(version = "2.0.2", hadoop_version = "2.4")
32 2.0.2    2.3  spark_install(version = "2.0.2", hadoop_version = "2.3")
33 2.1.0    2.7  spark_install(version = "2.1.0", hadoop_version = "2.7")
34 2.1.0    2.6  spark_install(version = "2.1.0", hadoop_version = "2.6")
35 2.1.0    2.4  spark_install(version = "2.1.0", hadoop_version = "2.4")
36 2.1.0    2.3  spark_install(version = "2.1.0", hadoop_version = "2.3")
37 2.1.1    2.7  spark_install(version = "2.1.1", hadoop_version = "2.7")
38 2.1.1    2.6  spark_install(version = "2.1.1", hadoop_version = "2.6")
39 2.1.1    2.4  spark_install(version = "2.1.1", hadoop_version = "2.4")
40 2.1.1    2.3  spark_install(version = "2.1.1", hadoop_version = "2.3")
41 2.2.0    2.7  spark_install(version = "2.2.0", hadoop_version = "2.7")
42 2.2.0    2.6  spark_install(version = "2.2.0", hadoop_version = "2.6")
43 2.2.1    2.7  spark_install(version = "2.2.1", hadoop_version = "2.7")
44 2.2.1    2.6  spark_install(version = "2.2.1", hadoop_version = "2.6")
45 2.3.0    2.7  spark_install(version = "2.3.0", hadoop_version = "2.7")
46 2.3.0    2.6  spark_install(version = "2.3.0", hadoop_version = "2.6")
```

and

```r
spark_installed_versions()
```
```
  spark hadoop                       dir
1 1.5.2    2.6 spark-1.5.2-bin-hadoop2.6
2 1.6.1    2.6 spark-1.6.1-bin-hadoop2.6
3 1.6.2    2.6 spark-1.6.2-bin-hadoop2.6
4 2.0.0    2.7 spark-2.0.0-bin-hadoop2.7
5 2.0.2    2.7 spark-2.0.2-bin-hadoop2.7
6 2.1.0    2.7 spark-2.1.0-bin-hadoop2.7
7 2.1.1    2.7 spark-2.1.1-bin-hadoop2.7
8 2.2.0    2.7 spark-2.2.0-bin-hadoop2.7
```

## After

```r
spark_available_versions()
```
```
   spark
1  2.3.0
2  2.2.1
3  2.2.0
4  2.1.1
5  2.1.0
6  2.0.2
7  2.0.1
8  2.0.0
9  1.6.3
10 1.6.2
11 1.6.1
12 1.6.0
```

and

```r
spark_installed_versions()
```
```
  spark hadoop                                                   dir
1 1.5.2    2.6 /Users/javierluraschi/spark/spark-1.5.2-bin-hadoop2.6
2 1.6.1    2.6 /Users/javierluraschi/spark/spark-1.6.1-bin-hadoop2.6
3 1.6.2    2.6 /Users/javierluraschi/spark/spark-1.6.2-bin-hadoop2.6
4 2.0.0    2.7 /Users/javierluraschi/spark/spark-2.0.0-bin-hadoop2.7
5 2.0.2    2.7 /Users/javierluraschi/spark/spark-2.0.2-bin-hadoop2.7
6 2.1.0    2.7 /Users/javierluraschi/spark/spark-2.1.0-bin-hadoop2.7
7 2.1.1    2.7 /Users/javierluraschi/spark/spark-2.1.1-bin-hadoop2.7
8 2.2.0    2.7 /Users/javierluraschi/spark/spark-2.2.0-bin-hadoop2.7
```