### PR TITLE
Attempt to fix travis covr escaping

### DIFF
--- a/.travis.R
+++ b/.travis.R
@@ -1,5 +1,15 @@
-parent_dir <- dir("../", full.names = TRUE)
-sparklyr_package <- parent_dir[grepl("sparklyr_", parent_dir)]
-install.packages(sparklyr_package, repos = NULL, type = "source")
+args <- commandArgs(trailingOnly=TRUE)
 
-source("testthat.R")
+if (length(args) == 0) {
+  stop("Missing arguments")
+} else if (args[[1]] == "--testthat") {
+  parent_dir <- dir("../", full.names = TRUE)
+  sparklyr_package <- parent_dir[grepl("sparklyr_", parent_dir)]
+  install.packages(sparklyr_package, repos = NULL, type = "source")
+
+  source("testthat.R")
+} else if (args[[1]] == "--coverage") {
+  covr::codecov()
+} else {
+  stop("Unsupported arguments")
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
     export SPARKLYR_LOG_FILE=/tmp/sparklyr.log
     if [[ $SPARK_VERSION == "2.3.0" ]]; then
       R CMD check --no-build-vignettes --no-manual --no-tests sparklyr*tar.gz
-      travis_wait 35 Rscript -e "covr::codecov()"
+      travis_wait 35 Rscript .travis.R --coverage
     else
       travis_wait 30 R CMD check --no-build-vignettes --no-manual sparklyr*tar.gz
     fi
@@ -36,5 +36,5 @@ after_failure:
     grep -B 10 -A 20 ERROR /tmp/sparklyr.log
     cd tests
     export NOT_CRAN=true
-    travis_wait 35 Rscript ../.travis.R
+    travis_wait 35 Rscript ../.travis.R --testthat
     sleep 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
     export SPARKLYR_LOG_FILE=/tmp/sparklyr.log
     if [[ $SPARK_VERSION == "2.3.0" ]]; then
       R CMD check --no-build-vignettes --no-manual --no-tests sparklyr*tar.gz
-      travis_wait 35 Rscript -e 'covr::codecov()'
+      travis_wait 35 Rscript -e "covr::codecov()"
     else
       travis_wait 30 R CMD check --no-build-vignettes --no-manual sparklyr*tar.gz
     fi


### PR DESCRIPTION
Looks like a change in travis causing... 

```
/home/travis/.travis/job_stages: eval: line 57: syntax error near unexpected token `('
/home/travis/.travis/job_stages: eval: line 57: `Rscript -e covr::codecov() '
```