### PR TITLE
Add dbplyr to travis devel check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
       env: R_DEVEL_PACKAGES="true"
       r_github_packages:
         - tidyverse/dplyr
+        - tidyverse/dbplyr
         - tidyverse/tibble
         - r-lib/rlang
         - rstudio/forge


### PR DESCRIPTION
A few additional failures already spotted by @kevinykuo in `dbplyr`:

```
the implementation of 'sample_frac' functions returns a sample: error: `con` must not be NULL 
'sample_n' and 'sample_frac' work in nontrivial queries (#1299): error: `con` must not be NULL
ft_dplyr_transformer() handles cases where table name isn't quoted (#1249): error: `con` must not be NULL 
```