### PR TITLE
support sparklyr executor memory setting and warn to fix printed book issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sparklyr
 Type: Package
 Title: R Interface to Apache Spark
-Version: 1.0.5
+Version: 1.0.5.9000
 Authors@R: c(
     person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut", "cre")),
     person("Kevin", "Kuo", role = "aut", email = "kevin.kuo@rstudio.com",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# Sparklyr 1.0.5.9000 (unreleased)
+
+### Configuration
+
+- Also support with warning `sparklyr.executor.memory` as `spark.executor.memory` to
+  fix reference in spark with R book.
+
 # Sparklyr 1.0.5
 
 ### Serialization

--- a/R/config_spark.R
+++ b/R/config_spark.R
@@ -157,3 +157,13 @@ spark_config_packages <- function(config, packages, version) {
 
   config
 }
+
+spark_config_fix <- function(config) {
+  # Mastering Spark with R contains typo and some users are using this setting, so fix it with warning.
+  if("sparklyr.executor.memory" %in% names(config) && !"spark.executor.memory" %in% names(config)) {
+    config["spark.executor.memory"] <- config["sparklyr.executor.memory"]
+    warning("Please use 'spark.executor.memory' instead of 'sparklyr.executor.memory'.")
+  }
+
+  config
+}

--- a/R/connection_spark.R
+++ b/R/connection_spark.R
@@ -140,6 +140,9 @@ spark_connect <- function(master,
   # add packages to config
   if (!is.null(packages)) config <- spark_config_packages(config, packages, version)
 
+  # fix config if needed
+  config <- spark_config_fix(config)
+
   if (is.null(spark_home) || !nzchar(spark_home)) spark_home <- spark_config_value(config, "spark.home", "")
 
   # increase default memory


### PR DESCRIPTION
The printed version of Spark with R book suggests connecting in YARN as:

```
# Memory in Driver
config["sparklyr.shell.driver-memory"] <- "2g"

# Memory per Worker
config["sparklyr.executor.memory"] <- "2G" 

# Cores per Worker
config["sparklyr.shell.executor-cores"] <- 1

# Number of Workers
config["sparklyr.shell.num-executors"] <- 3
```

which is honestly kinda intuitive since one is specifying all settings with `sparklyr` prefix; however, this is incorrect. To help out users, we will support `sparklyr.shell.executor-cores`, but warn users this is the incorrect setting.