### PR TITLE
Enable Kerberos authentication with Livy

### DIFF
--- a/man/livy_config.Rd
+++ b/man/livy_config.Rd
@@ -5,7 +5,8 @@
 \title{Create a Spark Configuration for Livy}
 \usage{
 livy_config(config = spark_config(), username = NULL, password = NULL,
-  custom_headers = list(`X-Requested-By` = "sparklyr"), ...)
+  negotiate = FALSE, custom_headers = list(`X-Requested-By` = "sparklyr"),
+  ...)
 }
 \arguments{
 \item{config}{Optional base configuration}
@@ -13,6 +14,8 @@ livy_config(config = spark_config(), username = NULL, password = NULL,
 \item{username}{The username to use in the Authorization header}
 
 \item{password}{The password to use in the Authorization header}
+
+\item{negotiate}{Whether to use gssnegotiate method or not}
 
 \item{custom_headers}{List of custom headers to append to http requests. Defaults to \code{list("X-Requested-By" = "sparklyr")}.}
 

--- a/tests/testthat/test-zzz-livy.R
+++ b/tests/testthat/test-zzz-livy.R
@@ -26,11 +26,18 @@ test_that("'livy_config()' works with extended parameters", {
 })
 
 test_that("'livy_config()' works with authentication", {
-  config <- livy_config(username = "foo", password = "bar")
+  config_basic <- livy_config(username = "foo", password = "bar")
 
   expect_equal(
-    config$sparklyr.livy.headers$Authorization,
-    "Basic Zm9vOmJhcg=="
+    config_basic$sparklyr.livy.auth,
+    httr::authenticate("foo", "bar", type = "basic")
+  )
+
+  config_negotiate <- livy_config(negotiate = TRUE)
+
+  expect_equal(
+    config_negotiate$sparklyr.livy.auth,
+    httr::authenticate("", "", type = "gssnegotiate")
   )
 })
 


### PR DESCRIPTION
While both Livy and Kerberos are individually supported, using them together is not possible yet.

Currently, `livy_config` considers only Basic authentication. But, if the Livy server is using Kerberos authentication, we need to use "Negotiate (SPNEGO) authentication". If we use curl CLI, `--negotiate` will allow us to use Negotiate. With R/httr, it is available via `httr::authenticate("", "", type = "gssnegotiate")`.

c.f.:
- https://stackoverflow.com/questions/26255964/r-negotiate-authentication-with-rcurl-or-httr
- https://stackoverflow.com/a/38664954

Since it is not as simple as adding one header, it seems better to store it as `sparklyr.livy.auth` config and use it when making a request.

Note that users need to get and cache the ticket priorly, which is described on https://spark.rstudio.com/guides/connections/#kerberos