### PR TITLE
Improve LDA formula interface behavior

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.9.9002
+Version: 0.9.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/R/ml_model_helpers.R
+++ b/R/ml_model_helpers.R
@@ -29,7 +29,7 @@ ml_clustering_pipeline <- function(predictor, dataset, formula, features_col) {
                    output_col = "token") %>%
       ft_count_vectorizer(input_col = "token",
                           output_col = "word_count") %>%
-      ft_r_formula("~word_count") %>%
+      ft_r_formula("~word_count", features_col = features_col) %>%
       ml_add_stage(predictor)
   } else{
     r_formula <- ft_r_formula(sc, formula = formula, features_col = features_col)

--- a/R/ml_model_helpers.R
+++ b/R/ml_model_helpers.R
@@ -31,7 +31,7 @@ ml_clustering_pipeline <- function(predictor, dataset, formula, features_col) {
     count_vectorizer_out <- random_string("count_vectorizer_out_")
 
     ml_pipeline(sc) %>%
-      ft_tokenizer(input_col = gsub("~", "", formula),
+      ft_regex_tokenizer(input_col = gsub("~", "", formula),
                    output_col = tokenizer_out) %>%
       ft_stop_words_remover(tokenizer_out, stop_words_remover_out) %>%
       ft_count_vectorizer(input_col = stop_words_remover_out,

--- a/R/ml_model_helpers.R
+++ b/R/ml_model_helpers.R
@@ -24,12 +24,19 @@ ml_clustering_pipeline <- function(predictor, dataset, formula, features_col) {
     )
     ml_pipeline(vector_assembler, predictor)
   } else if (inherits(predictor, "ml_lda")){
+
+    # Temporary column names to prevent clashes
+    tokenizer_out <- random_string("tokenizer_out_")
+    stop_words_remover_out <- random_string("stop_words_remover_out_")
+    count_vectorizer_out <- random_string("count_vectorizer_out_")
+
     ml_pipeline(sc) %>%
       ft_tokenizer(input_col = gsub("~", "", formula),
-                   output_col = "token") %>%
-      ft_count_vectorizer(input_col = "token",
-                          output_col = "word_count") %>%
-      ft_r_formula("~word_count", features_col = features_col) %>%
+                   output_col = tokenizer_out) %>%
+      ft_stop_words_remover(tokenizer_out, stop_words_remover_out) %>%
+      ft_count_vectorizer(input_col = stop_words_remover_out,
+                          output_col = count_vectorizer_out) %>%
+      ft_r_formula(paste0("~", count_vectorizer_out), features_col = features_col) %>%
       ml_add_stage(predictor)
   } else{
     r_formula <- ft_r_formula(sc, formula = formula, features_col = features_col)

--- a/R/ml_model_lda.R
+++ b/R/ml_model_lda.R
@@ -1,7 +1,9 @@
 new_ml_model_lda <- function(pipeline_model, formula, dataset,
                              features_col) {
 
-  vocabulary <- pipeline_model$stages[[2]]$vocabulary
+  vocabulary <- pipeline_model %>%
+    ml_stage("count_vectorizer") %>%
+    ml_vocabulary()
 
   new_ml_model_clustering(
     pipeline_model = pipeline_model,


### PR DESCRIPTION
- Use temporary names for feature transformer columns to avoid clashes.
- Use regex tokenizer instead of tokenizer, which is more robust (e.g. splits on `\\s+` instead of ` `).
- Add a stop words remover stage.