### PR TITLE
`spark_table_name()` handles multiline expressions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.7.0-9025
+Version: 0.7.0-9026
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.7.1 (UNRELEASED)
 
+- `sdf_copy_to()` no longer gives a spurious warning when user enters a multiline expression for `x` (#1386).
+
 - Added `ml_vocabulary()` to extract vocabulary from count vectorizer model and `ml_topics_matrix()` to extract matrix from LDA model.
 
 - `ml_tree_feature_importance()` now works properly with decision tree classification models (#1401).

--- a/R/spark_utils.R
+++ b/R/spark_utils.R
@@ -35,7 +35,9 @@ spark_get_checkpoint_dir <- function(sc) {
 #' @export
 spark_table_name <- function(expr) {
   table_name <- deparse(expr)
-  if (grepl("^[a-zA-Z][a-zA-Z0-9_]*$", table_name)) table_name else random_string(prefix = "sparklyr_")
+  if (identical(length(table_name), 1L) &&
+      grepl("^[a-zA-Z][a-zA-Z0-9_]*$", table_name[[1]])
+  ) table_name else random_string(prefix = "sparklyr_")
 }
 
 #' Superclasses of object

--- a/tests/testthat/test-copy-to.R
+++ b/tests/testthat/test-copy-to.R
@@ -4,7 +4,7 @@ sc <- testthat_spark_connection()
 test_that("sdf_copy_to works for scala serializer", {
   skip_on_cran()
 
-  df <- matrix(0, ncol = 5, nrow = 2) %>% as_data_frame()
+  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_data_frame()
   df_tbl <- sdf_copy_to(sc, df, overwrite = TRUE, serializer = "csv_file_scala")
 
   expect_equal(
@@ -16,11 +16,21 @@ test_that("sdf_copy_to works for scala serializer", {
 test_that("sdf_copy_to works for csv serializer", {
   skip_on_cran()
 
-  df <- matrix(0, ncol = 5, nrow = 2) %>% as_data_frame()
+  df <- matrix(0, ncol = 5, nrow = 2) %>% dplyr::as_data_frame()
   df_tbl <- sdf_copy_to(sc, df, overwrite = TRUE, serializer = "csv_file")
 
   expect_equal(
     sdf_nrow(df_tbl),
     2
+  )
+})
+
+test_that("spark_table_name() doesn't warn for multiline expression (#1386)", {
+  expect_warning(
+    spark_table_name(data.frame(foo = c(1, 2, 3),
+               bar = c(2, 1, 3),
+               foobar = c("a", "b", "c"))
+               ),
+    NA
   )
 })


### PR DESCRIPTION
Fix the weird warning described in #1386.