### PR TITLE
adds support for printing the RDD debug string 

### DIFF
--- a/R/spark_utils.R
+++ b/R/spark_utils.R
@@ -56,3 +56,18 @@ jobj_class <- function(jobj, simple_name = TRUE) {
                 ensure_scalar_boolean(simple_name)) %>%
     unlist()
 }
+
+#' Description of dependencies for debugging
+#' 
+#' Print a plan of execution to generate \code{.data}. This plan will, among other things, show the
+#' number of partitions in parenthesis at the far left and indicate stages using indendatations.
+#' 
+#' @param x An \R object wrapping, or containing, a Spark DataFrame.
+#' @export
+spark_debug_string <- function(x) {
+  spark_dataframe(x) %>% 
+    invoke("rdd") %>% 
+    invoke("toDebugString") %>% 
+    strsplit("\n", fixed=TRUE) %>%
+    unlist()
+}

--- a/R/spark_utils.R
+++ b/R/spark_utils.R
@@ -64,10 +64,17 @@ jobj_class <- function(jobj, simple_name = TRUE) {
 #' 
 #' @param x An \R object wrapping, or containing, a Spark DataFrame.
 #' @export
-spark_debug_string <- function(x) {
-  spark_dataframe(x) %>% 
+spark_debug_string <- function(x, print=TRUE) {
+  debug_string <- x %>%
+    spark_dataframe() %>% 
     invoke("rdd") %>% 
-    invoke("toDebugString") %>% 
+    invoke("toDebugString") 
+  
+  if (print)
+    cat(debug_string)
+  
+  debug_string %>% 
     strsplit("\n", fixed=TRUE) %>%
-    unlist()
+    unlist() %>%
+    invisible()
 }

--- a/R/spark_utils.R
+++ b/R/spark_utils.R
@@ -59,7 +59,7 @@ jobj_class <- function(jobj, simple_name = TRUE) {
 
 #' Description of dependencies for debugging
 #' 
-#' Print a plan of execution to generate \code{.data}. This plan will, among other things, show the
+#' Print a plan of execution to generate \code{x}. This plan will, among other things, show the
 #' number of partitions in parenthesis at the far left and indicate stages using indendatations.
 #' 
 #' @param x An \R object wrapping, or containing, a Spark DataFrame.

--- a/tests/testthat/test-spark-utils.R
+++ b/tests/testthat/test-spark-utils.R
@@ -31,3 +31,9 @@ test_that("jobj_class() works", {
       "Object")
   )
 })
+
+test_that("debug_string works", {
+  spk_iris <- copy_to(sc, iris, overwrite = TRUE)
+  debug <- spark_debug_string(spk_iris)
+  expect_true(grepl("^\\(1\\)", debug[1]))
+})

--- a/tests/testthat/test-spark-utils.R
+++ b/tests/testthat/test-spark-utils.R
@@ -34,6 +34,6 @@ test_that("jobj_class() works", {
 
 test_that("debug_string works", {
   spk_iris <- copy_to(sc, iris, overwrite = TRUE)
-  debug <- spark_debug_string(spk_iris)
+  debug <- spark_debug_string(spk_iris, print=FALSE)
   expect_true(grepl("^\\(1\\)", debug[1]))
 })


### PR DESCRIPTION
This mimics the pySpark `toDebugString` method. Useful for diagnosing how spark is splitting a pipeline up into stages and also for inspecting the parallelization (number of partitions) at each stage.