### PR TITLE
Avoid requiring use of SPARK_HOME_VERSION when version is set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.9.3 (unreleased)
 
+- Cloudera autodetect Spark version improvements.
+
 - Fixed default for `session` in `reactiveSpark()`.
 
 - Improved memory use in Livy by using string builders and avoid print

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # Sparklyr 0.9.3 (unreleased)
 
+- Fix requirement to specify `SPARK_HOME_VERSION` when `version`
+  parameter is set in `spark_connect()`.
+
 - Cloudera autodetect Spark version improvements.
 
 - Fixed default for `session` in `reactiveSpark()`.

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -26,7 +26,7 @@ livy_install <- function(version       = "0.5.0",
 
     # if spark_home is set, then infer spark version based on that
     if (!is.null(spark_home)) {
-      spark_version <- spark_version_from_home(spark_home)
+      spark_version <- spark_version_from_home(spark_home, default = spark_version)
     } else {
       spark_version <- switch(
         version,

--- a/R/spark_version.R
+++ b/R/spark_version.R
@@ -26,10 +26,6 @@ spark_version.default <- function(sc) {
   if (!is.null(sc$state$spark_version))
     return(sc$state$spark_version)
 
-  # if `SPARK_HOME` is specified, infer version from it
-  if (!is.null(sc$spark_home))
-    return(spark_version_from_home(sc$spark_home))
-
   # get the version
   version <- invoke(spark_context(sc), "version")
 

--- a/R/spark_version.R
+++ b/R/spark_version.R
@@ -82,7 +82,8 @@ spark_version_from_home <- function(spark_home, default = NULL) {
         list(path = "yarn", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar"),
         list(path = "yarn", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar"),
         list(path = "lib", pattern = "spark-([0-9\\.]*)-preview-yarn-shuffle\\.jar"),
-        list(path = "lib", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar")
+        list(path = "lib", pattern = "spark-([0-9\\.]*)-yarn-shuffle\\.jar"),
+        list(path = "lib", pattern = "spark-assembly-([0-9\\.]*)-cdh[0-9\\.]*-hadoop.[0-9\\.]*\\.jar")
       )
 
       candidateFiles <- lapply(candidateVersions, function(e) {


### PR DESCRIPTION
CC: @edgararuiz 