### PR TITLE
Fix download urls for recent spark versions

### DIFF
--- a/inst/extdata/versions.json
+++ b/inst/extdata/versions.json
@@ -254,25 +254,25 @@
   {
     "spark": "2.2.1",
     "hadoop": "2.7",
-    "base": "https://www-us.apache.org/dist/spark/spark-2.2.1/",
+    "base": "https://archive.apache.org/dist/spark/spark-2.2.1/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
   },
   {
     "spark": "2.2.1",
     "hadoop": "2.6",
-    "base": "https://www-us.apache.org/dist/spark/spark-2.2.1/",
+    "base": "https://archive.apache.org/dist/spark/spark-2.2.1/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
   },
   {
     "spark": "2.3.0",
     "hadoop": "2.7",
-    "base": "https://www-us.apache.org/dist/spark/spark-2.3.0/",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.0/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
   },
   {
     "spark": "2.3.0",
     "hadoop": "2.6",
-    "base": "https://www-us.apache.org/dist/spark/spark-2.3.0/",
+    "base": "https://archive.apache.org/dist/spark/spark-2.3.0/",
     "pattern": "spark-%s-bin-hadoop%s.tgz"
   }
 ]


### PR DESCRIPTION
Fix for https://github.com/rstudio/sparklyr/issues/1602, Spark download URLs changed for recent versions.