### PR TITLE
Fix new spark connection selectors in mojave

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.9.2 (unreleased)
 
+- Fix new connection RStudio selectors colors when running
+  under OS X Mojave.
+
 - Removed `overwrite` parameter in `spark_read_table()` (#1698).
 
 - Fix regression preventing using R 3.2 (#1695).

--- a/R/connection_shinyapp.R
+++ b/R/connection_shinyapp.R
@@ -119,6 +119,10 @@ connection_spark_ui <- function() {
             margin-top: 7px;
           }
 
+          select {
+            background: #FFF;
+          }
+
           .shiny-input-container {
             min-width: 100%;
             margin-bottom: ", elementSpacing, "px;


### PR DESCRIPTION
Under OS X Mojave.

Before,

<img width="583" alt="screen shot 2018-10-09 at 8 04 50 pm" src="https://user-images.githubusercontent.com/3478847/46711371-f5c20680-cc00-11e8-86a9-a97a45bc0fc8.png">

After,

<img width="583" alt="screen shot 2018-10-09 at 8 09 07 pm" src="https://user-images.githubusercontent.com/3478847/46711372-f65a9d00-cc00-11e8-9466-a25439b1f7d3.png">
