### PR TITLE
Avoid hangs in Spark web UI launcher when r/spark are busy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.0.1.9002
+Version: 1.0.1.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 # Sparklyr 1.0.1
 
+### RStudio
+
+- Spark UI path can now be accessed even when the R session and Spark are bussy.
+
 ### ML
 
 - `ml_lda()`: Allow passing of optional arguments via `...` to regex tokenizer, stop words remover, and count vectorizer components in the formula API.

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -218,10 +218,13 @@ spark_connect <- function(master,
   }
 
   # register mapping tables for spark.ml
-
   register_mapping_tables()
-  
+
+  # custom initializers for connection methods
   scon <- initialize_method(structure(scon, class = method), scon)
+
+  # cache spark web
+  scon$state$spark_web <- tryCatch(spark_web(scon), error = function(e) NULL)
 
   # notify connection viewer of connection
   libs <- c("sparklyr", extensions)

--- a/R/spark_connection.R
+++ b/R/spark_connection.R
@@ -193,6 +193,8 @@ print.spark_log <- function(x, ...) {
 #'
 #' @export
 spark_web <- function(sc, ...) {
+  if (!identical(sc$state, NULL) && !identical(sc$state$spark_web, NULL)) return(sc$state$spark_web)
+
   sparkui_url <- spark_config_value(
     sc$config, c("sparklyr.web.spark", "sparklyr.sparkui.url")
   )


### PR DESCRIPTION
See https://community.rstudio.com/t/rstudio-sparkui-button-unresponsive-while-r-is-busy-with-a-spark-session/33387