### PR TITLE
Improve type error

### DIFF
--- a/R/core_serialize.R
+++ b/R/core_serialize.R
@@ -73,7 +73,7 @@ writeObject <- function(con, object, writeType = TRUE) {
          POSIXct = writeTime(con, object),
          factor = writeFactor(con, object),
          `data.frame` = writeList(con, object),
-         stop("Unsupported type for serialization'", type, "'"))
+         stop("Unsupported type '", type, "' for serialization"))
 }
 
 writeVoid <- function(con) {
@@ -130,7 +130,7 @@ writeType <- function(con, class) {
                  POSIXct = "t",
                  factor = "c",
                  `data.frame` = "l",
-                 stop("Unsupported type for serialization '", class, "'"))
+                 stop("Unsupported type '", type, "' for serialization"))
   writeBin(charToRaw(type), con)
 }
 

--- a/R/core_serialize.R
+++ b/R/core_serialize.R
@@ -73,7 +73,7 @@ writeObject <- function(con, object, writeType = TRUE) {
          POSIXct = writeTime(con, object),
          factor = writeFactor(con, object),
          `data.frame` = writeList(con, object),
-         stop(paste("Unsupported type for serialization", type)))
+         stop("Unsupported type for serialization'", type, "'"))
 }
 
 writeVoid <- function(con) {
@@ -130,7 +130,7 @@ writeType <- function(con, class) {
                  POSIXct = "t",
                  factor = "c",
                  `data.frame` = "l",
-                 stop(paste("Unsupported type for serialization", class)))
+                 stop("Unsupported type for serialization '", class, "'"))
   writeBin(charToRaw(type), con)
 }
 

--- a/R/data_interface.R
+++ b/R/data_interface.R
@@ -345,13 +345,9 @@ spark_expect_jobj_class <- function(jobj, expectedClassName) {
   class <- invoke(jobj, "getClass")
   className <- invoke(class, "getName")
   if (!identical(className, expectedClassName)) {
-    stop(paste(
-      "This operation is only supported on",
-      expectedClassName,
-      "jobjs but found",
-      className,
-      "instead.")
-    )
+    stop("This operation is only supported on ",
+         expectedClassName, " jobjs but found ",
+         className, " instead.")
   }
 }
 

--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -8,7 +8,7 @@ databricks_connection <- function(config, extensions) {
                                          # startSparklyr will search & find proper JAR file
                                          system.file("java/", package = "sparklyr")))
   }, error = function(err) {
-    stop(paste("Failed to start sparklyr backend:", err$message))
+    stop("Failed to start sparklyr backend: ", err$message)
   })
 
   new_databricks_connection(

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -44,7 +44,7 @@ spark_install_find <- function(version = NULL,
       sparkInstall$version <- sparkVersion
       sparkInstall$hadoop_version <- hadoopVersion
 
-      stop(paste("Spark version not installed. To install, use", deparse(sparkInstall)))
+      stop("Spark version not installed. To install, use", deparse(sparkInstall))
     } else {
       stop("Spark version not available. Find available versions, using spark_available_versions()")
     }
@@ -296,14 +296,14 @@ spark_install_old_dir <- function() {
 #' @export
 spark_install_tar <- function(tarfile) {
   if (!file.exists(tarfile)) {
-    stop(paste0("The file \"", tarfile, "\", does not exist."))
+    stop("The file \"", tarfile, "\", does not exist.")
   }
 
   filePattern <- spark_versions_file_pattern();
   fileName <- basename(tarfile)
   if (length(grep(filePattern, fileName)) == 0) {
-    stop(paste(
-      "The given file does not conform with the following pattern: ", filePattern))
+    stop(
+      "The given file does not conform with the following pattern: ", filePattern)
   }
 
   untar(tarfile = tarfile,

--- a/R/livy_install.R
+++ b/R/livy_install.R
@@ -206,7 +206,7 @@ livy_install_find <- function(livyVersion = NULL) {
     livyInstall <- quote(livy_install(version = ""))
     livyInstall$version <- livyVersion
 
-    stop(paste("Livy version not installed. To install, use", deparse(livyInstall)))
+    stop("Livy version not installed. To install, use ", deparse(livyInstall))
   }
 
   tail(versions, n = 1)

--- a/R/ml_model_random_forest.R
+++ b/R/ml_model_random_forest.R
@@ -54,7 +54,7 @@ ml_random_forest <- function(x, formula = NULL, type = c("auto", "regression", "
   # choose classification vs. regression model based on column type
   schema <- sdf_schema(sdf)
   if (!response_col %in% names(schema))
-    stop(paste0("`", response_col, "` is not a column in the input dataset."))
+    stop("`", response_col, "` is not a column in the input dataset.")
 
   response_type <- schema[[response_col]]$type
 

--- a/R/ml_pipeline_utils.R
+++ b/R/ml_pipeline_utils.R
@@ -30,8 +30,8 @@ maybe_set_param <- function(jobj, setter, value, min_version = NULL, default = N
     if (ver < min_version) {
       if (!isTRUE(all.equal(value, default))) {
         # if user does not have required version, and tries to set parameter, throw error
-        stop(paste0("Parameter '", deparse(substitute(value)),
-                    "' is only available for Spark ", min_version, " and later."))
+        stop("Parameter '", deparse(substitute(value)),
+             "' is only available for Spark ", min_version, " and later.")
       } else {
         # otherwise, return jobj untouched
         return(jobj)

--- a/R/ml_utils.R
+++ b/R/ml_utils.R
@@ -42,7 +42,7 @@ fitted.ml_model_prediction <- function(object, ...) {
 
 #' @export
 residuals.ml_model <- function(object, ...) {
-  stop(paste0("'residuals()' not supported for ", class(object)[[1]]))
+  stop("'residuals()' not supported for ", class(object)[[1L]])
 }
 
 #' Model Residuals

--- a/R/tidiers_utils.R
+++ b/R/tidiers_utils.R
@@ -6,23 +6,20 @@ extract_model_metrics <- function(object, metric_names, new_names) {
 
 #' @export
 tidy.ml_model <- function(x, ...) {
-  stop(paste0("'tidy()' not yet supported for ",
-              setdiff(class(x), "ml_model"))
-  )
+  stop("'tidy()' not yet supported for ",
+       setdiff(class(x), "ml_model"))
 }
 
 #' @export
 augment.ml_model <- function(x, ...) {
-  stop(paste0("'augment()' not yet supported for ",
-              setdiff(class(x), "ml_model"))
-  )
+  stop("'augment()' not yet supported for ",
+       setdiff(class(x), "ml_model"))
 }
 
 #' @export
 glance.ml_model <- function(x, ...) {
-  stop(paste0("'glance()' not yet supported for ",
-              setdiff(class(x), "ml_model"))
-  )
+  stop("'glance()' not yet supported for ",
+       setdiff(class(x), "ml_model"))
 }
 
 # this function provides broom::augment() for

--- a/inst/livy/spark-1.6.0/sources.scala
+++ b/inst/livy/spark-1.6.0/sources.scala
@@ -133,7 +133,7 @@ readTypedObject <- function(con, type) {
           "s" = readStruct(con),
           "n" = NULL,
           "j" = getJobj(con, readString(con)),
-          stop("Unsupported type for deserialization '", type, "'"))
+          stop("Unsupported type '", type, "' for deserialization"))
 }
 
 readString <- function(con) {
@@ -901,7 +901,7 @@ writeObject <- function(con, object, writeType = TRUE) {
          POSIXct = writeTime(con, object),
          factor = writeFactor(con, object),
          `data.frame` = writeList(con, object),
-         stop("Unsupported type for serialization '", type, "'"))
+         stop("Unsupported type '", type, "' for serialization"))
 }
 
 writeVoid <- function(con) {
@@ -958,7 +958,7 @@ writeType <- function(con, class) {
                  POSIXct = "t",
                  factor = "c",
                  `data.frame` = "l",
-                 stop(paste("Unsupported type for serialization", class)))
+                 stop("Unsupported type '", class, "' for serialization"))
   writeBin(charToRaw(type), con)
 }
 

--- a/inst/livy/spark-1.6.0/sources.scala
+++ b/inst/livy/spark-1.6.0/sources.scala
@@ -133,7 +133,7 @@ readTypedObject <- function(con, type) {
           "s" = readStruct(con),
           "n" = NULL,
           "j" = getJobj(con, readString(con)),
-          stop(paste("Unsupported type for deserialization", type)))
+          stop("Unsupported type for deserialization '", type, "'"))
 }
 
 readString <- function(con) {
@@ -901,7 +901,7 @@ writeObject <- function(con, object, writeType = TRUE) {
          POSIXct = writeTime(con, object),
          factor = writeFactor(con, object),
          `data.frame` = writeList(con, object),
-         stop(paste("Unsupported type for serialization", type)))
+         stop("Unsupported type for serialization '", type, "'"))
 }
 
 writeVoid <- function(con) {

--- a/java/spark-1.6.0/sources.scala
+++ b/java/spark-1.6.0/sources.scala
@@ -130,7 +130,7 @@ readTypedObject <- function(con, type) {
           "s" = readStruct(con),
           "n" = NULL,
           "j" = getJobj(con, readString(con)),
-          stop(paste("Unsupported type for deserialization", type)))
+          stop("Unsupported type for deserialization '", type, "'"))
 }
 
 readString <- function(con) {
@@ -955,7 +955,7 @@ writeType <- function(con, class) {
                  POSIXct = "t",
                  factor = "c",
                  `data.frame` = "l",
-                 stop(paste("Unsupported type for serialization", class)))
+                 stop("Unsupported type for serialization '", class, "'"))
   writeBin(charToRaw(type), con)
 }
 


### PR DESCRIPTION
I was met with this confusing error and spent some time debugging it:

> Unsupported type for serialization glue

I think I would have realized what was going on right away if the message was instead:

> Unsupported type 'glue' for serialization

I also noticed some usage of the `stop(paste(` form of building error messages, which is discouraged where it can be avoided (it's why `stop` has `...` argument). This is a separate commit as it's more cosmetic and can be more easily reversed.

I wasn't sure if I should add tests; let me know.