### PR TITLE
Appropriately handle NA's in string columns

### DIFF
--- a/inst/livy/spark-1.5.2/utils.scala
+++ b/inst/livy/spark-1.5.2/utils.scala
@@ -341,8 +341,7 @@ object Utils {
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _ => value
-        }
+          case _           => if (value == "NA") null.asInstanceOf[String] else value        }
       })
 
       org.apache.spark.sql.Row.fromSeq(typed)
@@ -376,7 +375,7 @@ object Utils {
           case "double"    => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical"   => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _ => value
+          case _           => if (value == "NA") null.asInstanceOf[String] else value
         }
       })
 

--- a/inst/livy/spark-1.5.2/utils.scala
+++ b/inst/livy/spark-1.5.2/utils.scala
@@ -341,7 +341,8 @@ object Utils {
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _           => if (value == "NA") null.asInstanceOf[String] else value        }
+          case _           => if (value == "NA") null.asInstanceOf[String] else value
+        }
       })
 
       org.apache.spark.sql.Row.fromSeq(typed)

--- a/inst/livy/spark-1.5.2/utils.scala
+++ b/inst/livy/spark-1.5.2/utils.scala
@@ -341,7 +341,7 @@ object Utils {
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _           => if (value == "NA") null.asInstanceOf[String] else value
+          case _ => if (value == "NA") null.asInstanceOf[String] else value
         }
       })
 
@@ -376,7 +376,7 @@ object Utils {
           case "double"    => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical"   => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _           => if (value == "NA") null.asInstanceOf[String] else value
+          case _ => if (value == "NA") null.asInstanceOf[String] else value
         }
       })
 

--- a/java/spark-1.5.2/utils.scala
+++ b/java/spark-1.5.2/utils.scala
@@ -338,7 +338,7 @@ object Utils {
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _           => if (value == "NA") null.asInstanceOf[String] else value
+          case _ => if (value == "NA") null.asInstanceOf[String] else value
         }
       })
 
@@ -373,7 +373,7 @@ object Utils {
           case "double"    => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical"   => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _           => if (value == "NA") null.asInstanceOf[String] else value
+          case _ => if (value == "NA") null.asInstanceOf[String] else value
         }
       })
 

--- a/java/spark-1.5.2/utils.scala
+++ b/java/spark-1.5.2/utils.scala
@@ -338,8 +338,7 @@ object Utils {
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _ => value
-        }
+          case _           => if (value == "NA") null.asInstanceOf[String] else value        }
       })
 
       org.apache.spark.sql.Row.fromSeq(typed)
@@ -373,7 +372,7 @@ object Utils {
           case "double"    => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical"   => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _ => value
+          case _           => if (value == "NA") null.asInstanceOf[String] else value
         }
       })
 

--- a/java/spark-1.5.2/utils.scala
+++ b/java/spark-1.5.2/utils.scala
@@ -338,7 +338,8 @@ object Utils {
           case "double"  => if (Try(value.toDouble).isSuccess) value.toDouble else null.asInstanceOf[Double]
           case "logical" => if (Try(value.toBoolean).isSuccess) value.toBoolean else null.asInstanceOf[Boolean]
           case "timestamp" => if (Try(new java.sql.Timestamp(value.toLong * 1000)).isSuccess) new java.sql.Timestamp(value.toLong * 1000) else null.asInstanceOf[java.sql.Timestamp]
-          case _           => if (value == "NA") null.asInstanceOf[String] else value        }
+          case _           => if (value == "NA") null.asInstanceOf[String] else value
+        }
       })
 
       org.apache.spark.sql.Row.fromSeq(typed)


### PR DESCRIPTION
This PR fixes #1836 by adding an extra condition to `createDataFrameFromCsv()` and `createDataFrameFromText()` to handle "NA" values in columns that are of type strings. I haven't added the recompiled package jars to this PR, let me know if I need to!