### PR TITLE
Use full url with protocol to avoid yarn-cluster errors and fix #2157

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.0.4.9002
+Version: 1.0.4.9003
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,10 @@
 
 - Support for Scala 12 (@lu-wang-dl, #2154).
 
+### YARN
+
+- Fix `curl_fetch_memory` error when using YARN Cluster mode (#2157).
+
 # Sparklyr 1.0.4
 
 ### Arrow

--- a/R/yarn_cluster.R
+++ b/R/yarn_cluster.R
@@ -113,7 +113,7 @@ spark_yarn_cluster_resource_manager_is_online <- function(rm_webapp) {
   )
 
   tryCatch({
-    rmResult <- httr::GET(rmQuery)
+    rmResult <- httr::GET(paste0(spark_yarn_cluster_get_protocol(), "://", rmQuery))
     if (httr::http_error(rmResult)) {
       warning("Failed to open ", rmQuery, " with status ", httr::status_code(rmResult), ". ")
       FALSE


### PR DESCRIPTION
See https://github.com/rstudio/sparklyr/issues/2157. This fix makes sense since while `https` might not be required it could be blocked, etc.