### PR TITLE
Add support for https in resource manager when using yarn cluster

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.8.1-9000
+Version: 0.8.1-9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,11 @@
 
 # Sparklyr 0.8.2 (unreleased)
 
+- Support for resource managers using `https` in `yarn-cluster` mode (#1459).
+
 - Fixed regression for connections using Livy and Spark 1.6.X.
 
 # Sparklyr 0.8.1
-
-- Support for resource managers using `https` in `yarn-cluster` mode (#1459).
 
 - Fixed regression for connections using `mode` with `databricks`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 # Sparklyr 0.8.1
 
+- Support for resource managers using `https` in `yarn-cluster` mode (#1459).
+
 - Fixed regression for connections using `mode` with `databricks`.
 
 # Sparklyr 0.8.0

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -167,6 +167,7 @@ spark_yarn_cluster_get_resource_manager_webapp <- function() {
 
     mainRMWebapp <- NULL
     propCandidates <- c(
+      "yarn.resourcemanager.webapp.https.address.",
       "yarn.resourcemanager.webapp.address.",
       "yarn.resourcemanager.admin.address."
     )


### PR DESCRIPTION
Fix for https://github.com/rstudio/sparklyr/issues/1459