### PR TITLE
Minor stream related improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.8.4.9011
+Version: 0.8.4.9012
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -2,7 +2,7 @@
 spark_data_build_types <- function(sc, columns) {
   names <- names(columns)
   fields <- lapply(names, function(name) {
-    invoke_static(sc, "sparklyr.SQLUtils", "createStructField", name, columns[[name]], TRUE)
+    invoke_static(sc, "sparklyr.SQLUtils", "createStructField", name, columns[[name]][[1]], TRUE)
   })
 
   invoke_static(sc, "sparklyr.SQLUtils", "createStructType", fields)

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -163,6 +163,10 @@ spark_apply <- function(x,
     columns <- args$names
   }
 
+  if (!is.null(group_by) && sdf_is_streaming(sdf)) {
+    stop("'group_by' is unsupported with streams.")
+  }
+
   # set default value for packages based on config
   if (identical(packages, NULL)) {
     if (identical(packages_config, NULL)) {

--- a/R/stream_data.R
+++ b/R/stream_data.R
@@ -164,7 +164,7 @@ stream_read_csv <- function(sc,
 #' @param trigger The trigger for the stream query, defaults to micro-batches runnnig
 #'   every 5 seconds. See \code{\link{stream_trigger_interval}} and
 #'   \code{\link{stream_trigger_continuous}}.
-#' @param checkpoint The location where the system will write all the checkpoint.
+#' @param checkpoint The location where the system will write all the checkpoint
 #' information to guarantee end-to-end fault-tolerance.
 #'
 #' @family Spark stream serialization
@@ -291,7 +291,7 @@ stream_read_text <- function(sc,
                       path = path,
                       type = "text",
                       name = name,
-                      columns = list(text = "character"),
+                      columns = list(line = "character"),
                       stream_options = options)
 }
 

--- a/R/stream_view.R
+++ b/R/stream_view.R
@@ -1,8 +1,6 @@
 #' @importFrom jsonlite fromJSON
 stream_progress <- function(stream)
 {
-  return(NULL)
-
   lastProgress <- invoke(stream, "lastProgress")
 
   if (is.null(lastProgress)) {

--- a/R/stream_view.R
+++ b/R/stream_view.R
@@ -28,7 +28,7 @@ stream_progress <- function(stream)
 #' dir.create("iris-in")
 #' write.csv(iris, "iris-in/iris.csv", row.names = FALSE)
 #'
-#' stream_read_csv("iris-in/") %>%
+#' stream_read_csv(sc, "iris-in/") %>%
 #'   stream_write_csv("iris-out/") %>%
 #'   stream_view() %>%
 #'   stream_stop()
@@ -44,7 +44,21 @@ stream_view <- function(
   validate <- stream_progress(stream)
   interval <- 1000
 
-  ui <- d3Output("plot")
+  ui <- shinyUI(
+    div(
+      tags$head(
+        tags$style(HTML("
+          html, body, body > div {
+            width: 100%;
+            height: 100%;
+            margin: 0px;
+          }
+        "))
+      ),
+      d3Output("plot", width = "100%", height = "100%")
+    )
+  )
+
   options <- list(...)
 
   server <- function(input, output, session) {

--- a/inst/streams/stream.js
+++ b/inst/streams/stream.js
@@ -77,8 +77,8 @@ function StreamRenderer(stats) {
   var rowsPerSecondOut;
 
   var barWidth = 10;
-  var margin = 25;
-  var marginLeft = margin + 20;
+  var margin = 30;
+  var marginLeft = margin + 10;
   var remotesCircle = 10;
   var remotesMargin = margin;
   var remotesHeight = 0;

--- a/man/stream_write_csv.Rd
+++ b/man/stream_write_csv.Rd
@@ -23,7 +23,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{header}{Should the first row of data be used as a header? Defaults to \code{TRUE}.}

--- a/man/stream_write_jdbc.Rd
+++ b/man/stream_write_jdbc.Rd
@@ -19,7 +19,7 @@ stream_write_jdbc(x, mode = c("append", "complete", "update"),
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}

--- a/man/stream_write_json.Rd
+++ b/man/stream_write_json.Rd
@@ -21,7 +21,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}

--- a/man/stream_write_kafka.Rd
+++ b/man/stream_write_kafka.Rd
@@ -19,7 +19,7 @@ stream_write_kafka(x, mode = c("append", "complete", "update"),
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}

--- a/man/stream_write_memory.Rd
+++ b/man/stream_write_memory.Rd
@@ -22,7 +22,7 @@ stream_write_memory(x, name = random_string("sparklyr_tmp_"),
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}

--- a/man/stream_write_orc.Rd
+++ b/man/stream_write_orc.Rd
@@ -21,7 +21,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}

--- a/man/stream_write_parquet.Rd
+++ b/man/stream_write_parquet.Rd
@@ -21,7 +21,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}

--- a/man/stream_write_text.Rd
+++ b/man/stream_write_text.Rd
@@ -21,7 +21,7 @@ Supports the \samp{"hdfs://"}, \samp{"s3a://"} and \samp{"file://"} protocols.}
 every 5 seconds. See \code{\link{stream_trigger_interval}} and
 \code{\link{stream_trigger_continuous}}.}
 
-\item{checkpoint}{The location where the system will write all the checkpoint.
+\item{checkpoint}{The location where the system will write all the checkpoint
 information to guarantee end-to-end fault-tolerance.}
 
 \item{options}{A list of strings with additional options.}


### PR DESCRIPTION
- `group_by` unsupported in `spark_apply()` with streams.
- Match schema for `stream_read_text()` to `spark_read_text()`.
- Allow passing `columns` parameter to `spark_apply()` using `lapply(df, class)` for convenience. 