### PR TITLE
2.4 is not a missing version for sparklyr jar on Databricks any more

### DIFF
--- a/R/databricks_connection.R
+++ b/R/databricks_connection.R
@@ -2,7 +2,6 @@ databricks_expand_jars <- function() {
   jars_path <- system.file("java/", package = "sparklyr")
 
   missing_versions <- c(
-    "2.4",
     "2.2",
     "2.1"
   )


### PR DESCRIPTION
This is a follow up to https://github.com/rstudio/sparklyr/pull/2154