### PR TITLE
Support configuring gateway address and port for Kubernetes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@
   
 ## Kubernetes
 
+- Added config `sparklyr.gateway.routing` to avoid routing to ports since
+  Kubernetes clusters have unique spark masters.
+
 - Change backend ports to be choosen deterministically by searching for
   free ports starting on `sparklyr.gateway.port` which default to `8880`. This
   allows users to enable port forwarding with `kubectl port-forward`.

--- a/R/core_config.R
+++ b/R/core_config.R
@@ -16,6 +16,28 @@ spark_config_value <- function(config, name, default = NULL) {
   }
 }
 
+spark_config_value_retries <- function(config, name, default, retries) {
+  success <- FALSE
+  value <- default
+
+  while (!success && retries > 0) {
+    tryCatch({
+      value <<- spark_config_value(config, name, default)
+      success <<- TRUE
+    }, error = function(e) {
+      if (sparklyr_boolean_option("sparklyr.verbose")) {
+        message("Reading ", name, " failed with error: ", e$message)
+      }
+    })
+  }
+
+  if (!success) {
+    stop("Failed after ", retries, " attempts while reading conf value ", name)
+  }
+
+  value
+}
+
 spark_config_integer <- function(config, name, default = NULL) {
   as.integer(spark_config_value(config, name, default))
 }

--- a/R/core_config.R
+++ b/R/core_config.R
@@ -21,6 +21,8 @@ spark_config_value_retries <- function(config, name, default, retries) {
   value <- default
 
   while (!success && retries > 0) {
+    retries <- retries - 1
+
     tryCatch({
       value <<- spark_config_value(config, name, default)
       success <<- TRUE
@@ -28,6 +30,8 @@ spark_config_value_retries <- function(config, name, default, retries) {
       if (sparklyr_boolean_option("sparklyr.verbose")) {
         message("Reading ", name, " failed with error: ", e$message)
       }
+
+      if (retries > 0) Sys.sleep(1)
     })
   }
 

--- a/R/core_config.R
+++ b/R/core_config.R
@@ -23,16 +23,26 @@ spark_config_value_retries <- function(config, name, default, retries) {
   while (!success && retries > 0) {
     retries <- retries - 1
 
-    tryCatch({
-      value <<- spark_config_value(config, name, default)
-      success <<- TRUE
+    result <- tryCatch({
+      list(
+        value = spark_config_value(config, name, default),
+        success = TRUE
+      )
     }, error = function(e) {
       if (sparklyr_boolean_option("sparklyr.verbose")) {
         message("Reading ", name, " failed with error: ", e$message)
       }
 
       if (retries > 0) Sys.sleep(1)
+
+      list(
+        success = FALSE
+      )
     })
+
+    success <- result$success
+    value <- result$value
+
   }
 
   if (!success) {

--- a/R/kubernetes_config.R
+++ b/R/kubernetes_config.R
@@ -61,6 +61,7 @@ spark_config_kubernetes <- function(
       paste("spark.kubernetes.driver.pod.name", driver, sep = "="),
       paste("spark.kubernetes.authenticate.driver.serviceAccountName", account, sep = "=")
     ),
+    sparklyr.gateway.routing = FALSE,
     sparklyr.app.jar = "local:///opt/sparklyr/sparklyr-2.3-2.11.jar",
     sparklyr.events.aftersubmit = forward_function,
     spark.home = spark_home_dir()

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -322,7 +322,7 @@ start_shell <- function(master,
     }
 
     # reload port and address to let kubernetes hooks find the right container
-    gatewayConfigRetries <- spark_config_value_retries(config, "sparklyr.gateway.config.retries", 10)
+    gatewayConfigRetries <- spark_config_value(config, "sparklyr.gateway.config.retries", 10)
     gatewayPort <- as.integer(spark_config_value_retries(config, "sparklyr.gateway.port", "8880", gatewayConfigRetries))
     gatewayAddress <- spark_config_value_retries(config, "sparklyr.gateway.address", "localhost", gatewayConfigRetries)
 

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -160,10 +160,13 @@ start_shell <- function(master,
     spark_session_random()
 
   # attempt to connect into an existing gateway
-  gatewayInfo <- spark_connect_gateway(gatewayAddress = gatewayAddress,
-                                       gatewayPort = gatewayPort,
-                                       sessionId = sessionId,
-                                       config = config)
+  gatewayInfo <- NULL
+  if (spark_config_value(config, "sparklyr.gateway.routing", TRUE)) {
+    gatewayInfo <- spark_connect_gateway(gatewayAddress = gatewayAddress,
+                                         gatewayPort = gatewayPort,
+                                         sessionId = sessionId,
+                                         config = config)
+  }
 
   output_file <- NULL
   error_file <- NULL
@@ -318,6 +321,11 @@ start_shell <- function(master,
       gatewayAddress <- config[["sparklyr.gateway.address"]] <- spark_yarn_cluster_get_gateway(config, start_time)
     }
 
+    # reload port and address to let kubernetes hooks find the right container
+    gatewayConfigRetries <- spark_config_value_retries(config, "sparklyr.gateway.config.retries", 10)
+    gatewayPort <- as.integer(spark_config_value_retries(config, "sparklyr.gateway.port", "8880", gatewayConfigRetries))
+    gatewayAddress <- spark_config_value_retries(config, "sparklyr.gateway.address", "localhost", gatewayConfigRetries)
+
     tryCatch({
       # connect and wait for the service to start
       gatewayInfo <- spark_connect_gateway(gatewayAddress,
@@ -333,7 +341,7 @@ start_shell <- function(master,
           if (spark_master_is_yarn_cluster(master, config)) {
             paste0(
               ") and address (",
-              config[["sparklyr.gateway.address"]]
+              gatewayAddress
             )
           }
           else {

--- a/tests/testthat/test-kubernetes-config.R
+++ b/tests/testthat/test-kubernetes-config.R
@@ -15,6 +15,7 @@ test_that("spark_kubernetes_config can generate correct config", {
         "spark.kubernetes.driver.pod.name=spark-driver",
         "spark.kubernetes.authenticate.driver.serviceAccountName=spark"
       ),
+      sparklyr.gateway.routing = FALSE,
       sparklyr.app.jar = "local:///opt/sparklyr/sparklyr-2.3-2.11.jar",
       sparklyr.events.aftersubmit = NULL,
       spark.home = spark_home_dir()


### PR DESCRIPTION
For Kubernetes clusters that don't use port forwarding, we can now use `sparklyr.gateway.address` to attach a function that finds the spark master in the cluster.

Also, it's recommended to set `sparklyr.gateway.routing = FALSE` to avoid routing sessions since this is not required in Kubernetes clusters, the spark master is always unique.