### PR TITLE
spark_connect() should not attempt to download version data

### DIFF
--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -99,7 +99,7 @@ spark_connect <- function(master,
 
   # determine whether we need cores in master
   passedMaster <- master
-  cores <- spark_config_value(config, "sparklyr.connect.cores.local")
+  cores <- spark_config_value(config, c("sparklyr.connect.cores.local", "sparklyr.cores.local"))
   if (master == "local" && !identical(cores, NULL))
     master <- paste("local[", cores, "]", sep = "")
 

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -51,7 +51,7 @@ spark_install_find <- function(version = NULL,
   }
 
   versions <- versions[with(versions, order(default, spark, hadoop_default, decreasing = TRUE)), ]
-  spark_install_info(as.character(versions[1,]$spark), as.character(versions[1,]$hadoop))
+  spark_install_info(as.character(versions[1,]$spark), as.character(versions[1,]$hadoop), latest = latest)
 }
 
 #' determine the version that will be used by default if version is NULL
@@ -79,8 +79,8 @@ spark_default_version <- function() {
        hadoop = hadoop)
 }
 
-spark_install_info <- function(sparkVersion = NULL, hadoopVersion = NULL) {
-  versionInfo <- spark_versions_info(sparkVersion, hadoopVersion)
+spark_install_info <- function(sparkVersion = NULL, hadoopVersion = NULL, latest = TRUE) {
+  versionInfo <- spark_versions_info(sparkVersion, hadoopVersion, latest = latest)
 
   componentName <- versionInfo$componentName
   packageName <- versionInfo$packageName

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -133,14 +133,21 @@ spark_versions <- function(latest = TRUE) {
       notCurrentRow <- mergedData[mergedData$spark != row$spark | mergedData$hadoop != row$hadoop, ]
 
       newRow <- c(row, installed = TRUE)
-      newRow$base <- if (NROW(currentRow) > 0) currentRow$base else ""
-      newRow$pattern <- if (NROW(currentRow) > 0) currentRow$pattern else ""
-      newRow$download <- if (NROW(currentRow) > 0) currentRow$download else ""
-      newRow$default <- identical(currentRow$spark, "2.3.1")
-      newRow$hadoop_default <- if (compareVersion(currentRow$spark, "2.0") >= 0)
-          identical(currentRow$hadoop, "2.7")
-        else
-          identical(currentRow$hadoop, "2.6")
+      newRow$base <- ""
+      newRow$pattern <- ""
+      newRow$download <- ""
+      newRow$default <- FALSE
+      newRow$hadoop_default <- FALSE
+
+      if (NROW(currentRow) > 0) {
+        hadoop_default <- if (compareVersion(currentRow$spark, "2.0") >= 0) "2.7" else "2.6"
+
+        newRow$base <- currentRow$base
+        newRow$pattern <- currentRow$pattern
+        newRow$download <- currentRow$download
+        newRow$default <- identical(currentRow$spark, "2.3.1")
+        newRow$hadoop_default <- identical(currentRow$hadoop, hadoop_default)
+      }
 
       mergedData <<- rbind(notCurrentRow, newRow)
     }
@@ -150,8 +157,8 @@ spark_versions <- function(latest = TRUE) {
 }
 
 # Retrieves component information for the given Spark and Hadoop versions
-spark_versions_info <- function(version, hadoop_version) {
-  versions <- spark_versions()
+spark_versions_info <- function(version, hadoop_version, latest = TRUE) {
+  versions <- spark_versions(latest = latest)
 
   versions <- versions[versions$spark == version, ]
   if (NROW(versions) == 0) {


### PR DESCRIPTION
Found a case while connecting using Spark 2.3.1 (which just recently got added), in which `spark_connect()` would attempt to download the versions and fail since the version 2.3.1 was not int he versions file.

Fixed the original issue but more importantly, `spark_connect()` should never rely on the remote versions file to make sure that, even if we make a bad commit to the versions file, we wouldn't affect users workflow in `spark_connect()` but rather, only while using `spark_install()`.