### PR TITLE
Implement `DBI::db_explain()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,8 @@
 
 ### Data
 
+- Implemented support for `DBI::db_explain()` (#1623).
+
 - Fixed for `timestamp` fields when using `copy_to()` (#1312, @yutannihilation).
 
 - Added support to read and write ORC files using `spark_read_orc()` and

--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -31,7 +31,9 @@ db_desc.src_spark <- function(x) {
 #' @export
 #' @importFrom dplyr db_explain
 db_explain.spark_connection <- function(con, sql, ...) {
-  ""
+  explained <- DBI::dbGetQuery(con, paste("EXPLAIN", sql))
+
+  message(explained$plan)
 }
 
 #' @export


### PR DESCRIPTION
Implement `db_explain()` to fix https://github.com/rstudio/sparklyr/issues/1623.