### PR TITLE
Install arrow from arrowlib mirror

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: deb https://s3-us-west-2.amazonaws.com/arrowlib/ubuntu/ trusty universe
-              key_url: https://s3-us-west-2.amazonaws.com/arrowlib/ubuntu/red-data-tools-keyring.gpg
+            - sourceline: deb https://arrowlib.rstudio.com/ubuntu/ trusty universe
+              key_url: https://arrowlib.rstudio.com/ubuntu/red-data-tools-keyring.gpg
           packages:
             - apt-transport-https
             - lsb-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,8 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: deb https://packages.red-data-tools.org/ubuntu/ trusty universe
-              key_url: https://packages.red-data-tools.org/ubuntu/red-data-tools-keyring.gpg
+            - sourceline: deb https://s3-us-west-2.amazonaws.com/arrowlib/ubuntu/ trusty universe
+              key_url: https://s3-us-west-2.amazonaws.com/arrowlib/ubuntu/red-data-tools-keyring.gpg
           packages:
             - apt-transport-https
             - lsb-release


### PR DESCRIPTION
To avoid `sparklyr` Arrow bindings breaking inadvertently, this PR adds support to install the bindings from a location we can control and upgrade when `sparklyr` releases to CRAN.