### PR TITLE
updates deprecated registerTempTable calls

### DIFF
--- a/R/data_copy.R
+++ b/R/data_copy.R
@@ -232,5 +232,5 @@ spark_data_copy <- function(
 
   df <- spark_data_perform_copy(sc, serializers[[serializer]], df, repartition)
 
-  invoke(df, "registerTempTable", name)
+  invoke(df, "createOrReplaceTempView", name)
 }

--- a/R/dplyr_spark_data.R
+++ b/R/dplyr_spark_data.R
@@ -11,7 +11,7 @@ spark_partition_register_df <- function(sc, df, name, repartition, memory) {
   }
 
   if (!name %in% dbListTables(sc)) {
-    invoke(df, "registerTempTable", name)
+    invoke(df, "createOrReplaceTempView", name)
   }
 
   if (memory) {

--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -134,7 +134,7 @@ sdf_register.list <- function(x, name = NULL) {
 #' @importFrom dplyr tbl
 sdf_register.spark_jobj <- function(x, name = NULL) {
   name <- name %||% random_string("sparklyr_tmp_")
-  invoke(x, "registerTempTable", name)
+  invoke(x, "createOrReplaceTempView", name)
   sc <- spark_connection(x)
   on_connection_updated(sc, name)
   tbl(sc, name)


### PR DESCRIPTION
`registerTempTable` is a deprecated function. Not sure when it may be removed. This PR replaces with the recommended replacement method per https://spark.apache.org/docs/2.4.0/api/java/index.html?org/apache/spark/sql/functions.html