### PR TITLE
spark_apply() used to cache results by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,9 @@
 
 ### Distributed R
 
+- Added `name` parameter to `spark_apply()` to optionally name resulting
+  table.
+
 - Fix to `spark_apply()` to retain column types when NAs are present (#1665).
 
 - `spark_apply()` now supports `rlang` anonymous functions. For example,

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -273,7 +273,7 @@ spark_apply <- function(x,
       as.environment(spark_apply_options)
     )
 
-    # while workers need to relaunch sparklyr backends, cache by default
+    # cache by default
     if (memory) rdd <- invoke(rdd, "cache")
 
     schema <- spark_schema_from_rdd(sc, rdd, columns)
@@ -356,6 +356,9 @@ spark_apply <- function(x,
       context_serialize,
       as.environment(spark_apply_options)
     )
+
+    # cache by default
+    if (memory) transformed <- invoke(transformed, "cache")
   }
 
   sdf_register(transformed)

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -363,7 +363,7 @@ spark_apply <- function(x,
   name <- name %||% random_string("sparklyr_tmp_")
   registered <- sdf_register(transformed, name = name)
 
-  if (memory && !identical(args$rdd, TRUE)) tbl_cache(sc, name, force = FALSE)
+  if (memory && !identical(args$rdd, TRUE) && !sdf_is_streaming(sdf)) tbl_cache(sc, name, force = FALSE)
 
   registered
 }

--- a/man/spark_apply.Rd
+++ b/man/spark_apply.Rd
@@ -5,7 +5,7 @@
 \title{Apply an R Function in Spark}
 \usage{
 spark_apply(x, f, columns = NULL, memory = TRUE, group_by = NULL,
-  packages = NULL, context = NULL, ...)
+  packages = NULL, context = NULL, name = NULL, ...)
 }
 \arguments{
 \item{x}{An object (usually a \code{spark_tbl}) coercable to a Spark DataFrame.}
@@ -53,6 +53,8 @@ specify the the column types. The sample size is confgirable using the
   to the local packages library.}
 
 \item{context}{Optional object to be serialized and passed back to \code{f()}.}
+
+\item{name}{Optional table name while registering the resulting data frame.}
 
 \item{...}{Optional arguments; currently unused.}
 }


### PR DESCRIPTION
- spark_apply() used to cache results by default.
- Add `name` parameter to, optionally, name explicitly the cached table.