### PR TITLE
Fix Livy under spark 1.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr 0.9 (unreleased)
 
+# Sparklyr 0.8.2 (unreleased)
+
+- Fixed regression for connections using Livy and Spark 1.6.X.
+
 # Sparklyr 0.8.1
 
 - Fixed regression for connections using `mode` with `databricks`.

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -753,6 +753,7 @@ initialize_connection.livy_connection <- function(sc) {
     sc$spark_version <- spark_version(sc)
 
     sc$hive_context <- create_hive_context(sc)
+    sc$hive_context$connection <- sc
 
     if (spark_version(sc) < "2.0.0") {
       params <- connection_config(sc, "spark.sql.")

--- a/inst/livy/spark-1.6.0/livyutils.scala
+++ b/inst/livy/spark-1.6.0/livyutils.scala
@@ -8,7 +8,6 @@ object LivyUtils {
     "Logger" -> new Logger("", 0),
     "SQLUtils" -> SQLUtils,
     "Utils" -> Utils,
-    "Repartition" -> Repartition,
     "ApplyUtils" -> ApplyUtils,
     "WorkerHelper" -> WorkerHelper,
     "WorkerUtils" -> WorkerUtils,


### PR DESCRIPTION
Regression from 0.8.0 release that affects Livy and Spark 1.6.