### PR TITLE
An example of ml_pca()

### DIFF
--- a/R/ml_feature_pca.R
+++ b/R/ml_feature_pca.R
@@ -90,6 +90,18 @@ new_ml_pca_model <- function(jobj) {
 #' @details \code{ml_pca()} is a wrapper around \code{ft_pca()} that returns a
 #'   \code{ml_model}.
 #'
+#' @examples
+#' \dontrun{
+#' library(dplyr)
+#'
+#' sc <- spark_connect(master = "local")
+#' iris_tbl <- sdf_copy_to(sc, iris, name = "iris_tbl", overwrite = TRUE)
+#'
+#' iris_tbl %>%
+#'   select(-Species) %>%
+#'   ml_pca(k = 2)
+#' }
+#'
 #' @export
 #' @importFrom dplyr tbl_vars
 ml_pca <- function(x,

--- a/man/ft_pca.Rd
+++ b/man/ft_pca.Rd
@@ -66,6 +66,19 @@ When \code{dataset} is provided for an estimator transformer, the function
 \code{ml_pca()} is a wrapper around \code{ft_pca()} that returns a
   \code{ml_model}.
 }
+\examples{
+\dontrun{
+library(dplyr)
+
+sc <- spark_connect(master = "local")
+iris_tbl <- sdf_copy_to(sc, iris, name = "iris_tbl", overwrite = TRUE)
+
+iris_tbl \%>\%
+  select(-Species) \%>\%
+  ml_pca(k = 2)
+}
+
+}
 \seealso{
 See \url{http://spark.apache.org/docs/latest/ml-features.html} for
   more information on the set of transformations available for DataFrame


### PR DESCRIPTION
It's an example of ml_pca(). 
I didn't include an example for ft_pca() because ml_pca() is a wrapper around ft_pca().