### PR TITLE
Fix regression from streaming feature while reading CSV with renamed columns

### DIFF
--- a/R/data_csv.R
+++ b/R/data_csv.R
@@ -57,7 +57,9 @@ spark_csv_read <- function(sc,
     options <- invoke(options, "option", csvOptionName, csvOptions[[csvOptionName]])
   }
 
-  if (identical(columns, NULL)) {
+  columnsHaveTypes <- !identical(columns, NULL) && length(names(columns)) > 0
+
+  if (identical(columns, NULL) || !columnsHaveTypes) {
     optionSchema <- options
   }
   else {
@@ -70,7 +72,6 @@ spark_csv_read <- function(sc,
     spark_csv_load_name(sc),
     path)
 
-  columnsHaveTypes <- !identical(columns, NULL) && length(names(columns)) > 0
   if ((identical(columns, NULL) && identical(csvOptions$header, "false")) ||
       (!identical(columns, NULL) && !columnsHaveTypes)) {
     if (!identical(columns, NULL)) {

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -93,7 +93,7 @@ spark_read_csv <- function(sc,
     sc,
     spark_normalize_path(path),
     options,
-    if (columnsHaveTypes) columns else NULL)
+    columns)
 
   spark_partition_register_df(sc, df, name, repartition, memory)
 }

--- a/tests/testthat/test-read-write.R
+++ b/tests/testthat/test-read-write.R
@@ -108,7 +108,7 @@ test_that("spark_read_text() and spark_write_text() read and write basic files",
 })
 
 test_that("spark_write_table() can append data", {
-  if (spark_version(sc) < "2.2.0") skip("svc not supported before 2.2.0")
+  if (spark_version(sc) < "2.2.0") skip("tables not supported before 2.2.0")
   test_requires("dplyr")
 
   iris_tbl <- testthat_tbl("iris")
@@ -127,7 +127,7 @@ test_that("spark_write_table() can append data", {
 })
 
 test_that("spark_write_table() can write data", {
-  if (spark_version(sc) < "2.2.0") skip("svc not supported before 2.2.0")
+  if (spark_version(sc) < "2.2.0") skip("tables not supported before 2.2.0")
   test_requires("dplyr")
 
   df <- copy_to(sc, data.frame(id = 1L))
@@ -137,4 +137,19 @@ test_that("spark_write_table() can write data", {
   append_table <- tbl(sc, "test_write_table_new")
 
   expect_equal(sdf_nrow(append_table), 1)
+})
+
+test_that("spark_read_csv() can rename columns", {
+  csv <- file("test.csv", "w+")
+  cat("a,b,c\n1,2,3", file = csv)
+  close(csv)
+
+  df <- spark_read_csv(
+    sc,
+    name = "test_column_rename",
+    path = "test.csv",
+    columns = c("AA", "BB", "CC")
+  ) %>% collect()
+
+  expect_equal(names(df), c("AA", "BB", "CC"))
 })


### PR DESCRIPTION
Reprex:

```
  csv <- file("test.csv", "w+")
  cat("a,b,c\n1,2,3", file = csv)
  close(csv)

  df <- spark_read_csv(
    sc,
    name = "test_column_rename",
    path = "test.csv",
    columns = c("AA", "BB", "CC")
  ) %>% collect()

  expect_equal(names(df), c("AA", "BB", "CC"))
```