### PR TITLE
Cast waitSeconds in stream_validate() to difftime

### DIFF
--- a/R/stream_operations.R
+++ b/R/stream_operations.R
@@ -49,7 +49,8 @@ stream_stop <- function(stream)
 
 stream_validate <- function(stream)
 {
-  waitSeconds <- cast_scalar_integer(spark_config_value(config, "sparklyr.stream.validate.timeout", 3))
+  waitSeconds <- cast_scalar_integer(spark_config_value(config, "sparklyr.stream.validate.timeout", 3)) %>%
+    as.difftime(units = "secs")
 
   commandStart <- Sys.time()
   while (!grepl("waiting", stream_status(stream)$message) &&


### PR DESCRIPTION
This change avoids a warning with devel forge where R complains about not finding a match when trying to dispatch `+` for `POSIXt` and `forge_stamped`.