### PR TITLE
Support retrieving Spark version from spark-submit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,8 @@
   
  - `sdf_len()`, `sdf_along()` and `sdf_seq()` default to 32 bit integers
    but allow support for 64 bits through `bits` parameter.
+   
+ - Support for detecting Spark version using `spark-submit`.
 
 # Sparklyr 0.9.3
 

--- a/R/spark_version.R
+++ b/R/spark_version.R
@@ -103,6 +103,17 @@ spark_version_from_home <- function(spark_home, default = NULL) {
           return(match[[1]][[2]])
         }
       }
+    },
+    useSparkSubmit = function() {
+      version_output <- system2(
+        file.path(spark_home, "bin", "spark-submit"),
+        "--version", stderr = TRUE, stdout = TRUE)
+
+      version_matches <- regmatches(version_output, regexec("   version (.*)$", version_output))
+      if (any(sapply(version_matches, length) > 0)) {
+        version_row <- which(sapply(version_matches, length) > 0)
+        return(version_matches[[version_row]][2])
+      }
     }
   )
 


### PR DESCRIPTION
Another way to detect the current Spark version, we could consider deprecating other mechanism but I don't recall if there were cases where `spark-submit` would not retrieve the correct version.