### PR TITLE
Compatibility with devel dbplyr

### DIFF
--- a/R/dplyr_sql.R
+++ b/R/dplyr_sql.R
@@ -6,15 +6,16 @@
 sql_build.op_sample_n <- function(op, con, ...) {
   select_query(
     from = sql(
-      sql_render(op$x, con = con),
+      sql_render(sql_build(op$x, con = con), con = con),
       sql(paste0(" TABLESAMPLE (",
                  as.integer(op$args$size),
-                 " rows) ", collapse = ""))
+                 " rows) ", collapse = "")),
+      con = con
     ) %>%
       as.character() %>%
       paste0(collapse = "") %>%
       sql(),
-    select = build_sql("*")
+    select = build_sql("*", con = con)
   )
 }
 
@@ -24,14 +25,15 @@ sql_build.op_sample_n <- function(op, con, ...) {
 sql_build.op_sample_frac <- function(op, con, ...) {
   select_query(
     from = sql(
-      sql_render(op$x, con = con),
+      sql_render(sql_build(op$x, con = con), con = con),
       sql(paste0(" TABLESAMPLE (",
                  op$args$size * 100,
-                 " PERCENT)", collapse = ""))
+                 " PERCENT)", collapse = "")),
+      con = con
     ) %>%
       as.character() %>%
       paste0(collapse = "") %>%
       sql(),
-    select = build_sql("*")
+    select = build_sql("*", con = con)
   )
 }


### PR DESCRIPTION
- Added `con` argument to `sql` function calls since it is now explicitly required.
- Refactored `sql_render()` call since `sql_render.op()` was removed.