### PR TITLE
Support for tables with periods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,8 @@
 # Sparklyr 0.9.3 (unreleased)
 
-- Tables with periods are now supported; however, this is a 
-  **breaking change** for users referencing tables as `database.table` 
-  since now they will have to set the `sparklyr.dplyr.period.splits`
-  to `TRUE`.
+- Tables with periods are now supported; for `database.name` use instead
+  `dbplyr::in_schema()` or, for backwards compatibility set
+  `sparklyr.dplyr.period.splits` to `TRUE`.
 
 - Fix requirement to specify `SPARK_HOME_VERSION` when `version`
   parameter is set in `spark_connect()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr 0.9.3 (unreleased)
 
+- Tables with periods are now supported; however, this is a 
+  **breaking change** for users referencing tables as `database.table` 
+  since now they will have to set the `sparklyr.dplyr.period.splits`
+  to `TRUE`.
+
 - Fix requirement to specify `SPARK_HOME_VERSION` when `version`
   parameter is set in `spark_connect()`.
 

--- a/R/config_settings.R
+++ b/R/config_settings.R
@@ -21,6 +21,7 @@ spark_config_settings <- function() {
     sparklyr.connect.packages = "Spark packages to include when connecting to Spark.",
     sparklyr.connect.sparksubmit = "Command executed instead of spark-submit when connecting.",
     sparklyr.connect.timeout = "Total seconds before giving up connecting to the sparklyr gateway while initializing.",
+    sparklyr.dplyr.period.splits = "Should 'dplyr' split column names into database and table?",
     sparklyr.gateway.address = "The address of the driver machine.",
     sparklyr.gateway.config.retries = "Number of retries to retrieve port and address from config, useful when using functions to query port or address in kubernetes.",
     sparklyr.gateway.interval = "Total of seconds sparkyr wil check on a gateway connection.",

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -4,7 +4,7 @@
 sql_escape_ident.spark_connection <- function(con, x) {
   # Assuming it might include database name like: `dbname.tableName`
   if (length(x) == 1)
-    tbl_quote_name(x)
+    tbl_quote_name(sc, x)
   else
     dbplyr::sql_quote(x, '`')
 }

--- a/R/dplyr_spark_connection.R
+++ b/R/dplyr_spark_connection.R
@@ -4,7 +4,7 @@
 sql_escape_ident.spark_connection <- function(con, x) {
   # Assuming it might include database name like: `dbname.tableName`
   if (length(x) == 1)
-    tbl_quote_name(sc, x)
+    tbl_quote_name(con, x)
   else
     dbplyr::sql_quote(x, '`')
 }

--- a/R/tables_spark.R
+++ b/R/tables_spark.R
@@ -1,4 +1,8 @@
-tbl_quote_name <- function(name) {
+tbl_quote_name <- function(sc, name) {
+  if (!spark_config_value(sc$config, "sparklyr.dplyr.period.splits", FALSE)) {
+    return(dbplyr::sql_quote(name, '`'))
+  }
+
   y <- gsub("`", "``", name, fixed = TRUE)
   y <- strsplit(y, "\\.")[[1]]
   y <- paste(y, collapse = "`.`")
@@ -19,11 +23,11 @@ tbl_cache_sdf <- function(sc, name, force) {
 }
 
 tbl_cache_sql <- function(sc, name, force) {
-  sql <- paste("CACHE TABLE", tbl_quote_name(name))
+  sql <- paste("CACHE TABLE", tbl_quote_name(sc, name))
   invoke(hive_context(sc), "sql", sql)
 
   if (force) {
-    sql <- paste("SELECT count(*) FROM ", tbl_quote_name(name))
+    sql <- paste("SELECT count(*) FROM ", tbl_quote_name(sc, name))
     sdf <- invoke(hive_context(sc), "sql", sql)
     sdf_collect(sdf)
   }
@@ -44,7 +48,7 @@ tbl_cache_sql <- function(sc, name, force) {
 #' @export
 tbl_cache <- function(sc, name, force = TRUE) {
   countColumns <- function(sc, name) {
-    sql <- paste("SELECT * FROM ", tbl_quote_name(name))
+    sql <- paste("SELECT * FROM ", tbl_quote_name(sc, name))
     sdf <- invoke(hive_context(sc), "sql", sql)
 
     length(invoke(sdf, "columns"))
@@ -72,7 +76,7 @@ tbl_cache <- function(sc, name, force = TRUE) {
 #'
 #' @export
 tbl_uncache <- function(sc, name) {
-  sql <- paste("UNCACHE TABLE", tbl_quote_name(name))
+  sql <- paste("UNCACHE TABLE", tbl_quote_name(sc, name))
   invoke(hive_context(sc), "sql", sql)
 
   invisible(NULL)
@@ -85,7 +89,7 @@ tbl_uncache <- function(sc, name) {
 #'
 #' @export
 tbl_change_db <- function(sc, name) {
-  sql <- paste("USE ", tbl_quote_name(name))
+  sql <- paste("USE ", tbl_quote_name(sc, name))
   invoke(hive_context(sc), "sql", sql)
 
   invisible(NULL)


### PR DESCRIPTION
```r
sensors <- data.frame(
    sensor = c("s.ensor@1", "s.ensor@1","s.ensor@1","s.ensor@2","s.ensor@2","s.ensor@2"),
    time = c(1,2,3,1,2,3),
    metric = c(1,2,3,10,20,30)
)

sc <- spark_connect(master = "local")

sensors_tbl <- sdf_copy_to(sc, sensors, overwrite = T)

sensors_tbl %>%
  sdf_pivot(time ~ sensor, fun.aggregate = c("avg", "metric")) %>%
  select(`s.ensor@1`)
```

```
# Source: spark<?> [?? x 1]
  `s.ensor@1`
*       <dbl>
1           1
2           3
3           2
```

Consider using instead [dbplyr::in_schema(database, table)](https://www.rdocumentation.org/packages/dbplyr/versions/1.2.2/topics/in_schema) instead.

This can also be reverted to match previous versions through:

```r
sc <- spark_connect(master = "local", config = list(sparklyr.dplyr.period.splits = T))
sensors_tbl <- sdf_copy_to(sc, sensors, overwrite = T)

sensors_tbl %>%
  sdf_pivot(time ~ sensor, fun.aggregate = c("avg", "metric")) %>%
  select(`s.ensor@1`) %>% dbplyr::sql_render()
```
```
<SQL> SELECT `s`.`ensor@1`
FROM `sparklyr_tmp_f23019c81436`
```

Current workaround:

```r
sensors_tbl %>%
  mutate(sensor = regexp_replace(sensor, "\\\\.", "_")) %>%
  sdf_pivot(time ~ sensor, fun.aggregate = c("avg", "metric")) %>%
  select(`s_ensor@1`)
```
```
# Source: spark<?> [?? x 1]
  `s_ensor@1`
*       <dbl>
1           1
2           3
3           2
```