### PR TITLE
Add older versions of R while testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ r_packages:
 
 matrix:
   include:
-    - name: "Spark 1.6.3 (R 3.0.3, openjdk7)"
-      r: 3.0.3
+    - name: "Spark 1.6.3 (R 3.1.2, openjdk7)"
+      r: 3.1.2
       env:
         - SPARK_VERSION="1.6.3"
         - JAVA_VERSION=openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ r_packages:
 
 matrix:
   include:
-    - name: "Spark 1.6.3 (R 3.1.2, openjdk7)"
+    - name: "Spark 1.6.3 (R 3.2, openjdk7)"
       r: 3.2
       env:
         - SPARK_VERSION="1.6.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,23 @@ r_packages:
 
 matrix:
   include:
-    - name: "Spark 1.6.3 (openjdk7)"
+    - name: "Spark 1.6.3 (R 3.0.3, openjdk7)"
+      r: 3.0.3
       env:
         - SPARK_VERSION="1.6.3"
         - JAVA_VERSION=openjdk7
-    - name: "Spark 2.2.1 (oraclejdk8)"
+    - name: "Spark 2.2.1 (R oldrel, oraclejdk8)"
+      r: oldrel
       env:
         - SPARK_VERSION="2.2.1"
         - JAVA_VERSION=oraclejdk8
-    - name: "Spark 2.3.1 (openjdk8)"
+    - name: "Spark 2.3.1 (R release, openjdk8)"
+      r: release
       env:
         - SPARK_VERSION="2.3.1"
         - JAVA_VERSION=openjdk8
-    - name: "Livy 0.5.0 (openjdk8)"
+    - name: "Livy 0.5.0 (R release, openjdk8)"
+      r: release
       env:
         - LIVY_VERSION="0.5.0"
         - JAVA_VERSION=openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ r_packages:
 matrix:
   include:
     - name: "Spark 1.6.3 (R 3.1.2, openjdk7)"
-      r: 3.1.2
+      r: 3.1
       env:
         - SPARK_VERSION="1.6.3"
         - JAVA_VERSION=openjdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ r_packages:
 matrix:
   include:
     - name: "Spark 1.6.3 (R 3.1.2, openjdk7)"
-      r: 3.1
+      r: 3.2
       env:
         - SPARK_VERSION="1.6.3"
         - JAVA_VERSION=openjdk7

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.9.1
+Version: 0.9.1.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ BugReports: https://github.com/rstudio/sparklyr/issues
 LazyData: TRUE
 RoxygenNote: 6.1.0
 Depends:
-    R (>= 3.1.2)
+    R (>= 3.2)
 Imports:
     assertthat,
     base64enc,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# Sparklyr 0.9.1 (unreleased)
+
 # Sparklyr 0.9.1
 
 - Terminate streams when Shiny app terminates.

--- a/R/core_config.R
+++ b/R/core_config.R
@@ -7,7 +7,7 @@
 #' @keywords internal
 #' @export
 spark_config_value <- function(config, name, default = NULL) {
-  if (getOption("sparklyr.test.enforce.config", FALSE) && any(startsWith(name, "sparklyr."))) {
+  if (getOption("sparklyr.test.enforce.config", FALSE) && any(grepl("^sparklyr.", name))) {
     settings <- get("spark_config_settings")()
     if (!any(name %in% settings$name)) {
       stop("Config value '", name[[1]], "' not described in spark_config_settings()")

--- a/R/dplyr_spark_table.R
+++ b/R/dplyr_spark_table.R
@@ -106,7 +106,7 @@ print.tbl_spark <- function(x, ...) {
   attributes(data)$spark_dims <- c(NA_real_, sdf_ncol(x))
 
   remote_name <- dbplyr::remote_name(x)
-  remote_name <- if(is.null(remote_name) || startsWith(remote_name, "sparklyr_tmp_")) "?" else remote_name
+  remote_name <- if(is.null(remote_name) || grepl("^sparklyr_tmp_", remote_name)) "?" else remote_name
 
   attributes(data)$spark_summary <- c(
     Source = paste0(

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -278,3 +278,30 @@ test_that("collect() can retrieve as.POSIXct fields with timezones", {
     all.equal(tz_entries, collected)
   )
 })
+
+test_that("collect() can retrieve specific dates without timezones", {
+  data_tbl <- sdf_copy_to(
+    sc,
+    data_frame(
+      t = c(1419126103)
+    )
+  )
+
+  expect_equal(
+    data_tbl %>%
+      mutate(date_alt = from_utc_timestamp(timestamp(t) ,'UTC')) %>%
+      pull(date_alt),
+    as.POSIXct("2014-12-21 01:41:43 UTC", tz = "UTC")
+  )
+
+  expect_equal(
+    data_tbl %>%
+      mutate(date_alt = to_date(from_utc_timestamp(timestamp(t) ,'UTC'))) %>%
+      pull(date_alt),
+    as.Date(
+      data_tbl %>%
+        mutate(date_alt = as.character(to_date(from_utc_timestamp(timestamp(t) ,'UTC')))) %>%
+        pull(date_alt)
+    )
+  )
+})


### PR DESCRIPTION
Would be good to test against older versions of R in Travis, related to https://github.com/rstudio/sparklyr/issues/1695.