### PR TITLE
Fix Arrow devel tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,19 +92,6 @@ matrix:
         - r-lib/ellipsis
   allow_failures:
     - env: R_DEVEL_PACKAGES="true"
-    - r: release
-      dist: xenial
-      sudo: true
-      env:
-        - ARROW_ENABLED="true"
-        - ARROW_VERSION="devel"
-        - ARROW_SOURCE="build"
-        - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
-        - LD_LIBRARY_PATH="/usr/local/lib"
-      addons:
-        apt:
-          packages:
-            - openjdk-8-jre
 
 before_install:
   - if [[ ! -z "$JAVA_VERSION" ]]; then jdk_switcher use $JAVA_VERSION ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,7 @@ matrix:
         - ARROW_SOURCE="build"
         - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre"
         - LD_LIBRARY_PATH="/usr/local/lib"
+        - ARROW_PRE_0_15_IPC_FORMAT=1
       addons:
         apt:
           packages:

--- a/R/core_arrow.R
+++ b/R/core_arrow.R
@@ -27,6 +27,10 @@ arrow_record_stream_reader <- function(stream) {
   }
   else {
     record_batch_stream_reader <- get("RecordBatchStreamReader", envir = as.environment(asNamespace("arrow")))
+    if (inherits(record_batch_stream_reader, "R6ClassGenerator")) {
+      # Before, RecordBatchStreamReader was the constructor, now it's $create()
+      record_batch_stream_reader <- record_batch_stream_reader$create
+    }
   }
 
   record_batch_stream_reader(stream)

--- a/inst/livy/spark-1.6.0/sources.scala
+++ b/inst/livy/spark-1.6.0/sources.scala
@@ -34,6 +34,10 @@ arrow_record_stream_reader <- function(stream) {
   }
   else {
     record_batch_stream_reader <- get("RecordBatchStreamReader", envir = as.environment(asNamespace("arrow")))
+    if (inherits(record_batch_stream_reader, "R6ClassGenerator")) {
+      # Before, RecordBatchStreamReader was the constructor, now it's $create()
+      record_batch_stream_reader <- record_batch_stream_reader$create
+    }
   }
 
   record_batch_stream_reader(stream)

--- a/java/spark-1.6.0/sources.scala
+++ b/java/spark-1.6.0/sources.scala
@@ -31,6 +31,10 @@ arrow_record_stream_reader <- function(stream) {
   }
   else {
     record_batch_stream_reader <- get("RecordBatchStreamReader", envir = as.environment(asNamespace("arrow")))
+    if (inherits(record_batch_stream_reader, "R6ClassGenerator")) {
+      # Before, RecordBatchStreamReader was the constructor, now it's $create()
+      record_batch_stream_reader <- record_batch_stream_reader$create
+    }
   }
 
   record_batch_stream_reader(stream)


### PR DESCRIPTION
This attempts to fix the failing Arrow devel build, which is caused by the moving of the record batch stream reader function to be a method on the R6 class. 

The build is still failing for me, though not as hard as on rstudio/master. It's hard for me to read the traceback though, so maybe you can see what's missing.

I also changed the travis config so that arrow devel is no longer an allowed failure. We shouldn't be breaking things and we should learn about it as soon as we do break something. 