### PR TITLE
Add support Livy for MapR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.9.0 (unreleased)
 
+- Fixed Livy version with MapR distributions.
+
 - Avoid preparing windows environment in non-local connections.
 
 - Removed `install` column from `livy_available_versions()`.

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -704,6 +704,7 @@ livy_load_scala_sources <- function(sc) {
 
   livySparkVersion <- livy_post_statement(sc, "sc.version") %>%
     gsub("^.+= |[\n\r \t]", "", .) %>%
+    spark_version_clean() %>%
     numeric_version()
 
   livySourcesFiles <- livySourcesFiles[sourceOrder] %>%
@@ -712,6 +713,7 @@ livy_load_scala_sources <- function(sc) {
         dirname() %>%
         basename() %>%
         gsub("^spark-", "", .) %>%
+        spark_version_clean() %>%
         numeric_version()
       requiredVersion <= livySparkVersion
     }, .)


### PR DESCRIPTION
From gitter:

```
with version greater than 0.7.0, I get an error Failed to initialize livy connection: invalid version specification '2.2.1-mapr-1803'
```