### PR TITLE
Enable createDataFrameFromText to handle timestamp columns

### DIFF
--- a/inst/livy/spark-1.5.2/utils.scala
+++ b/inst/livy/spark-1.5.2/utils.scala
@@ -337,6 +337,7 @@ object Utils {
           case "integer"  => if (Try(value.toInt).isSuccess) value.toInt else null.asInstanceOf[Int]
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
+          case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
           case _ => value
         }
       })

--- a/java/spark-1.5.2/utils.scala
+++ b/java/spark-1.5.2/utils.scala
@@ -334,6 +334,7 @@ object Utils {
           case "integer"  => if (Try(value.toInt).isSuccess) value.toInt else null.asInstanceOf[Int]
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
+          case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
           case _ => value
         }
       })


### PR DESCRIPTION
This fixes #1312 

As I commented on https://github.com/rstudio/sparklyr/issues/1312#issuecomment-417251307, it seems https://github.com/rstudio/sparklyr/commit/adea07e22af14a4f072e46cd528053c5a78328de should have implemented `timestamp` case for `createDataFrameFromText ` as well. Actually, this fixes the problem in my environment.

Should I include jar file in this PR? Sorry, I don't know about the manner of Java development...