### PR TITLE
Keeping old Backend.main() shim for databricks mode

### DIFF
--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -64,7 +64,7 @@ NULL
 #' spark_disconnect(sc)
 #'
 #' @export
-spark_connect <- function(master = "local",
+spark_connect <- function(master,
                           spark_home = Sys.getenv("SPARK_HOME"),
                           method = c("shell", "livy", "databricks", "test"),
                           app_name = "sparklyr",
@@ -78,11 +78,15 @@ spark_connect <- function(master = "local",
   method <- match.arg(method)
 
   # master can be missing if it's specified in the config file
-  if (missing(master) && method != "databricks") {
-    master <- config$spark.master
-    if (is.null(master))
-      stop("You must either pass a value for master or include a spark.master ",
-           "entry in your config.yml")
+  if (missing(master)) {
+    if (identical(method, "databricks")) {
+      master <- "databricks"
+    } else {
+      master <- config$spark.master
+      if (is.null(master))
+        stop("You must either pass a value for master or include a spark.master ",
+             "entry in your config.yml")
+    }
   }
 
   # determine whether we need cores in master

--- a/java/spark-1.5.2/backend.scala
+++ b/java/spark-1.5.2/backend.scala
@@ -459,3 +459,10 @@ class Backend() {
     }
   }
 }
+
+object Backend {
+  /* Leaving this entry for backward compatibility with databricks */
+  def main(args: Array[String]): Unit = {
+    Shell.main(args)
+  }
+}


### PR DESCRIPTION
This patch address issue 1461. Latest sparklyr code refactoring caused two issues:
1. default value for master was removed
2. main class shim in Backend was removed.

This patch fixes both. For the first one I am copying @kevinykuo's fix here. For the second issue I am adding back the Shim.

For some context, Databricks was supposed to switch to switch to new main class last year. Unfortunately, my patch in our runtime got reverted and I did not realize. I am making sure it happens now, but for backwards compatibility it would be good to keep the shim for a bit longer.

cc @javierluraschi 