### PR TITLE
Unique SqlContext per databricks connection

### DIFF
--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -1,7 +1,7 @@
 databricks_connection <- function(config, extensions) {
   tryCatch({
     callSparkR <- get("callJStatic", envir = asNamespace("SparkR"))
-    # In Databricks notebooks, this variable is in the default namespace
+    # In Databricks environments (notebooks & rstudio) DATABRICKS_GUID is in the default namespace
     guid <- get("DATABRICKS_GUID", envir = .GlobalEnv)
     gatewayPort <- as.numeric(callSparkR("com.databricks.backend.daemon.driver.RDriverLocal",
                                          "startSparklyr",
@@ -39,8 +39,10 @@ new_databricks_connection <- function(scon, guid) {
     scon,
     class = "databricks_connection"
   )
-  rDriverLocal <- "com.databricks.backend.daemon.driver.RDriverLocal"
-  hive_context <- invoke_static(sc, rDriverLocal, "getDriver", guid) %>% invoke("sqlContext")
+  # In databricks, sparklyr should use the SqlContext associated with the RDriverLocal instance for
+  # this guid.
+  r_driver_local <- "com.databricks.backend.daemon.driver.RDriverLocal"
+  hive_context <- invoke_static(sc, r_driver_local, "getDriver", guid) %>% invoke("sqlContext")
   sc$state$hive_context <- hive_context
   sc
 }

--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -1,10 +1,11 @@
 databricks_connection <- function(config, extensions) {
   tryCatch({
     callSparkR <- get("callJStatic", envir = asNamespace("SparkR"))
+    # In Databricks notebooks, this variable is in the default namespace
+    guid <- get("DATABRICKS_GUID", envir = .GlobalEnv)
     gatewayPort <- as.numeric(callSparkR("com.databricks.backend.daemon.driver.RDriverLocal",
                                          "startSparklyr",
-                                         # In Databricks notebooks, this variable is in the default namespace
-                                         get("DATABRICKS_GUID", envir = .GlobalEnv),
+                                         guid,
                                          # startSparklyr will search & find proper JAR file
                                          system.file("java/", package = "sparklyr")))
   }, error = function(err) {
@@ -15,7 +16,8 @@ databricks_connection <- function(config, extensions) {
     gateway_connection(
       paste("sparklyr://localhost:", gatewayPort, "/", gatewayPort, sep = ""),
       config = config
-    )
+    ),
+    guid
   )
 }
 
@@ -32,9 +34,13 @@ spark_version.databricks_connection <- function(sc) {
   sc$state$spark_version
 }
 
-new_databricks_connection <- function(scon) {
-  new_spark_gateway_connection(
+new_databricks_connection <- function(scon, guid) {
+  sc <- new_spark_gateway_connection(
     scon,
     class = "databricks_connection"
   )
+  rDriverLocal <- "com.databricks.backend.daemon.driver.RDriverLocal"
+  hive_context <- invoke_static(sc, rDriverLocal, "getDriver", guid) %>% invoke("sqlContext")
+  sc$state$hive_context <- hive_context
+  sc
 }


### PR DESCRIPTION
In databricks we create a unique SqlContext (HiveContext) for each notebook or rstudio session even though all users share the same spark context. Because sparklyr uses getOrCreate to get the SqlContext for each user, our users end up sharing a SqlContext. This has causes unexpected behavior and errors for our sparklyr users.

This PR allows databricks connections to get the right SqlContext upfront, resolving this issue.