### PR TITLE
Fix monitoring hang under Spark 1.6.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,9 @@
 
 - Support for monitoring job progress within RStudio, required RStudio 1.2.
 
+- Progress reports can be turned off by setting `sparklyr.progress` to `FALSE`
+  in `spark_config()`.
+
 ### Data
 
 - Added support to read and write ORC files using `spark_read_orc()` and

--- a/R/connection_progress.R
+++ b/R/connection_progress.R
@@ -14,15 +14,20 @@ connection_progress_update <- function(jobName, progressUnits, url)
 {
   api <- connection_progress_api()
   if ("actions" %in% names(formals(api$add_job)) && nchar(url) > 0) {
+    jobActions <- NULL
+    if (nchar(url) > 0) {
+      jobActions <- list(
+        info = function(id) {
+          browseURL(url)
+        }
+      )
+    }
+
     api$add_job(jobName,
                 progressUnits = progressUnits,
                 show = FALSE,
                 autoRemove = FALSE,
-                actions = list(
-                  info = function(id) {
-                    browseURL(url)
-                  }
-                ))
+                actions = jobActions)
   } else if ("show" %in% names(formals(api$add_job))) {
     api$add_job(jobName,
                 progressUnits = progressUnits,
@@ -55,9 +60,7 @@ connection_progress_base <- function(sc, terminated = FALSE)
     connection_progress_context(sc, function() {
       if (is.null(env$web_url)) {
         env$web_url <- tryCatch({
-          spark_context(sc) %>%
-            invoke("uiWebUrl") %>%
-            invoke("get")
+          spark_web(sc)
         }, error = function(e) {
           ""
         })

--- a/R/connection_progress.R
+++ b/R/connection_progress.R
@@ -181,6 +181,8 @@ connection_progress_context <- function(sc, f)
 
 connection_progress <- function(sc, terminated = FALSE)
 {
+  if (!spark_config_logical(sc$config, "sparklyr.progress", TRUE)) return()
+
   tryCatch({
     connection_progress_base(sc, terminated)
   }, error = function(e) {
@@ -190,5 +192,7 @@ connection_progress <- function(sc, terminated = FALSE)
 
 connection_progress_terminated <- function(sc)
 {
+  if (!spark_config_logical(sc$config, "sparklyr.progress", TRUE)) return()
+
   connection_progress(sc, terminated = TRUE)
 }

--- a/R/core_config.R
+++ b/R/core_config.R
@@ -9,3 +9,11 @@
 spark_config_value <- function(config, name, default = NULL) {
   if (!name %in% names(config)) default else config[[name]]
 }
+
+spark_config_integer <- function(config, name, default = NULL) {
+  as.integer(spark_config_value(config, name, default))
+}
+
+spark_config_logical <- function(config, name, default = NULL) {
+  as.logical(spark_config_value(config, name, default))
+}


### PR DESCRIPTION
Using unsupported Spark 2.0.0 seems to have fixed this hang, regardless, also adding configuration option to turn off progress updates. See https://github.com/rstudio/sparklyr/issues/1576