### PR TITLE
Allow missing master for Databricks connections

### DIFF
--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -64,7 +64,7 @@ NULL
 #' spark_disconnect(sc)
 #'
 #' @export
-spark_connect <- function(master = "local",
+spark_connect <- function(master,
                           spark_home = Sys.getenv("SPARK_HOME"),
                           method = c("shell", "livy", "databricks", "test"),
                           app_name = "sparklyr",
@@ -78,11 +78,15 @@ spark_connect <- function(master = "local",
   method <- match.arg(method)
 
   # master can be missing if it's specified in the config file
-  if (missing(master) && method != "databricks") {
-    master <- config$spark.master
-    if (is.null(master))
-      stop("You must either pass a value for master or include a spark.master ",
-           "entry in your config.yml")
+  if (missing(master)) {
+    if (identical(method, "databricks")) {
+      master <- "databricks"
+    } else {
+      master <- config$spark.master
+      if (is.null(master))
+        stop("You must either pass a value for master or include a spark.master ",
+             "entry in your config.yml")
+    }
   }
 
   # determine whether we need cores in master

--- a/man/spark-connections.Rd
+++ b/man/spark-connections.Rd
@@ -12,7 +12,7 @@
 \alias{spark_disconnect_all}
 \title{Manage Spark Connections}
 \usage{
-spark_connect(master = "local", spark_home = Sys.getenv("SPARK_HOME"),
+spark_connect(master, spark_home = Sys.getenv("SPARK_HOME"),
   method = c("shell", "livy", "databricks", "test"), app_name = "sparklyr",
   version = NULL, hadoop_version = NULL, config = spark_config(),
   extensions = sparklyr::registered_extensions(), ...)


### PR DESCRIPTION
Pending testing on Databricks.

This should resolve both https://github.com/rstudio/sparklyr/issues/1461 and https://github.com/rstudio/sparklyr/issues/1373. Note that the default was never respected which is why it was removed.