### PR TITLE
Remove gmlnet from R old release tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
         - JAVA_VERSION=oraclejdk8
     - name: "Spark 2.4.0 (R release, oraclejdk8)"
       r: release
+      r_packages:
+        - glmnet
       env:
         - SPARK_VERSION="2.4.0"
         - JAVA_VERSION=oraclejdk8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,7 +53,6 @@ Imports:
 Suggests:
     broom,
     ggplot2,
-    glmnet,
     janeaustenr,
     Lahman,
     mlbench,

--- a/tests/testthat/test-ml-regression-linear-regression.R
+++ b/tests/testthat/test-ml-regression-linear-regression.R
@@ -28,6 +28,8 @@ test_that("ml_linear_regression() param setting", {
 
 test_that("ml_linear_regression and 'penalized' produce similar model fits", {
   test_requires("glmnet")
+
+  glmnet <- get("glmnet", envir = asNamespace("glmnet"))
   sc <- testthat_spark_connection()
   mtcars_tbl <- testthat_tbl("mtcars")
 
@@ -38,7 +40,7 @@ test_that("ml_linear_regression and 'penalized' produce similar model fits", {
     alpha  <- parMatrix[[1]][[i]]
     lambda <- parMatrix[[2]][[i]]
 
-    gFit <- glmnet::glmnet(
+    gFit <- glmnet(
       x = as.matrix(mtcars[, c("cyl", "disp")]),
       y = mtcars$mpg,
       family = "gaussian",


### PR DESCRIPTION
glmnet no longer supports R old release, therefore, disabling tests.