### PR TITLE
Support for repositories in extensions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ SystemRequirements: Spark: 1.6.x or 2.x
 URL: http://spark.rstudio.com
 BugReports: https://github.com/rstudio/sparklyr/issues
 LazyData: TRUE
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Depends:
     R (>= 3.2)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.0.9005
+Version: 1.0.9006
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 
 - Fix support for multiple library paths when using `spark.r.libpaths` (@mattpollock, #1956).
 
+### Extensions
+
+- Add support for repositories in `spark_dependency()`.
+
 # Sparklyr 1.0.0
 
 ### Arrow

--- a/R/livy_connection.R
+++ b/R/livy_connection.R
@@ -600,6 +600,7 @@ livy_connection <- function(master,
 
     config[["sparklyr.livy.sources"]] <- FALSE
     config[["spark.jars.packages"]] <- paste(c(config[["spark.jars.packages"]], extensions$packages), collapse = ",")
+    config[["spark.jars.repositories"]] <- paste(c(config[["spark.jars.repositories"]], extensions$repositories), collapse = ",")
   }
 
   session <- livy_create_session(master, config)

--- a/R/shell_connection.R
+++ b/R/shell_connection.R
@@ -247,6 +247,7 @@ start_shell <- function(master,
     all_jars <- c(jars, extensions$jars)
     jars <- if (length(all_jars) > 0) normalizePath(unlist(unique(all_jars))) else list()
     packages <- unique(c(packages, extensions$packages))
+    repositories <- extensions$repositories
 
     # include embedded jars, if needed
     csv_config_value <- spark_config_value(config, c("sparklyr.connect.csv.embedded", "sparklyr.csv.embedded"))
@@ -278,6 +279,11 @@ start_shell <- function(master,
     # add packages to arguments
     if (length(packages) > 0) {
       shell_args <- c(shell_args, "--packages", paste(shQuote(packages, type = shQuoteType), collapse=","))
+    }
+
+    # add repositories to arguments
+    if (length(repositories) > 0) {
+      shell_args <- c(shell_args, "--repositories", paste(repositories, collapse=","))
     }
 
     # add environment parameters to arguments

--- a/R/spark_extensions.R
+++ b/R/spark_extensions.R
@@ -32,6 +32,7 @@ registered_extensions <- function() {
 #' @param packages Character vector of Spark packages names.
 #' @param initializer Optional callback function called when initializing a connection.
 #' @param catalog Optional location where extension JAR files can be downloaded for Livy.
+#' @param repositories Character vector of Spark package repositories.
 #' @param ... Additional optional arguments.
 #'
 #' @return An object of type `spark_dependency`
@@ -41,12 +42,14 @@ spark_dependency <- function(jars = NULL,
                              packages = NULL,
                              initializer = NULL,
                              catalog = NULL,
+                             repositories = NULL,
                              ...) {
   structure(class = "spark_dependency", list(
     jars = jars,
     packages = packages,
     initializer = initializer,
-    catalog = catalog
+    catalog = catalog,
+    repositories = repositories
   ))
 }
 
@@ -60,6 +63,7 @@ spark_dependencies_from_extensions <- function(spark_version, extensions, config
   packages <- character()
   initializers <- list()
   catalog_jars <- character()
+  repositories <- character()
 
   for (extension in extensions) {
     dependencies <- spark_dependencies_from_extension(spark_version, scala_version, extension)
@@ -67,6 +71,7 @@ spark_dependencies_from_extensions <- function(spark_version, extensions, config
       jars <- c(jars, dependency$jars)
       packages <- c(packages, dependency$packages)
       initializers <- c(initializers, dependency$initializer)
+      repositories <- c(repositories, dependency$repositories)
 
       config_catalog <- spark_config_value(config, "sparklyr.extensions.catalog", TRUE)
       if (!identical(dependency$catalog, NULL) && !identical(config_catalog, FALSE)) {

--- a/ci/.travis.R
+++ b/ci/.travis.R
@@ -15,6 +15,8 @@ if (length(args) == 0) {
   setwd("tests")
   source("testthat.R")
 } else if (args[[1]] == "--coverage") {
+  install.packages("devtools")
+
   devtools::install_github("javierluraschi/covr", ref = "feature/no-batch")
   covr::codecov(type = "none", code = "setwd('tests'); source('testthat.R')", batch = FALSE)
 } else if (args[[1]] == "--arrow") {

--- a/man/spark_apply.Rd
+++ b/man/spark_apply.Rd
@@ -51,7 +51,8 @@ specify the the column types. The sample size is confgirable using the
 
   For clusters where R packages already installed in every worker node,
   the \code{spark.r.libpaths} config entry can be set in \code{spark_config()}
-  to the local packages library.}
+  to the local packages library. To specify multiple paths collapse them
+  (without spaces) with a comma delimiter (e.g., \code{"/lib/path/one,/lib/path/two"}).}
 
 \item{context}{Optional object to be serialized and passed back to \code{f()}.}
 

--- a/man/spark_dependency.Rd
+++ b/man/spark_dependency.Rd
@@ -5,7 +5,7 @@
 \title{Define a Spark dependency}
 \usage{
 spark_dependency(jars = NULL, packages = NULL, initializer = NULL,
-  catalog = NULL, ...)
+  catalog = NULL, repositories = NULL, ...)
 }
 \arguments{
 \item{jars}{Character vector of full paths to JAR files.}
@@ -15,6 +15,8 @@ spark_dependency(jars = NULL, packages = NULL, initializer = NULL,
 \item{initializer}{Optional callback function called when initializing a connection.}
 
 \item{catalog}{Optional location where extension JAR files can be downloaded for Livy.}
+
+\item{repositories}{Character vector of Spark package repositories.}
 
 \item{...}{Additional optional arguments.}
 }


### PR DESCRIPTION
Found that some extensions would require custom repositories while writing a `spark-solr` example for contributing chapter.