### PR TITLE
Improve spark_connect() version precedence

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 # Sparklyr 0.8.4 (unreleased)
 
-- `sdf_bind_rows()` prepends id column to match column order changes in `dplyr 0.7.5`.
+- Changed `spark_connect()` to give precedence to the `version` parameter over `SPARK_HOME_VERSION` and
+  other automatic version detection mechanisms, improved automatic version detection in Spark 2.X.
+  
+- Fixed `sdf_bind_rows()` with `dplyr 0.7.5` and prepend id column instead of appending it to match
+  behavior.
 
 - `broom::tidy()` for linear regression and generalized linear regression models now give correct results (#1501).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.8.4 (unreleased)
 
+- Support for `sparklyr.spark-submit` as `config` entry to allow customizing the `spark-submit`
+  command.
+
 - Changed `spark_connect()` to give precedence to the `version` parameter over `SPARK_HOME_VERSION` and
   other automatic version detection mechanisms, improved automatic version detection in Spark 2.X.
   

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -210,6 +210,9 @@ start_shell <- function(master,
                            unix = c("spark2-submit", "spark-submit"),
                            windows = "spark-submit2.cmd")
 
+    # allow users to override spark-submit if needed
+    spark_submit <- spark_config_value(config, "sparklyr.spark-submit", spark_submit)
+
     spark_submit_paths <- unlist(lapply(
       spark_submit,
       function(submit_path) {
@@ -217,7 +220,7 @@ start_shell <- function(master,
       }))
 
     if (!any(file.exists(spark_submit_paths))) {
-      stop("Failed to find spark-submit under '", spark_home, "', please verify SPARK_HOME.")
+      stop("Failed to find '", paste(spark_submit, collapse = "' or '"), "' under '", spark_home, "', please verify SPARK_HOME.")
     }
 
     spark_submit_path <- spark_submit_paths[[which(file.exists(spark_submit_paths))[[1]]]]

--- a/R/spark_version.R
+++ b/R/spark_version.R
@@ -51,6 +51,9 @@ spark_version_from_home_version <- function() {
 #' @export
 spark_version_from_home <- function(spark_home, default = NULL) {
   versionAttempts <- list(
+    useDefault = function() {
+      default
+    },
     useEnvironmentVariable = function() {
       spark_version_from_home_version()
     },
@@ -67,7 +70,8 @@ spark_version_from_home <- function(spark_home, default = NULL) {
     useAssemblies = function() {
       candidateVersions <- list(
         list(path = "lib", pattern = "spark-assembly-([0-9\\.]*)-hadoop.[0-9\\.]*\\.jar"),
-        list(path = "yarn", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar")
+        list(path = "yarn", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar"),
+        list(path = "yarn", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar")
       )
 
       candidateFiles <- lapply(candidateVersions, function(e) {
@@ -90,9 +94,6 @@ spark_version_from_home <- function(spark_home, default = NULL) {
           return(match[[1]][[2]])
         }
       }
-    },
-    useDefault = function() {
-      default
     }
   )
 


### PR DESCRIPTION
CDH user reported:

```
sc <- spark_connect(master = "yarn-client", version="2.2.0", spark_home = '/opt/cloudera/parcels/SPARK2-2.2.0.cloudera1-1.cdh5.12.0.p0.######/') 

Error in force(code) : 
Failed while connecting to sparklyr to port (8880) for sessionid (#####): Gateway in port (8880) does not have the requested session registered
Path: /opt/cloudera/parcels/SPARK2-2.2.0.cloudera1-1.cdh5.12.0.p0.######/bin/spark2-submit 
Parameters: --class, sparklyr.Shell, '/usr/lib64/R/library/sparklyr/java/sparklyr-1.6-2.10.jar', 8880, ##### 
Log: /tmp/Rtmpi####w/file#####a5c6e2d_spark.log
```

Notice that `sparklyr` is choosing the `sparklyr-1.6-2.10.jar` jar when `version="2.2.0"` is being explicitly requested; additionally, `sparklyr` was failing to correctly detect the installed version in `SPARK_HOME`.