### PR TITLE
Fix regression in sdf_collect()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.9.2 (unreleased)
 
+- Fix regression in `sdf_collect()` failing to collect tables.
+
 - Fix new connection RStudio selectors colors when running
   under OS X Mojave.
 

--- a/R/sdf_streaming.R
+++ b/R/sdf_streaming.R
@@ -7,5 +7,5 @@
 sdf_is_streaming <- function(x)
 {
   sc <- spark_connection(x)
-  spark_version(sc) >= "2.0.0" && invoke(x, "isStreaming")
+  spark_version(sc) >= "2.0.0" && invoke(spark_dataframe(x), "isStreaming")
 }

--- a/tests/testthat/test-sdf-collect.R
+++ b/tests/testthat/test-sdf-collect.R
@@ -1,0 +1,10 @@
+context("describe")
+
+sc <- testthat_spark_connection()
+
+test_that("sdf_collect() works properly", {
+  mtcars_tbl <- testthat_tbl("mtcars")
+  mtcars_data <- sdf_collect(mtcars_tbl)
+
+  expect_equivalent(mtcars, mtcars_data)
+})


### PR DESCRIPTION
`sdf_collect(x)` used to be able to collect from `tbl` objects but a regression scoped this function to require collection as `sdf_collect(spark_dataframe(x))`.