### PR TITLE
Detect yarn cluster from config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9021
+Version: 0.7.0-9022
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- `yarn-cluster` now supported by connecting with `master="yarn"` and
+  `config` entry `sparklyr.shell.deploy-mode` set to `cluster` (#1404).
+  
 - Added support for `offset` argument in `ml_generalized_linear_regression()` (#1396).
 
 - `ml_save()` outputs message when model is successfully saved (#1348).

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -145,7 +145,7 @@ spark_connect <- function(master,
                              remote = spark_config_value(
                                config,
                                "sparklyr.gateway.remote",
-                               spark_master_is_yarn_cluster(master)),
+                               spark_master_is_yarn_cluster(master, config)),
                              extensions = extensions)
   } else if (method == "livy") {
     scon <- livy_connection(master = master,
@@ -320,8 +320,12 @@ spark_master_is_yarn_client <- function(master) {
   grepl("^yarn-client$", master, ignore.case = TRUE, perl = TRUE)
 }
 
-spark_master_is_yarn_cluster <- function(master) {
-  grepl("^yarn-cluster$", master, ignore.case = TRUE, perl = TRUE)
+spark_master_is_yarn_cluster <- function(master, config) {
+  grepl("^yarn-cluster$", master, ignore.case = TRUE, perl = TRUE) ||
+    (
+      identical(config[["sparklyr.shell.deploy-mode"]], cluster) &&
+      identical(master, "yarn")
+    )
 }
 
 spark_master_is_gateway <- function(master) {

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -323,7 +323,7 @@ spark_master_is_yarn_client <- function(master) {
 spark_master_is_yarn_cluster <- function(master, config) {
   grepl("^yarn-cluster$", master, ignore.case = TRUE, perl = TRUE) ||
     (
-      identical(config[["sparklyr.shell.deploy-mode"]], cluster) &&
+      identical(config[["sparklyr.shell.deploy-mode"]], "cluster") &&
       identical(master, "yarn")
     )
 }

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -33,7 +33,7 @@ shell_connection <- function(master,
   }
 
   # for yarn-cluster set deploy mode as shell arguments
-  if (spark_master_is_yarn_cluster(master)) {
+  if (spark_master_is_yarn_cluster(master, config)) {
     if (is.null(config[["sparklyr.shell.deploy-mode"]])) {
       shell_args <- c(shell_args, "--deploy-mode", "cluster")
     }
@@ -306,7 +306,7 @@ start_shell <- function(master,
     })
 
     # for yarn-cluster
-    if (spark_master_is_yarn_cluster(master) && is.null(config[["sparklyr.gateway.address"]])) {
+    if (spark_master_is_yarn_cluster(master, config) && is.null(config[["sparklyr.gateway.address"]])) {
       gatewayAddress <- config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway(config, start_time)
     }
 
@@ -322,7 +322,7 @@ start_shell <- function(master,
         paste(
           "Failed while connecting to sparklyr to port (",
           gatewayPort,
-          if (spark_master_is_yarn_cluster(master)) {
+          if (spark_master_is_yarn_cluster(master, config)) {
             paste0(
               ") and address (",
               config[["sparklyr.gateway.address"]]
@@ -505,7 +505,7 @@ initialize_connection.spark_shell_connection <- function(sc) {
       conf <- invoke_new(sc, "org.apache.spark.SparkConf")
       conf <- invoke(conf, "setAppName", sc$app_name)
 
-      if (!spark_master_is_yarn_cluster(sc$master) &&
+      if (!spark_master_is_yarn_cluster(sc$master, config) &&
           !spark_master_is_gateway(sc$master)) {
         conf <- invoke(conf, "setMaster", sc$master)
 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -505,7 +505,7 @@ initialize_connection.spark_shell_connection <- function(sc) {
       conf <- invoke_new(sc, "org.apache.spark.SparkConf")
       conf <- invoke(conf, "setAppName", sc$app_name)
 
-      if (!spark_master_is_yarn_cluster(sc$master, config) &&
+      if (!spark_master_is_yarn_cluster(sc$master, sc$config) &&
           !spark_master_is_gateway(sc$master)) {
         conf <- invoke(conf, "setMaster", sc$master)
 


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/1404, we were missing to detect `yarn-cluster` mode is master was not explicitly set to `yarn-cluster`.