### PR TITLE
Databricks connection should be using SparkSession not HiveContext

### DIFF
--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -66,7 +66,10 @@ new_databricks_connection <- function(scon, guid) {
   # In databricks, sparklyr should use the SqlContext associated with the RDriverLocal instance for
   # this guid.
   r_driver_local <- "com.databricks.backend.daemon.driver.RDriverLocal"
-  hive_context <- invoke_static(sc, r_driver_local, "getDriver", guid) %>% invoke("sqlContext")
-  sc$state$hive_context <- hive_context
+  session <- invoke_static(sc, r_driver_local, "getDriver", guid) %>%
+    invoke("sqlContext") %>%
+    invoke("sparkSession")
+  # This is called hive_context but for spark > 2.0, it should actually be a spark session
+  sc$state$hive_context <- session
   sc
 }


### PR DESCRIPTION
It seems that sparklyr is expect `sc$state$hive_context` to be a SparkSession for spark 2.x. This PR updates the "hive_context" to use the same SparkSession as the notebook or rstudio environment.

This PR brings the databricks connection in line with what's done for spark_shell_connection, https://github.com/rstudio/sparklyr/blob/e05190e953d313483660af6a2c6a16f4ae50fb86/R/shell_connection.R#L595-L608