### PR TITLE
Opt-in to enable support for tables with periods

### DIFF
--- a/.travis.R
+++ b/.travis.R
@@ -3,6 +3,10 @@ args <- commandArgs(trailingOnly=TRUE)
 if (length(args) == 0) {
   stop("Missing arguments")
 } else if (args[[1]] == "--testthat") {
+  if (package_version(paste(R.Version()$major, R.Version()$minor, sep = ".")) >= "3.3") {
+    install.packages("sparklyr.nested")
+  }
+
   parent_dir <- dir(".", full.names = TRUE)
   sparklyr_package <- parent_dir[grepl("sparklyr_", parent_dir)]
   install.packages(sparklyr_package, repos = NULL, type = "source")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,5 +62,4 @@ Suggests:
     R6,
     RCurl,
     reshape2,
-    sparklyr.nested,
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,4 +62,5 @@ Suggests:
     R6,
     RCurl,
     reshape2,
+    sparklyr.nested,
     testthat

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 # Sparklyr 0.9.3 (unreleased)
 
-- Tables with periods are now supported by setting
-  `sparklyr.dplyr.period.splits` to `FALSE`. `database.name` is being
-   deprecated in future releases, please use instead `dbplyr::in_schema()`.
+- Tables with periods supported by setting
+  `sparklyr.dplyr.period.splits` to `FALSE`.
 
 - Deprecate `sdf_mutate()` (#1754).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,8 @@
-<<<<<<< HEAD
 # Sparklyr 0.9.3 (unreleased)
 
-- Tables with periods are now supported; for `database.name` use instead
-  `dbplyr::in_schema()` or, for backwards compatibility set
-  `sparklyr.dplyr.period.splits` to `TRUE`.
+- Tables with periods are now supported by setting
+  `sparklyr.dplyr.period.splits` to `FALSE`. `database.name` is being
+   deprecated in future releases, please use instead `dbplyr::in_schema()`.
 
 - Deprecate `sdf_mutate()` (#1754).
 
@@ -24,11 +23,6 @@
   not yet implemented in Spark.
   
 - Support for collecting NA values from logical columns (#1729).
-||||||| merged common ancestors
-<<<<<<<<< Temporary merge branch 1
-# Sparklyr 0.9.3 (unreleased)
-
-- Proactevely clean JVM objects when R object is deallocated.
 
 # Sparklyr 0.9.2
 
@@ -38,13 +32,6 @@
 
 - Fix missing callstack and error case while logging in
   `spark_apply()`.
-||||||||| merged common ancestors
-# Sparklyr 0.9.2 (unreleased)
-=========
-# Sparklyr 0.9.3 (unreleased)
-=======
-# Sparklyr 0.9.3 (unreleased)
->>>>>>> 9eb66531aa503f1d2451d13726cac60bbd3737fa
 
 - Proactevely clean JVM objects when R object is deallocated.
 

--- a/R/tables_spark.R
+++ b/R/tables_spark.R
@@ -1,6 +1,10 @@
 tbl_quote_name <- function(sc, name) {
-  if (!spark_config_value(sc$config, "sparklyr.dplyr.period.splits", FALSE)) {
+  if (!spark_config_value(sc$config, "sparklyr.dplyr.period.splits", TRUE)) {
     return(dbplyr::sql_quote(name, '`'))
+  }
+
+  if (grepl("\\.", name)) {
+    warning("Using periods to split database and tables is being deprecated, use dbplyr::in_schema() instead.")
   }
 
   y <- gsub("`", "``", name, fixed = TRUE)

--- a/R/tables_spark.R
+++ b/R/tables_spark.R
@@ -3,10 +3,6 @@ tbl_quote_name <- function(sc, name) {
     return(dbplyr::sql_quote(name, '`'))
   }
 
-  if (grepl("\\.", name)) {
-    warning("Using periods to split database and tables is being deprecated, use dbplyr::in_schema() instead.")
-  }
-
   y <- gsub("`", "``", name, fixed = TRUE)
   y <- strsplit(y, "\\.")[[1]]
   y <- paste(y, collapse = "`.`")

--- a/tests/testthat/test-extension-nested.R
+++ b/tests/testthat/test-extension-nested.R
@@ -1,0 +1,12 @@
+context("extension sparklyr.nested")
+sc <- testthat_spark_connection()
+
+test_that("sparklyr.nested can query nested columns", {
+  iris_tbl <- testthat_tbl("iris")
+  iris_nst <- iris_tbl %>% sparklyr.nested::sdf_nest(Species, Sepal_Width)
+
+  expect_equal(
+    iris_nst %>% filter(data.Species == "setosa") %>% count() %>% pull(n) %>% as.integer(),
+    50
+  )
+})

--- a/tests/testthat/test-extension-nested.R
+++ b/tests/testthat/test-extension-nested.R
@@ -2,6 +2,9 @@ context("extension sparklyr.nested")
 sc <- testthat_spark_connection()
 
 test_that("sparklyr.nested can query nested columns", {
+  if (package_version(paste(R.Version()$major, R.Version()$minor, sep = ".")) < "3.3")
+    skip("sparklyr.nested requires R 3.3")
+
   iris_tbl <- testthat_tbl("iris")
   iris_nst <- iris_tbl %>% sparklyr.nested::sdf_nest(Species, Sepal_Width)
 

--- a/tests/testthat/test-extension-nested.R
+++ b/tests/testthat/test-extension-nested.R
@@ -2,8 +2,8 @@ context("extension sparklyr.nested")
 sc <- testthat_spark_connection()
 
 test_that("sparklyr.nested can query nested columns", {
-  if (package_version(paste(R.Version()$major, R.Version()$minor, sep = ".")) < "3.3")
-    skip("sparklyr.nested requires R 3.3")
+  if (!"sparklyr.nested" %in% installed.packages())
+    skip("sparklyr.nested not installed.")
 
   iris_tbl <- testthat_tbl("iris")
   iris_nst <- iris_tbl %>% sparklyr.nested::sdf_nest(Species, Sepal_Width)


### PR DESCRIPTION
Follow up from https://github.com/rstudio/sparklyr/pull/1753, we need to ensure nested data works properly to support compatibility with `sparklyr 0.9`, etc.