### PR TITLE
Fix hang in some operations caused by monitored connection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.8.4.9003
+Version: 0.8.4.9004
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # Sparklyr 0.9.0 (unreleased)
 
+### Monitoring
+
+- Support for interrupting long running operations and recover gracefully
+  using the same connection.
+  
+- Support cancelling Spark jobs by interrupting R session.
+
+- Support for monitoring job progress within RStudio, required RStudio 1.2.
+
 ### Data
 
 - Added support to read and write ORC files using `spark_read_orc()` and

--- a/R/connection_progress.R
+++ b/R/connection_progress.R
@@ -19,7 +19,7 @@ connection_progress_update <- function(jobName, progressUnits)
     api$add_job(jobName, progressUnits = progressUnits, autoRemove = FALSE)
 }
 
-connection_progress <- function(sc, terminated = FALSE)
+connection_progress_base <- function(sc, terminated = FALSE)
 {
   env <- sc$state$progress
 
@@ -149,6 +149,14 @@ connection_progress_context <- function(sc, f)
   f()
 }
 
+connection_progress <- function(sc, terminated = FALSE)
+{
+  tryCatch({
+    connection_progress_base(sc, terminated)
+  }, error = function(e) {
+    # ignore all connection progress errors
+  })
+}
 
 connection_progress_terminated <- function(sc)
 {

--- a/R/connection_progress.R
+++ b/R/connection_progress.R
@@ -144,6 +144,8 @@ connection_progress_context <- function(sc, f)
   sc$state$use_monitoring <- TRUE
   on.exit(sc$state$use_monitoring <- FALSE)
 
+  sc$config$sparklyr.backend.timeout <- 1
+
   f()
 }
 

--- a/R/core_invoke.R
+++ b/R/core_invoke.R
@@ -19,6 +19,10 @@ core_invoke_cancel_running <- function(sc)
   if (is.null(sc$spark_context))
     return()
 
+  # if something fails while using a monitored connection we don't cancel jobs
+  if (!identical(sc$use_monitoring, TRUE))
+    return()
+
   connection_progress_context(sc, function() {
     invoke(sc$spark_context, "cancelAllJobs")
   })

--- a/R/core_invoke.R
+++ b/R/core_invoke.R
@@ -16,10 +16,8 @@ core_invoke_sync <- function(sc)
 
 core_invoke_cancel_running <- function(sc)
 {
-  if (is.null(sc$spark_context) || !is.null(sc$state$cancelling))
+  if (is.null(sc$spark_context))
     return()
-
-  sc$state$cancelling <- TRUE
 
   connection_progress_context(sc, function() {
     invoke(sc$spark_context, "cancelAllJobs")


### PR DESCRIPTION
Fix a hang with reprex:

```
sc <- spark_connect(master = "local")
sdf_len(sc, 10) %>% spark_apply(function(e) { Sys.sleep(3) ; e })
```

reproduce-able only on the first run, apparently, caused by race condition accessing tracking object in spark context.

Made also monitored connections resilient to errors since they should never cause jobs to be aborted.