### PR TITLE
Add support for Livy 0.4 and Livy 0.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9016
+Version: 0.7.0-9017
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- Added support for Livy 0.4 and Livy 0.5.
+
 - Added support for Huber loss for linear regression (#1335).
 
 - `ft_bucketizer()` and `ft_quantile_discretizer()` now support

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -13,7 +13,7 @@
 #'   A version of Spark known to be compatible with the requested version of
 #'   \samp{livy} is chosen when possible.
 #' @export
-livy_install <- function(version       = "0.3.0",
+livy_install <- function(version       = "0.5.0",
                          spark_home    = NULL,
                          spark_version = NULL)
 {
@@ -29,7 +29,9 @@ livy_install <- function(version       = "0.3.0",
       spark_version <- switch(
         version,
         "0.2.0" = "1.6.2",
-        "0.3.0" = "2.0.1"
+        "0.3.0" = "2.0.1",
+        "0.4.0" = "2.1.0",
+        "0.5.0" = "2.2.0"
       )
     }
 
@@ -86,10 +88,18 @@ livy_install <- function(version       = "0.3.0",
   }
 
   # construct path to livy download
-  url <- sprintf(
-    "http://archive.cloudera.com/beta/livy/livy-server-%s.zip",
-    version
-  )
+  if (version <= "0.3.0") {
+    url <- sprintf(
+      "http://archive.cloudera.com/beta/livy/livy-server-%s.zip",
+      version
+    )
+  } else {
+    url <- sprintf(
+      "http://archive.apache.org/dist/incubator/livy/%s-incubating/livy-%s-incubating-bin.zip",
+      version,
+      version
+    )
+  }
 
   # download to cache directory
   ensure_directory(livy_cache)
@@ -142,7 +152,7 @@ livy_install <- function(version       = "0.3.0",
 #' @rdname livy_install
 #' @export
 livy_available_versions <- function() {
-  versions <- data.frame(livy = c("0.2.0", "0.3.0"))
+  versions <- data.frame(livy = c("0.2.0", "0.3.0", "0.4.0", "0.5.0"))
 
   versions$install <- paste0("livy_install(version = \"",
                              versions$livy,

--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -56,19 +56,19 @@ java_context <- function(sc) {
 #' @name spark-api
 #' @export
 hive_context <- function(sc) {
-  if (!is.null(sc$hive_context))
-    sc$hive_context
-  else
-    create_hive_context(sc)
+  if (is.null(sc$hive_context))
+    sc$hive_context <- create_hive_context(sc)
+
+  sc$hive_context
 }
 
 #' @name spark-api
 #' @export
 spark_session <- function(sc) {
-  if (!is.null(sc$hive_context))
-    sc$hive_context
-  else
-    create_hive_context(sc)
+  if (is.null(sc$hive_context))
+    sc$hive_context <- create_hive_context(sc)
+
+  sc$hive_context
 }
 
 #' Retrieve the Spark Connection Associated with an R Object

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -120,7 +120,7 @@ testthat_livy_connection <- function() {
   }
 
   if (nrow(livy_installed_versions()) == 0) {
-    livy_install("0.3.0", spark_version = version)
+    livy_install("0.5.0", spark_version = version)
   }
 
   expect_gt(nrow(livy_installed_versions()), 0)

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -134,7 +134,7 @@ testthat_livy_connection <- function() {
 
   if (!connected) {
     livy_service_start(
-      version = "0.3.0",
+      version = "0.5.0",
       spark_version = version,
       stdout = FALSE,
       stderr = FALSE)

--- a/tests/testthat/test-zzz-livy.R
+++ b/tests/testthat/test-zzz-livy.R
@@ -2,7 +2,6 @@ context("livy")
 test_requires("dplyr")
 
 test_that("'spark_version()' works under Livy connections", {
-  sc <- testthat_spark_connection()
   lc <- testthat_livy_connection()
 
   version <- spark_version(lc)
@@ -12,7 +11,6 @@ test_that("'spark_version()' works under Livy connections", {
 })
 
 test_that("'copy_to()' works under Livy connections", {
-  sc <- testthat_spark_connection()
   lc <- testthat_livy_connection()
 
   df <- data.frame(a = c(1, 2), b = c("A", "B"), stringsAsFactors = FALSE)
@@ -44,7 +42,6 @@ test_that("'livy_config()' works with authentication", {
 })
 
 test_that("'spark_apply()' works under Livy connections", {
-  sc <- testthat_spark_connection()
   lc <- testthat_livy_connection()
 
   df <- data.frame(id = 10)


### PR DESCRIPTION
Livy as an Apache incubation project has released 0.4 and 0.5, see https://livy.incubator.apache.org/download/. This PR adds support for both, makes 0.5 the default and slight performance improvement for Livy by eagerly caching the hive context.