### PR TITLE
Improve document about livy_config()

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -61,9 +61,13 @@ livy_validate_http_response <- function(message, req) {
 #'   \item{\code{num_executors}}{Number of executors to launch for this session}
 #'   \item{\code{archives}}{Archives to be used in this session}
 #'   \item{\code{queue}}{The name of the YARN queue to which submitted}
-#'   \item{\code{queue}}{The name of this session}
+#'   \item{\code{name}}{The name of this session}
 #'   \item{\code{heartbeat_timeout}}{Timeout in seconds to which session be orphaned}
 #' }
+#'
+#' Note that \code{queue} is supported only by version 0.4.0 of Livy or newer.
+#' If you are using the older one, specify queue via \code{config} (e.g.
+#' \code{config = spark_config(spark.yarn.queue = "my_queue")}).
 #'
 #' @return Named list with configuration data
 livy_config <- function(config = spark_config(), username = NULL, password = NULL, negotiate = FALSE,

--- a/man/livy_config.Rd
+++ b/man/livy_config.Rd
@@ -4,9 +4,9 @@
 \alias{livy_config}
 \title{Create a Spark Configuration for Livy}
 \usage{
-livy_config(config = spark_config(), username = NULL, password = NULL,
-  negotiate = FALSE, custom_headers = list(`X-Requested-By` = "sparklyr"),
-  ...)
+livy_config(config = spark_config(), username = NULL,
+  password = NULL, negotiate = FALSE,
+  custom_headers = list(`X-Requested-By` = "sparklyr"), ...)
 }
 \arguments{
 \item{config}{Optional base configuration}
@@ -48,7 +48,11 @@ Additional parameters for Livy sessions are:
   \item{\code{num_executors}}{Number of executors to launch for this session}
   \item{\code{archives}}{Archives to be used in this session}
   \item{\code{queue}}{The name of the YARN queue to which submitted}
-  \item{\code{queue}}{The name of this session}
+  \item{\code{name}}{The name of this session}
   \item{\code{heartbeat_timeout}}{Timeout in seconds to which session be orphaned}
 }
+
+Note that \code{queue} is supported only by version 0.4.0 of Livy or newer.
+If you are using the older one, specify queue via \code{config} (e.g.
+\code{config = spark_config(spark.yarn.queue = "my_queue")}).
 }


### PR DESCRIPTION
This PR Closes #1624 

- Fix the description of a parameters of Livy session.
- Add a note about using queue parameter with Livy <0.4.0.