### PR TITLE
Fix params has been deprecated and will be removed in a future release

### DIFF
--- a/tests/testthat/test-ml-feature-string-indexer.R
+++ b/tests/testthat/test-ml-feature-string-indexer.R
@@ -37,12 +37,6 @@ test_that("ft_string_indexer() works", {
   indexer <- ft_string_indexer(sc, "string", "indexed") %>%
     ml_fit(df_tbl)
   expect_identical(ml_labels(indexer), c("foo", "bar"))
-
-  # backwards compat
-  my_env <- new.env(emptyenv())
-  transformed <- df_tbl %>%
-    ft_string_indexer("string", "indexed", params = my_env)
-  expect_identical(my_env$labels, c("foo", "bar"))
 })
 
 test_that("ft_index_to_string() works", {


### PR DESCRIPTION
```
Context: ml feature string indexer + index to string
ft_index_to_string() param setting: skip: test requires Spark version 2.3.0 
ft_string_indexer() default params: skip: test requires Spark version 2.3.0 
ft_index_to_string() param setting: 0.0081639289855957
ft_string_indexer() param setting: skip: test requires Spark version 2.3.0 
ft_string_indexer() default params: 0.0166115760803223
ft_string_indexer() param setting: 0.00855326652526855
ft_string_indexer() works: warning: `params` has been deprecated and will be removed in a future release. 
ft_string_indexer() works: error: 1 components of ... were not used:
* params
```