### PR TITLE
Update test-dplyr.R

### DIFF
--- a/tests/testthat/test-dplyr.R
+++ b/tests/testthat/test-dplyr.R
@@ -28,13 +28,14 @@ test_that("the implementation of 'filter' functions as expected", {
       filter(`Sepal.Width` == 3.5) %>%
       filter(`Petal.Length` == 1.4) %>%
       filter(`Petal.Width` == 0.2) %>%
-      select(`Species`),
-    iris %>%
-      filter(`Sepal.Length` == 5.1) %>%
-      filter(`Sepal.Width` == 3.5) %>%
-      filter(`Petal.Length` == 1.4) %>%
-      filter(`Petal.Width` == 0.2) %>%
-      select(`Species`)
+      nrow(),
+    iris_tbl %>%
+      filter(`Sepal_Length` == 5.1) %>%
+      filter(`Sepal_Width` == 3.5) %>%
+      filter(`Petal_Length` == 1.4) %>%
+      filter(`Petal_Width` == 0.2) %>%
+      collect() %>%
+      nrow()
   )
 })
 


### PR DESCRIPTION
Possible typo in the test for the `filter()` implementation. Original version compared two identical filtering expressions involving the local data frame `iris` with no reference to `iris_tbl` in Spark. Using `nrow()` instead of the Species value for the comparison to avoid converting between factor/string and data.frame/tibble within the test, output should be "1" in both cases.