### PR TITLE
Additional paths searching for spark version to fix #1694

### DIFF
--- a/R/spark_version.R
+++ b/R/spark_version.R
@@ -80,7 +80,9 @@ spark_version_from_home <- function(spark_home, default = NULL) {
       candidateVersions <- list(
         list(path = "lib", pattern = "spark-assembly-([0-9\\.]*)-hadoop.[0-9\\.]*\\.jar"),
         list(path = "yarn", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar"),
-        list(path = "yarn", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar")
+        list(path = "yarn", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar"),
+        list(path = "lib", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar"),
+        list(path = "lib", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar")
       )
 
       candidateFiles <- lapply(candidateVersions, function(e) {
@@ -88,7 +90,8 @@ spark_version_from_home <- function(spark_home, default = NULL) {
           list(
             files = list.files(
               file.path(spark_home, e$path),
-              pattern = e$pattern
+              pattern = e$pattern,
+              recursive = TRUE
             )
           )
         )

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,9 @@ get_java <- function(throws = FALSE) {
     if (!file.exists(java)) {
       if (throws) {
         stop("Java is required to connect to Spark. ",
-             "JAVA_HOME is set but does not point to a valid version. ",
+             "JAVA_HOME is set to '",
+             java_home,
+             "' but does not point to a valid version. ",
              "Please fix JAVA_HOME or reinstall from: ",
              java_install_url())
       }


### PR DESCRIPTION
Fix for https://github.com/rstudio/sparklyr/issues/1694.

Installable using:

```r
devtools::install_github("rstudio/sparklyr", ref = "bugfix/1694")
```