### PR TITLE
Fix `stream_view()` when loading large data

### DIFF
--- a/R/stream_view.R
+++ b/R/stream_view.R
@@ -1,9 +1,18 @@
 #' @importFrom jsonlite fromJSON
 stream_progress <- function(stream)
 {
-  invoke(stream, "lastProgress") %>%
-    invoke("toString") %>%
-    fromJSON()
+  return(NULL)
+
+  lastProgress <- invoke(stream, "lastProgress")
+
+  if (is.null(lastProgress)) {
+    NULL
+  }
+  else {
+    lastProgress %>%
+      invoke("toString") %>%
+      fromJSON()
+  }
 }
 
 #' View Stream


### PR DESCRIPTION
While a stream is being built out of large datasets, `lastProgress` can be `NULL` and `stream_view()` fail to render.