### PR TITLE
Support for installing and connecting using major Spark version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 0.9.9007
+Version: 0.9.9008
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,9 @@
 
 ## Other
 
+- Support to install and connect based on major Spark versions, for
+  instance: `spark_connect(master = "local", version = "2.4")`.
+
 - Faster retrieval of string arrays.
 
 - Support for installing and connecting to Spark 2.4.

--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -13,6 +13,13 @@ spark_install_available <- function(version, hadoop_version) {
   dir.exists(installInfo$sparkVersionDir)
 }
 
+spark_install_version_expand <- function(version) {
+  versions <- spark_available_versions(show_minor = T)$spark
+  versions <- versions[grepl(version, spark_available_versions(show_minor = T)$spark)]
+
+  sort(versions, decreasing = TRUE)[1]
+}
+
 #' Find a given Spark installation by version.
 #'
 #' @rdname spark_install
@@ -28,6 +35,10 @@ spark_install_find <- function(version = NULL,
                                installed_only = TRUE,
                                latest = FALSE,
                                hint = FALSE) {
+  if (identical(grepl("^[0-9]+\\.[0-9]+$", version), TRUE)) {
+    version <- spark_install_version_expand(version)
+  }
+
   sparkVersion <- version
   hadoopVersion <- hadoop_version
   installedOnly <- installed_only

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -74,7 +74,7 @@ spark_installed_versions <- function() {
 #' @rdname spark_install
 #'
 #' @export
-spark_available_versions <- function(show_hadoop = FALSE) {
+spark_available_versions <- function(show_hadoop = FALSE, show_minor = FALSE) {
   versions <- read_spark_versions_json(latest = TRUE)
   versions <- versions[versions$spark >= "1.6.0", 1:2]
   selection <- if (show_hadoop) c("spark", "hadoop") else "spark"
@@ -83,7 +83,9 @@ spark_available_versions <- function(show_hadoop = FALSE) {
 
   rownames(versions) <- 1:nrow(versions)
 
-  versions
+  if (!show_minor) versions$spark <- gsub("\\.[0-9]+$", "", versions$spark)
+
+  unique(versions)
 }
 
 #' Retrieves a dataframe available Spark versions that van be installed.

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -70,6 +70,7 @@ spark_installed_versions <- function() {
 }
 
 #' @param show_hadoop Show Hadoop distributions?
+#' @param show_minor Show minor Spark versions?
 #'
 #' @rdname spark_install
 #'

--- a/R/install_spark_versions.R
+++ b/R/install_spark_versions.R
@@ -86,7 +86,10 @@ spark_available_versions <- function(show_hadoop = FALSE, show_minor = FALSE) {
 
   if (!show_minor) versions$spark <- gsub("\\.[0-9]+$", "", versions$spark)
 
-  unique(versions)
+  versions <- unique(versions)
+  rownames(versions) <- NULL
+
+  versions
 }
 
 #' Retrieves a dataframe available Spark versions that van be installed.

--- a/man/spark_install.Rd
+++ b/man/spark_install.Rd
@@ -24,7 +24,7 @@ spark_install_tar(tarfile)
 
 spark_installed_versions()
 
-spark_available_versions(show_hadoop = FALSE)
+spark_available_versions(show_hadoop = FALSE, show_minor = FALSE)
 }
 \arguments{
 \item{version}{Version of Spark to install. See \code{spark_available_versions} for a list of supported versions}
@@ -47,6 +47,8 @@ spark_available_versions(show_hadoop = FALSE)
 reference spark and hadoop versions respectively.}
 
 \item{show_hadoop}{Show Hadoop distributions?}
+
+\item{show_minor}{Show minor Spark versions?}
 }
 \value{
 List with information about the installed version.


### PR DESCRIPTION
Support for:

```r
sc <- spark_connect(master = "local", version = "2.4")
```

```r
spark_available_versions()
```
````
   spark
1    1.6
5    2.0
8    2.1
10   2.2
12   2.3
15   2.4
```

```
spark_install("2.4")
```