### PR TITLE
Fail when uninstall is incomplete

### DIFF
--- a/R/install_spark.R
+++ b/R/install_spark.R
@@ -273,7 +273,12 @@ spark_uninstall <- function(version, hadoop_version) {
   sparkDir <- file.path(c(spark_install_old_dir(), spark_install_dir()), info$componentName)
   if (any(dir.exists(sparkDir))) {
     unlink(sparkDir, recursive = TRUE)
-    message(info$componentName, " successfully uninstalled.")
+
+    if (!dir.exists(sparkDir))
+      message(info$componentName, " successfully uninstalled.")
+    else
+      stop("Failed to completely uninstall ", info$componentName)
+
     invisible(TRUE)
   } else {
     message(info$componentName, " not found (no uninstall performed)")


### PR DESCRIPTION
Running `spark_uninstall()` might fail (say in Windows) if some files or folders are open by external applications leaving the install in an intermediate uninstall state, at least warn users.