### PR TITLE
Require version 0.6 or newer of rstudioapi to fix #1716

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Imports:
     rappdirs,
     rlang (>= 0.1.4),
     rprojroot,
-    rstudioapi,
+    rstudioapi (>= 0.6),
     shiny (>= 1.0.1),
     withr,
     xml2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.9.2 (unreleased)
 
+- Fix installation error with older versions of `rstudioapi` (#1716).
+
 - Fix missing callstack and error case while logging in
   `spark_apply()`.
 


### PR DESCRIPTION
Fix for #1716.