### PR TITLE
Fix spark_apply() serialize warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@
 
 - Spark UI path can now be accessed even when the R session and Spark are bussy.
 
+### Distributed
+
+- Configuration setting `sparklyr.apply.serializer` can be used to select serializer version in `spark_apply()`.
+
 ### ML
 
 - `ml_lda()`: Allow passing of optional arguments via `...` to regex tokenizer, stop words remover, and count vectorizer components in the formula API.

--- a/R/config_settings.R
+++ b/R/config_settings.R
@@ -7,6 +7,7 @@ spark_config_settings <- function() {
   settings <- list(
     sparklyr.apply.packages = "Configures default value for packages parameter in spark_apply().",
     sparklyr.apply.rlang = "Experimental feature. Turns on improved serialization for spark_apply().",
+    sparklyr.apply.serializer = "Configures the version spark_apply() uses to serialize the closure.",
     sparklyr.apply.schema.infer = "Number of rows collected to infer schema when column types specified in spark_apply().",
     sparklyr.arrow = "Use Apache Arrow to serialize data?",
     sparklyr.backend.interval = "Total seconds sparklyr will check on a backend operation.",

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -219,7 +219,7 @@ spark_apply <- function(x,
   )
 
   # create closure for the given function
-  closure <- if (is.function(f)) serialize(f, NULL) else f
+  closure <- if (is.function(f)) suppressWarnings(serialize(f, NULL)) else f
   context_serialize <- serialize(context, NULL)
 
   # create rlang closure

--- a/R/spark_apply.R
+++ b/R/spark_apply.R
@@ -160,6 +160,7 @@ spark_apply <- function(x,
   rlang <- spark_config_value(sc$config, "sparklyr.apply.rlang", FALSE)
   packages_config <- spark_config_value(sc$config, "sparklyr.apply.packages", NULL)
   proc_env <- c(connection_config(sc, "sparklyr.apply.env."), args$env)
+  serialize_version <- spark_config_value(sc$config, "sparklyr.apply.serializer", 2)
 
   time_zone <- ""
   records_per_batch <- NULL
@@ -219,7 +220,7 @@ spark_apply <- function(x,
   )
 
   # create closure for the given function
-  closure <- if (is.function(f)) suppressWarnings(serialize(f, NULL)) else f
+  closure <- if (is.function(f)) suppressWarnings(serialize(f, NULL, version = serialize_version)) else f
   context_serialize <- serialize(context, NULL)
 
   # create rlang closure


### PR DESCRIPTION
Fix for https://github.com/rstudio/sparklyr/issues/2056 and maintain serializer compatibility in `spark_apply()`.