### PR TITLE
[WIP] Don't force index numeric labels for classification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.8.4.9009
+Version: 0.8.4.9010
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
   
 ### Spark ML
 
+- **(Breaking change)** The formula API for ML classification algorithms no longer indexes numeric labels, to avoid the confusion of `0` being mapped to `"1"` and vice versa. This means that if the largest numeric label is `N`, Spark will fit a `N+1`-class classification model, regardless of how many distinct labels there are in the provided training set (#1591).
 - Fix retrieval of coefficients in `ml_logistic_regression()` (@shabbybanks, #1596).
 - **(Breaking change)** For model objects, `lazy val` and `def` attributes have been converted to closures, so they are not evaluated at object instantiation (#1453).
 - Input and output column names are no longer required to construct pipeline objects to be consistent with Spark (#1513).

--- a/R/ml_model_utils.R
+++ b/R/ml_model_utils.R
@@ -33,21 +33,9 @@ ml_generate_ml_model <- function(
   classification <- identical(type, "classification")
 
   pipeline <- if (classification) {
-    if (spark_version(sc) >= "2.1.0") {
-      r_formula <- ft_r_formula(sc, formula, features_col, label_col,
-                                force_index_label = TRUE)
-      pipeline <- ml_pipeline(r_formula, predictor)
-    } else {
-      r_formula <- ft_r_formula(sc, formula, features_col, random_string(label_col))
-      response_col <- formula %>%
-        strsplit("~", fixed = TRUE) %>%
-        rlang::flatten_chr() %>%
-        head(1) %>%
-        trimws()
-      string_indexer <- ft_string_indexer(sc, response_col, label_col)
-      pipeline <- ml_pipeline(r_formula, string_indexer, predictor)
-    }
-    pipeline
+    r_formula <- ft_r_formula(sc, formula, features_col, label_col,
+                              force_index_label = FALSE)
+    ml_pipeline(r_formula, predictor)
   } else if (identical(type, "clustering") && spark_version(sc) < "2.0.0") {
     # one-sided formulas not supported prior to Spark 2.0
     rdf <- sdf_schema(x) %>%

--- a/R/ml_model_utils.R
+++ b/R/ml_model_utils.R
@@ -28,7 +28,8 @@ ml_feature_names_metadata <- function(pipeline_model, dataset, features_col) {
 ml_generate_ml_model <- function(
   x, predictor, formula, features_col = "features",
   label_col = "label", type,
-  constructor, predicted_label_col = NULL) {
+  constructor, predicted_label_col = NULL
+) {
   sc <- spark_connection(x)
   classification <- identical(type, "classification")
 
@@ -68,16 +69,18 @@ ml_generate_ml_model <- function(
     label_indexer_model <- ml_stages(pipeline_model) %>%
       dplyr::nth(-2) # second from last, either RFormulaModel or StringIndexerModel
     index_labels <- ml_index_labels_metadata(label_indexer_model, x, label_col)
-    index_to_string <- ft_index_to_string(
-      sc, ml_param(predictor, "prediction_col"), predicted_label_col, index_labels)
-    pipeline <- pipeline %>%
-      ml_add_stage(index_to_string)
-    pipeline_model <- pipeline_model %>%
-      ml_add_stage(index_to_string) %>%
-      # ml_fit() here doesn't do any actual computation but simply
-      #   returns a PipelineModel since ml_add_stage() returns a
-      #   Pipeline (Estimator)
-      ml_fit(x)
+    if (!is.null(index_labels)) {
+      index_to_string <- ft_index_to_string(
+        sc, ml_param(predictor, "prediction_col"), predicted_label_col, index_labels)
+      pipeline <- pipeline %>%
+        ml_add_stage(index_to_string)
+      pipeline_model <- pipeline_model %>%
+        ml_add_stage(index_to_string) %>%
+        # ml_fit() here doesn't do any actual computation but simply
+        #   returns a PipelineModel since ml_add_stage() returns a
+        #   Pipeline (Estimator)
+        ml_fit(x)
+    }
   }
 
   # workaround for https://issues.apache.org/jira/browse/SPARK-19953

--- a/R/ml_transformation_methods.R
+++ b/R/ml_transformation_methods.R
@@ -123,13 +123,17 @@ ml_predict.ml_model_classification <- function(
     ml_transform(dataset)
 
   probability_col <- ml_param(x$model, "probability_col", allow_null = TRUE)
-  if (rlang::is_null(probability_col))
+  if (rlang::is_null(probability_col)) {
     predictions
-  else
+  } else {
+    index_labels <- spark_sanitize_names(
+      x$.index_labebls %||% seq_len(x$model$num_classes) - 1L
+    )
     sdf_separate_column(
       predictions, probability_col,
-      paste0(probability_prefix, spark_sanitize_names(x$.index_labels))
+      paste0(probability_prefix, index_labels)
     )
+  }
 }
 
 #' @export

--- a/tests/testthat/test-ml-classification-logistic-regression.R
+++ b/tests/testthat/test-ml-classification-logistic-regression.R
@@ -130,19 +130,19 @@ test_that("ml_logistic_regression() agrees with stats::glm() for reversed catego
            versicolor = ifelse(Species == "versicolor", 1L, 0L))
   iris_weighted_tbl <- testthat_tbl("iris_weighted")
 
-  r <- glm(not_versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
+  r <- glm(versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
            family = binomial(logit), weights = weights,
            data = iris_weighted)
   s <- ml_logistic_regression(iris_weighted_tbl,
-                              formula = "not_versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
+                              formula = "versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
                               reg_param = 0L,
                               weight_col = "weights")
   expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
 
-  r <- glm(not_versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
+  r <- glm(versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
            family = binomial(logit), data = iris_weighted)
   s <- ml_logistic_regression(iris_weighted_tbl,
-                              formula = "not_versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
+                              formula = "versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
                               reg_param = 0L,
                               weight_col = "ones")
   expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)

--- a/tests/testthat/test-ml-classification-logistic-regression.R
+++ b/tests/testthat/test-ml-classification-logistic-regression.R
@@ -121,6 +121,33 @@ test_that("ml_logistic_regression can fit without intercept",{
   expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
 })
 
+test_that("ml_logistic_regression() agrees with stats::glm() for reversed categories", {
+  sc <- testthat_spark_connection()
+  set.seed(42)
+  iris_weighted <- iris %>%
+    mutate(weights = rpois(nrow(iris), 1) + 1,
+           ones = rep(1, nrow(iris)),
+           versicolor = ifelse(Species == "versicolor", 1L, 0L))
+  iris_weighted_tbl <- testthat_tbl("iris_weighted")
+
+  r <- glm(not_versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
+           family = binomial(logit), weights = weights,
+           data = iris_weighted)
+  s <- ml_logistic_regression(iris_weighted_tbl,
+                              formula = "not_versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
+                              reg_param = 0L,
+                              weight_col = "weights")
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+
+  r <- glm(not_versicolor ~ Sepal.Width + Petal.Length + Petal.Width,
+           family = binomial(logit), data = iris_weighted)
+  s <- ml_logistic_regression(iris_weighted_tbl,
+                              formula = "not_versicolor ~ Sepal_Width + Petal_Length + Petal_Width",
+                              reg_param = 0L,
+                              weight_col = "ones")
+  expect_equal(unname(coef(r)), unname(coef(s)), tolerance = 1e-5)
+})
+
 test_that("ml_logistic_regression.tbl_spark() takes both quoted and unquoted formulas", {
   sc <- testthat_spark_connection()
   iris_weighted_tbl <- testthat_tbl("iris_weighted")


### PR DESCRIPTION
Fixes https://github.com/rstudio/sparklyr/issues/1591

@shabbybanks I cherry-picked your test from https://github.com/rstudio/sparklyr/pull/1598 and it seems to be passing at least locally. Please give this a shot and propose more tests as needed.

The use case that this change would break is where the labels are two distinct integers that are not 0 and 1, e.g.

```
library(sparklyr)
library(dplyr)
sc <- spark_connect(master = "local")
train_data <- iris %>%
  mutate(
    species_type = ifelse(Species == "setosa", 2, 1),
  )
spark_data <- copy_to(sc, train_data, "like_iris", overwrite = TRUE)
s_mod <- spark_data %>%
  ml_logistic_regression(formula = species_type ~ Sepal_Length)
s_mod
# Formula: species_type ~ Sepal_Length
# 
# Coefficients:
#      (Intercept) Sepal_Length
# [1,]   -3.455491 -5.161826758
# [2,]  -12.186625  5.168782843
# [3,]   15.642117 -0.006956085
```

but this is arguably less likely than users being misled by 0 and 1 being mapped to 1 and 0.

Will add a NEWS entry before merge that makes this behavior clear.