### PR TITLE
Small livy perf improvement by caching spark version

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -717,7 +717,7 @@ livy_load_scala_sources <- function(sc) {
 
   lapply(livySourcesFiles, function(sourceFile) {
     tryCatch({
-      subpath_name <- file.path(basename(dirname(sourceFile)), sourceFile)
+      subpath_name <- file.path(basename(dirname(sourceFile)), basename(sourceFile))
       if (sparklyr_boolean_option("sparklyr.verbose")) message("Loading ", subpath_name)
 
       sources <- paste(readLines(sourceFile), collapse = "\n")

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -748,6 +748,9 @@ initialize_connection.livy_connection <- function(sc) {
       sc$spark_context
     )
 
+    # cache spark version
+    sc$spark_version <- spark_version(sc)
+
     sc$hive_context <- create_hive_context(sc)
 
     if (spark_version(sc) < "2.0.0") {


### PR DESCRIPTION
Compared execution time for ml kmeans across sparklyr versions

**0.5.6** and **0.6.4**
```
system.time({
+   kmeans_model <- iris_tbl %>%
+     select(Petal_Width, Petal_Length) %>%
+     ml_kmeans(centers = 3, ~ .)
+ })
```

```
> system.time({
+   kmeans_model <- iris_tbl %>%
+     select(Petal_Width, Petal_Length) %>%
+     ml_kmeans(centers = 3)
+ })
user  system elapsed 
  3.660   0.615  32.802 
```

**devel**

```
> system.time({
   kmeans_model <- iris_tbl %>%
     select(Petal_Width, Petal_Length) %>%
     ml_kmeans(centers = 3, ~ .)
 })
   user  system elapsed 
  9.904   2.148 143.532 
```

Light improvement with **this PR**:

```
> system.time({
   kmeans_model <- iris_tbl %>%
     select(Petal_Width, Petal_Length) %>%
     ml_kmeans(centers = 3, ~ .)
 })
   user  system elapsed 
  8.485   1.856 122.769 
```