### PR TITLE
fix: mismatch between additional_params and livy jars

### DIFF
--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -118,11 +118,11 @@ livy_config <- function(config = spark_config(),
 
     target_jar <- dir(system.file("java", package = "sparklyr"), pattern = paste0("sparklyr-", target_version))
 
-    additional_params$jars <- paste0(
+    additional_params$jars <- list(paste0(
       "https://github.com/rstudio/sparklyr/blob/bugfix/livy-jars/inst/java/",
       target_jar,
       "?raw=true"
-    )
+    ))
   }
 
   #Params need to be restrictued or livy will complain about unknown parameters


### PR DESCRIPTION
use livy-jars feature to submit spark job and an error happened：
![2019-02-11 20 25 10](https://user-images.githubusercontent.com/17550838/52608823-0e477380-2eb6-11e9-8171-eee407b06585.png)
it caused by additional_params&jars is a vector and livy jars params needs a list。
I test my solution and can effect