### PR TITLE
Some cloudera clusters have been failing with this override

### DIFF
--- a/inst/conf/config-template.yml
+++ b/inst/conf/config-template.yml
@@ -5,9 +5,6 @@ default:
   # include the embedded csv package for spark 1.x
   sparklyr.connect.csv.embedded: "^1.*"
 
-  # Enable Hive support by default.
-  spark.sql.catalogImplementation: "hive"
-
   # default spark packages to load
   # sparklyr.defaultPackages:
 


### PR DESCRIPTION
Fixes:

```
Error: org.apache.spark.sql.AnalysisException: java.lang.RuntimeException: java.io.IOException: Permission denied;
        at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:108)
        at org.apache.spark.sql.hive.HiveExternalCatalog.databaseExists(HiveExternalCatalog.scala:216)
        at org.apache.spark.sql.internal.SharedState.externalCatalog$lzycompute(SharedState.scala:114)
        at org.apache.spark.sql.internal.SharedState.externalCatalog(SharedState.scala:102)
        at org.apache.spark.sql.internal.SharedState.globalTempViewManager$lzycompute(SharedState.scala:141)
        at org.apache.spark.sql.internal.SharedState.globalTempViewManager(SharedState.scala:136)
        at org.apache.spark.sql.hive.HiveSessionStateBuilder$$anonfun$2.apply(HiveSessionStateBuilder.scala:55)
        at org.apache.spark.sql.hive.HiveSessionStateBuilder$$anonfun$2.apply(HiveSessionStateBuilder.scala:55)
        at org.apache.spark.sql.catalyst.catalog.SessionCatalog.g
```

CC: @kevinykuo 