### PR TITLE
Expose spark_extension()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
 
 - Fix support for multiple library paths when using `spark.r.libpaths` (@mattpollock, #1956).
 
+### Extensions
+
+- Support for creating an Spark extension package using `spark_extension()`.
+
 # Sparklyr 1.0.0
 
 ### Arrow

--- a/R/project_template.R
+++ b/R/project_template.R
@@ -1,3 +1,14 @@
+#' Create Spark Extension
+#'
+#' Creates an R package ready to be used as an Spark extension.
+#'
+#' @param path Location where the extension will be created.
+#'
+#' @export
+spark_extension <- function(path) {
+  project_template(path)
+}
+
 project_template <- function(path, ...) {
   project_name <- tolower(basename(path))
 

--- a/ci/.travis.R
+++ b/ci/.travis.R
@@ -15,6 +15,8 @@ if (length(args) == 0) {
   setwd("tests")
   source("testthat.R")
 } else if (args[[1]] == "--coverage") {
+  install.packages("devtools")
+
   devtools::install_github("javierluraschi/covr", ref = "feature/no-batch")
   covr::codecov(type = "none", code = "setwd('tests'); source('testthat.R')", batch = FALSE)
 } else if (args[[1]] == "--arrow") {

--- a/inst/rstudio/templates/project/skeleton.dcf
+++ b/inst/rstudio/templates/project/skeleton.dcf
@@ -1,4 +1,4 @@
-Title: R Package using sparklyr
+Title: R Package using Spark
 Binding: project_template
 OpenFiles: README.Rmd, R/main.R, java/main.scala
 Icon: spark.png

--- a/tests/testthat/test-project-template.R
+++ b/tests/testthat/test-project-template.R
@@ -3,3 +3,7 @@ context("project template")
 test_that("'project_template' creation succeeds", {
   expect_true(project_template(tempdir()))
 })
+
+test_that("'spark_extension' creation succeeds", {
+  expect_true(spark_extension(tempdir()))
+})


### PR DESCRIPTION
Currently, a Spark extension template can be created from RStudio's new project menu; however, we don't expose this from code which would be useful to present in the contributing chapter and for non-RStudio users.