### PR TITLE
Support for Spark 2.3 in local windows clusters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.8.2-9000
+Version: 0.8.2-9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Sparklyr 0.9 (unreleased)
 
-# Sparklyr 0.8.2 (unreleased)
+- Support for Spark 2.3 in local windows clusters (#1473).
+
+# Sparklyr 0.8.2
 
 - Support for resource managers using `https` in `yarn-cluster` mode (#1459).
 

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -216,7 +216,7 @@ spark_install <- function(version = NULL,
       )
 
       if (.Platform$OS.type == "windows") {
-        hivePath <- normalizePath(file.path(installInfo$sparkVersionDir, "tmp", "hive"), mustWork = FALSE)
+        hivePath <- normalizePath(file.path(installInfo$sparkVersionDir, "tmp", "hive"), mustWork = FALSE, winslash = "/")
 
         hiveProperties <- c(hiveProperties, list(
           "hive.exec.scratchdir" = hivePath,


### PR DESCRIPTION
Paths in Spark 2.3.0 under windows no longer support `\`, fixing by using '/' in windows as well. See #1473.

Notice that applying this fix requires running in Windows:

```r
spark_install(version = "2.3.0", reset = TRUE)
```
