### PR TITLE
Let sdf_sql() accept glue strings

### DIFF
--- a/R/sdf_sql.R
+++ b/R/sdf_sql.R
@@ -19,6 +19,6 @@ df_from_sdf <- function(sc, sdf, take = -1) {
 #' @export
 sdf_sql <- function(sc, sql) {
   hive_context(sc) %>%
-    invoke("sql", sql) %>%
+    invoke("sql", as.character(sql)) %>%
     sdf_register()
 }


### PR DESCRIPTION
Fix #2170 

As an internal function `df_from_sql()` uses `as.character()` to ensure `sql` is character, I guess `sdf_sql()` should do the same thing:

https://github.com/rstudio/sparklyr/blob/dd5d5512f621a544eb888c01053cca68bb20822e/R/sdf_sql.R#L2-L5