### PR TITLE
Single user can create multiple session using qubole method.

### DIFF
--- a/R/connection_instances.R
+++ b/R/connection_instances.R
@@ -9,8 +9,6 @@ spark_connection_instances <- function() {
 }
 
 spark_connections_add <- function(sc) {
-  print("Connection getting added to instances")
-  print(sc$method)
   instances <- spark_connection_instances()
   instances[[length(instances) + 1]] <- sc
   sparkConnectionsEnv$instances <- instances

--- a/R/connection_instances.R
+++ b/R/connection_instances.R
@@ -9,6 +9,8 @@ spark_connection_instances <- function() {
 }
 
 spark_connections_add <- function(sc) {
+  print("Connection getting added to instances")
+  print(sc$method)
   instances <- spark_connection_instances()
   instances[[length(instances) + 1]] <- sc
   sparkConnectionsEnv$instances <- instances

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -184,7 +184,7 @@ spark_connect <- function(master,
                              extensions = extensions,
                              batch = NULL)
     if (method == "qubole") {
-      scon$master <- "qubole"
+      scon$method <- "qubole"
     }
   } else if (method == "livy") {
     scon <- livy_connection(master = master,

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -183,6 +183,9 @@ spark_connect <- function(master,
                                spark_master_is_yarn_cluster(master, config)),
                              extensions = extensions,
                              batch = NULL)
+    if (method == "qubole") {
+      scon$master <- "qubole"
+    }
   } else if (method == "livy") {
     scon <- livy_connection(master = master,
                             config = config,


### PR DESCRIPTION
Qubole method internally uses shell connection which sets method as in scon and when the comparison happens method in input is qubole, which is causing failure in identifying duplicate sessions.