### PR TITLE
Remove cancellable internal state

### DIFF
--- a/R/core_invoke.R
+++ b/R/core_invoke.R
@@ -16,10 +16,8 @@ core_invoke_sync <- function(sc)
 
 core_invoke_cancel_running <- function(sc)
 {
-  if (is.null(sc$spark_context) || !is.null(sc$state$cancelling))
+  if (is.null(sc$spark_context))
     return()
-
-  sc$state$cancelling <- TRUE
 
   connection_progress_context(sc, function() {
     invoke(sc$spark_context, "cancelAllJobs")


### PR DESCRIPTION
With further improvements to monitored connections, we shouldn't need to track internal cancelling state anymore.