### PR TITLE
Correct `tidy()` output for linear models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.8.3-9000
+Version: 0.8.3-9001
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# Sparklyr 0.9 (unreleased)
+# Sparklyr 0.8.4 (unreleased)
+
+- `broom::tidy()` for linear regression and generalized linear regression models now give correct results (#1501).
 
 # Sparklyr 0.8.3
 

--- a/R/ml_summary.R
+++ b/R/ml_summary.R
@@ -1,7 +1,6 @@
 new_ml_summary <- function(jobj, ..., subclass = NULL) {
   structure(
     list(
-      uid = jobj$uid,
       type = jobj_info(jobj)$class,
       ...,
       .jobj = jobj

--- a/R/ml_utils.R
+++ b/R/ml_utils.R
@@ -111,3 +111,10 @@ spark_sql_column <- function(sc, col, alias = NULL) {
     jobj <- invoke(jobj, "alias", alias)
   jobj
 }
+
+make_stats_arranger <- function(fit_intercept) {
+  if (fit_intercept)
+    function(x) { force(x); c(tail(x, 1), head(x, length(x) - 1)) }
+  else
+    identity
+}

--- a/R/tidiers_ml_linear_models.R
+++ b/R/tidiers_ml_linear_models.R
@@ -47,8 +47,8 @@ tidy.ml_model_generalized_linear_regression <- function(x, exponentiate = FALSE,
   c(coefficients, statistics) %>%
     as.data.frame() %>%
     broom::fix_data_frame(newnames = new_names) %>%
-    mutate(estimate = trans(!!sym("estimate"))) %>%
-    select(!!!syms(vars))
+    dplyr::mutate(estimate = trans(!!sym("estimate"))) %>%
+    dplyr::select(!!!syms(vars))
 
 }
 

--- a/tests/testthat/test-broom.R
+++ b/tests/testthat/test-broom.R
@@ -21,6 +21,9 @@ test_that("tidy.{glm type models} works", {
              exp.names = c("term", "estimate", "statistic", "p.value"))
   expect_equal(td2$term, c("(Intercept)", "wt", "disp"))
 
+  glmfit1_r <- glm(mpg ~ wt, mtcars, family = "gaussian")
+  expect_equal(broom::tidy(glmfit1_r), broom::tidy(glmfit1))
+
   lmfit1 <- ml_linear_regression(mtcars_tbl, "mpg ~ wt")
   td1 <- tidy(lmfit1)
   check_tidy(td1, exp.row = 2,
@@ -32,6 +35,9 @@ test_that("tidy.{glm type models} works", {
   check_tidy(td2, exp.row = 3,
              exp.names = c("estimate", "std.error", "statistic", "p.value"))
   expect_equal(td2$term, c("(Intercept)", "wt", "disp"))
+
+  lmfit1_r <- lm(mpg ~ wt, mtcars)
+  expect_equal(broom::tidy(lmfit1_r), broom::tidy(lmfit1))
 })
 
 test_that("augment.{glm type models} works", {


### PR DESCRIPTION
This change corrects the order of statistics associated with parameter estimates in the `broom::tidy()` output of lm and glm models. Fixes #1501.