### PR TITLE
Fix Arrow devel builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,7 @@ matrix:
         - ARROW_VERSION="devel"
         - ARROW_SOURCE="build"
         - JAVA_VERSION=oraclejdk8
+        - LD_LIBRARY_PATH="/usr/local/lib"
     - name: "Deps Devel (tidyverse, r-lib, forge)"
       env: R_DEVEL_PACKAGES="true"
       r_github_packages:
@@ -93,6 +94,7 @@ matrix:
         - ARROW_VERSION="devel"
         - ARROW_SOURCE="build"
         - JAVA_VERSION=oraclejdk8
+        - LD_LIBRARY_PATH="/usr/local/lib"
 
 before_install:
   - jdk_switcher use $JAVA_VERSION

--- a/ci/arrow-build.sh
+++ b/ci/arrow-build.sh
@@ -9,6 +9,9 @@ sudo apt install -y -V autoconf
 if [[ $ARROW_VERSION == "devel" ]]; then
   git clone https://github.com/apache/arrow
   cd arrow/cpp
+  # arrow@master has a broken R package, pending https://issues.apache.org/jira/browse/ARROW-5361
+  # Remove this version pin after that issue is resolved
+  git checkout 1ed608aa94f0d22cfa69c81687006b4ebaefa258
 else
   wget https://arrowlib.rstudio.com/dist/arrow/arrow-$ARROW_VERSION/apache-arrow-$ARROW_VERSION.tar.gz
   tar -xvzf apache-arrow-$ARROW_VERSION.tar.gz


### PR DESCRIPTION
Thanks to @kou for the fix. You can see the passing build [here](https://travis-ci.org/nealrichardson/sparklyr/builds/536416026).

This also pins the version (changeset) for the arrow build because the R package is broken on the current head of master. Once that issue is resolved, I'll make a PR to remove the pin.