### PR TITLE
Don't poll livy session repetitively when validating

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -511,15 +511,13 @@ livy_validate_master <- function(master, config) {
       retriesErr <- err
     })
 
+    if (is.null(retriesErr)) return(NULL)
+
     retries <- retries - 1;
     Sys.sleep(1)
   }
 
-  if (!is.null(retriesErr)) {
-    stop("Failed to connect to Livy service at ", master, ". ", retriesErr$message)
-  }
-
-  NULL
+  stop("Failed to connect to Livy service at ", master, ". ", retriesErr$message)
 }
 
 livy_connection_not_used_warn <- function(value, default = NULL, name = deparse(substitute(value))) {

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -505,6 +505,8 @@ livy_validate_master <- function(master, config) {
   retries <- 5
   retriesErr <- NULL
   while (retries >= 0) {
+    if (!is.null(retriesErr)) Sys.sleep(1)
+
     tryCatch({
       livy_get_sessions(master, config)
     }, error = function(err) {
@@ -514,7 +516,6 @@ livy_validate_master <- function(master, config) {
     if (is.null(retriesErr)) return(NULL)
 
     retries <- retries - 1;
-    Sys.sleep(1)
   }
 
   stop("Failed to connect to Livy service at ", master, ". ", retriesErr$message)


### PR DESCRIPTION
Quick fix https://github.com/rstudio/sparklyr/issues/1562, should save a few seconds when connecting via Livy