### PR TITLE
Support for Spark 2.4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Sparklyr 0.9.3 (unreleased)
 
+- Support to install and use Spark 2.4.0.
+
 - Improvements and fixes to `spark_config_kubernetes()`
   parameters.
 

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -171,7 +171,13 @@ spark_versions_info <- function(version, hadoop_version, latest = TRUE) {
 
   version <- versions[1,]
 
-  componentName <- sub("\\.tgz", "", sprintf(versions$pattern, version$spark, version$hadoop))
+  if (nchar(versions$pattern) > 0) {
+    componentName <- sub("\\.tgz", "", sprintf(versions$pattern, version$spark, version$hadoop))
+  }
+  else {
+    componentName <- sprintf("spark-%s-bin-hadoop%s", version$spark, version$hadoop)
+  }
+
   packageName <- paste0(componentName, ".tgz")
   packageRemotePath <- version$download
 

--- a/R/spark_extensions.R
+++ b/R/spark_extensions.R
@@ -95,10 +95,19 @@ sparklyr_jar_path <- function(spark_version) {
   else
     scala_version <- "2.11"
   spark_major_minor <- spark_version[1, 1:2]
-  system.file(
-    sprintf("java/sparklyr-%s-%s.jar", spark_major_minor, scala_version),
-    package = "sparklyr"
-  )
+
+  exact_jar <- sprintf("java/sparklyr-%s-%s.jar", spark_major_minor, scala_version)
+  all_jars <- dir(system.file("java",package = "sparklyr"), pattern = "sparklyr")
+
+  if (exact_jar %in% all_jars) {
+    system.file(exact_jar, package = "sparklyr")
+  } else if (spark_version > "1.6") {
+    # Spark is backwards compatible so we can use a new version with the latest jar
+    latest_jar <- sort(all_jars, decreasing = T)[[1]]
+    system.file(file.path("java", latest_jar), package = "sparklyr")
+  } else {
+    ""
+  }
 }
 
 # sparklyr's own declared dependencies

--- a/R/spark_extensions.R
+++ b/R/spark_extensions.R
@@ -96,11 +96,11 @@ sparklyr_jar_path <- function(spark_version) {
     scala_version <- "2.11"
   spark_major_minor <- spark_version[1, 1:2]
 
-  exact_jar <- sprintf("java/sparklyr-%s-%s.jar", spark_major_minor, scala_version)
+  exact_jar <- sprintf("sparklyr-%s-%s.jar", spark_major_minor, scala_version)
   all_jars <- dir(system.file("java",package = "sparklyr"), pattern = "sparklyr")
 
   if (exact_jar %in% all_jars) {
-    system.file(exact_jar, package = "sparklyr")
+    system.file(file.path("java", exact_jar), package = "sparklyr")
   } else if (spark_version > "1.6") {
     # Spark is backwards compatible so we can use a new version with the latest jar
     latest_jar <- sort(all_jars, decreasing = T)[[1]]


### PR DESCRIPTION
Adding support for Spark 2.4.0 by falling back to latest Spark jars, that would allow us to enable new Spark versions as soon as they are released by updating the `spark-install` project.