### PR TITLE
Update ft_one_hot_encoder to be compatible with spark 3.0

### DIFF
--- a/R/ml_feature_one_hot_encoder.R
+++ b/R/ml_feature_one_hot_encoder.R
@@ -33,6 +33,7 @@ ft_one_hot_encoder.spark_connection <- function(x, input_col = NULL, output_col 
     drop_last = drop_last,
     uid = uid
   ) %>%
+    c(rlang::dots_list(...)) %>%
     validator_ml_one_hot_encoder()
   version <- spark_version(x)
   if(version < "3.0.0") {
@@ -124,8 +125,6 @@ ft_one_hot_encoder.tbl_spark <- function(x, input_col = NULL, output_col = NULL,
   } else {
     ml_fit_and_transform(stage, x)
   }
-
-  # ml_transform(stage, x)
 }
 
 new_ml_one_hot_encoder <- function(jobj) {

--- a/R/ml_feature_one_hot_encoder.R
+++ b/R/ml_feature_one_hot_encoder.R
@@ -11,8 +11,7 @@
 #' @param drop_last Whether to drop the last category. Defaults to \code{TRUE}.
 #'
 #' @export
-ft_one_hot_encoder <- function(x, input_col = NULL, output_col = NULL,
-                               input_cols = NULL, output_cols = NULL, handle_invalid = NULL,
+ft_one_hot_encoder <- function(x, input_cols = NULL, output_cols = NULL, handle_invalid = NULL,
                                drop_last = TRUE, uid = random_string("one_hot_encoder_"), ...) {
   check_dots_used()
   UseMethod("ft_one_hot_encoder")
@@ -21,12 +20,9 @@ ft_one_hot_encoder <- function(x, input_col = NULL, output_col = NULL,
 ml_one_hot_encoder <- ft_one_hot_encoder
 
 #' @export
-ft_one_hot_encoder.spark_connection <- function(x, input_col = NULL, output_col = NULL,
-                                                input_cols = NULL, output_cols = NULL, handle_invalid = "error",
+ft_one_hot_encoder.spark_connection <- function(x, input_cols = NULL, output_cols = NULL, handle_invalid = "error",
                                                 drop_last = TRUE, uid = random_string("one_hot_encoder_"), ...) {
   .args <- list(
-    input_col = input_col,
-    output_col = output_col,
     input_cols = input_cols,
     output_cols = output_cols,
     handle_invalid = handle_invalid,
@@ -35,53 +31,49 @@ ft_one_hot_encoder.spark_connection <- function(x, input_col = NULL, output_col 
   ) %>%
     c(rlang::dots_list(...)) %>%
     validator_ml_one_hot_encoder()
-  version <- spark_version(x)
-  if(version < "3.0.0") {
-    jobj <- spark_pipeline_stage(
-      x, "org.apache.spark.ml.feature.OneHotEncoder",
-      input_col = .args[["input_col"]], output_col = .args[["output_col"]], uid = .args[["uid"]]
-    ) %>%
-      invoke("setDropLast", .args[["drop_last"]])
-
-    estimator <- new_ml_one_hot_encoder(jobj)
-  } else {
+  if(is_spark_3(x)) {
     estimator <- spark_pipeline_stage(
       x, "org.apache.spark.ml.feature.OneHotEncoder",
-      input_col = .args[["input_col"]], output_col = .args[["output_col"]],
       input_cols = .args[["input_cols"]], output_cols = .args[["output_cols"]], uid = .args[["uid"]]
     ) %>%
       invoke("setHandleInvalid", .args[["handle_invalid"]]) %>%
       invoke("setDropLast", .args[["drop_last"]]) %>%
-      new_ml_one_hot_encoder_estimator()
+      new_ml_one_hot_encoder()
+  } else {
+    if (lengths(.args[["input_cols"]]) > 1 || lengths(.args[["output_cols"]]) > 1) {
+      stop("OneHotEncoder does not support encoding multiple columns", call. = FALSE)
+    }
+    .args[["input_cols"]] <- cast_nullable_string(.args[["input_cols"]])
+    .args[["output_cols"]] <- cast_nullable_string(.args[["output_cols"]])
+    estimator <- spark_pipeline_stage(
+      x, "org.apache.spark.ml.feature.OneHotEncoder",
+      input_col = .args[["input_cols"]], output_col = .args[["output_cols"]], uid = .args[["uid"]]
+    ) %>%
+      invoke("setDropLast", .args[["drop_last"]]) %>%
+      new_ml_one_hot_encoder()
   }
 
   estimator
 }
 
 #' @export
-ft_one_hot_encoder.ml_pipeline <- function(x, input_col = NULL, output_col = NULL,
-                                           input_cols = NULL, output_cols = NULL, handle_invalid = "error",
+ft_one_hot_encoder.ml_pipeline <- function(x, input_cols = NULL, output_cols = NULL, handle_invalid = "error",
                                            drop_last = TRUE, uid = random_string("one_hot_encoder_"), ...) {
-  sc <- spark_connection(x)
-  version <- spark_version(sc)
-  version <- "3.0.0"
-  if(version < "3.0.0") {
+  if(is_spark_3(spark_connection(x))) {
     stage <- ft_one_hot_encoder.spark_connection(
-      x = sc,
-      input_col = input_col,
-      output_col = output_col,
+      x = spark_connection(x),
+      input_cols = input_cols,
+      output_cols = output_cols,
+      handle_invalid = handle_invalid,
       drop_last = drop_last,
       uid = uid,
       ...
     )
   } else {
     stage <- ft_one_hot_encoder.spark_connection(
-      x = sc,
-      input_col = input_col,
-      output_col = output_col,
+      x = spark_connection(x),
       input_cols = input_cols,
       output_cols = output_cols,
-      handle_invalid = handle_invalid,
       drop_last = drop_last,
       uid = uid,
       ...
@@ -92,28 +84,23 @@ ft_one_hot_encoder.ml_pipeline <- function(x, input_col = NULL, output_col = NUL
 }
 
 #' @export
-ft_one_hot_encoder.tbl_spark <- function(x, input_col = NULL, output_col = NULL,
-                                         input_cols = NULL, output_cols = NULL, handle_invalid = "error",
+ft_one_hot_encoder.tbl_spark <- function(x, input_cols = NULL, output_cols = NULL, handle_invalid = "error",
                                          drop_last = TRUE, uid = random_string("one_hot_encoder_"), ...) {
-  sc <- spark_connection(x)
-  version <- spark_version(sc)
-  if(version < "3.0.0") {
+  if(is_spark_3(spark_connection(x))) {
     stage <- ft_one_hot_encoder.spark_connection(
-      x = sc,
-      input_col = input_col,
-      output_col = output_col,
+      x = spark_connection(x),
+      input_cols = input_cols,
+      output_cols = output_cols,
+      handle_invalid = handle_invalid,
       drop_last = drop_last,
       uid = uid,
       ...
     )
   } else {
     stage <- ft_one_hot_encoder.spark_connection(
-      x = sc,
-      input_col = input_col,
-      output_col = output_col,
+      x = spark_connection(x),
       input_cols = input_cols,
       output_cols = output_cols,
-      handle_invalid = handle_invalid,
       drop_last = drop_last,
       uid = uid,
       ...

--- a/R/ml_feature_one_hot_encoder.R
+++ b/R/ml_feature_one_hot_encoder.R
@@ -115,11 +115,17 @@ ft_one_hot_encoder.tbl_spark <- function(x, input_cols = NULL, output_cols = NUL
 }
 
 new_ml_one_hot_encoder <- function(jobj) {
-  new_ml_transformer(jobj, class = "ml_one_hot_encoder")
+  if (is_spark_3(spark_connection(jobj))) {
+    one_hot_encoder <- new_ml_estimator(jobj, class = "ml_one_hot_encoder")
+  } else {
+    one_hot_encoder <- new_ml_transformer(jobj, class = "ml_one_hot_encoder")
+  }
+
+  one_hot_encoder
 }
 
 new_ml_one_hot_encoder_model <- function(jobj) {
-  spark_require_version(x, "3.0.0")
+  spark_require_version(spark_connection(jobj), "3.0.0")
   new_ml_transformer(
     jobj,
     category_size = invoke(jobj, "categorySize"),

--- a/R/ml_feature_one_hot_encoder_estimator.R
+++ b/R/ml_feature_one_hot_encoder_estimator.R
@@ -30,7 +30,7 @@ ml_one_hot_encoder_estimator <- ft_one_hot_encoder_estimator
 ft_one_hot_encoder_estimator.spark_connection <- function(x, input_cols = NULL, output_cols = NULL,
                                                            handle_invalid = "error", drop_last = TRUE,
                                                            uid = random_string("one_hot_encoder_estimator_"), ...) {
-  spark_require_version(x, "2.3.0")
+  spark_require_version(x, "2.3.0", "3.0.0")
 
   .args <- list(
     input_cols = input_cols,

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,6 +58,11 @@ spark_require_version <- function(sc, required, module = NULL, required_max = NU
   TRUE
 }
 
+is_spark_3 <- function(sc) {
+  version <- spark_version(sc)
+  version >= "3.0.0"
+}
+
 regex_replace <- function(string, ...) {
   dots <- list(...)
   nm <- names(dots)

--- a/R/utils.R
+++ b/R/utils.R
@@ -47,10 +47,12 @@ spark_require_version <- function(sc, required, required_max = NULL, module = NU
     fmt <- "%s requires Spark %s or higher."
     msg <- sprintf(fmt, module, required, version)
     stop(msg, call. = FALSE)
-  } else if (version >= required_max) {
-    fmt <- "%s is removed in Spark %s."
-    msg <- sprintf(fmt, module, required_max, version)
-    stop(msg, call. = FALSE)
+  } else if (!is.null(required_max)) {
+    if (version >= required_max) {
+      fmt <- "%s is removed in Spark %s."
+      msg <- sprintf(fmt, module, required_max, version)
+      stop(msg, call. = FALSE)
+    }
   }
 
   TRUE

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ printf <- function(fmt, ...) {
   cat(sprintf(fmt, ...))
 }
 
-spark_require_version <- function(sc, required, module = NULL) {
+spark_require_version <- function(sc, required, required_max = NULL, module = NULL) {
 
   # guess module based on calling function
   if (is.null(module)) {
@@ -46,6 +46,10 @@ spark_require_version <- function(sc, required, module = NULL) {
   if (version < required) {
     fmt <- "%s requires Spark %s or higher."
     msg <- sprintf(fmt, module, required, version)
+    stop(msg, call. = FALSE)
+  } else if (version >= required_max) {
+    fmt <- "%s is removed in Spark %s."
+    msg <- sprintf(fmt, module, required_max, version)
     stop(msg, call. = FALSE)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,7 +33,7 @@ printf <- function(fmt, ...) {
   cat(sprintf(fmt, ...))
 }
 
-spark_require_version <- function(sc, required, required_max = NULL, module = NULL) {
+spark_require_version <- function(sc, required, module = NULL, required_max = NULL) {
 
   # guess module based on calling function
   if (is.null(module)) {

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -217,14 +217,14 @@ get_default_args <- function(fn, exclude = NULL) {
     (function(x) x[setdiff(names(x), c(exclude, c("x", "uid", "...", "formula")))])
 }
 
-test_requires_version <- function(min_version, max_version = NULL, comment = NULL) {
+test_requires_version <- function(min_version, comment = NULL, max_version = NULL) {
   sc <- testthat_spark_connection()
   if (spark_version(sc) < min_version) {
     msg <- paste0("test requires Spark version ", min_version)
     if (!is.null(comment))
       msg <- paste0(msg, ": ", comment)
     skip(msg)
-  } else if (~is.null(max_version)) {
+  } else if (!is.null(max_version)) {
     if (spark_version(sc) >= max_version) {
       msg <- paste0("test is not needed with Spark version ", max_version)
       if (!is.null(comment))

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -217,10 +217,15 @@ get_default_args <- function(fn, exclude = NULL) {
     (function(x) x[setdiff(names(x), c(exclude, c("x", "uid", "...", "formula")))])
 }
 
-test_requires_version <- function(min_version, comment = NULL) {
+test_requires_version <- function(min_version, max_version = NULL, comment = NULL) {
   sc <- testthat_spark_connection()
   if (spark_version(sc) < min_version) {
     msg <- paste0("test requires Spark version ", min_version)
+    if (!is.null(comment))
+      msg <- paste0(msg, ": ", comment)
+    skip(msg)
+  } else if (spark_version(sc) >= max_version) {
+    msg <- paste0("test is not needed with Spark version ", max_version)
     if (!is.null(comment))
       msg <- paste0(msg, ": ", comment)
     skip(msg)

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -224,11 +224,13 @@ test_requires_version <- function(min_version, max_version = NULL, comment = NUL
     if (!is.null(comment))
       msg <- paste0(msg, ": ", comment)
     skip(msg)
-  } else if (spark_version(sc) >= max_version) {
-    msg <- paste0("test is not needed with Spark version ", max_version)
-    if (!is.null(comment))
-      msg <- paste0(msg, ": ", comment)
-    skip(msg)
+  } else if (~is.null(max_version)) {
+    if (spark_version(sc) >= max_version) {
+      msg <- paste0("test is not needed with Spark version ", max_version)
+      if (!is.null(comment))
+        msg <- paste0(msg, ": ", comment)
+      skip(msg)
+    }
   }
 }
 

--- a/tests/testthat/test-feature-one-hot-encoder-estimator.R
+++ b/tests/testthat/test-feature-one-hot-encoder-estimator.R
@@ -1,15 +1,13 @@
 context("ml feature one hot encoder estimator")
 
 test_that("ft_one_hot_encoder_estimator() default params", {
-  skip_on_spark_master()
-  test_requires_latest_spark()
+  test_requires_version(min_version="2.3.0", max_version="3.0.0")
   sc <- testthat_spark_connection()
   test_default_args(sc, ft_one_hot_encoder_estimator)
 })
 
 test_that("ft_one_hot_encoder_estimator() param setting", {
-  skip_on_spark_master()
-  test_requires_latest_spark()
+  test_requires_version("2.3.0",max_version = "3.0.0")
   sc <- testthat_spark_connection()
   test_args <- list(
     input_cols = c("foo", "foo1"),
@@ -20,8 +18,7 @@ test_that("ft_one_hot_encoder_estimator() param setting", {
 })
 
 test_that("ft_one_hot_encoder_estimator() works", {
-  skip_on_spark_master()
-  test_requires_latest_spark()
+  test_requires_version("2.3.0",max_version = "3.0.0")
   sc <- testthat_spark_connection()
   iris_tbl <- testthat_tbl("iris")
   expect_equal(

--- a/tests/testthat/test-feature-one-hot-encoder-estimator.R
+++ b/tests/testthat/test-feature-one-hot-encoder-estimator.R
@@ -7,7 +7,7 @@ test_that("ft_one_hot_encoder_estimator() default params", {
 })
 
 test_that("ft_one_hot_encoder_estimator() param setting", {
-  test_requires_version("2.3.0",max_version = "3.0.0")
+  test_requires_version(min_version="2.3.0",max_version = "3.0.0")
   sc <- testthat_spark_connection()
   test_args <- list(
     input_cols = c("foo", "foo1"),
@@ -18,7 +18,7 @@ test_that("ft_one_hot_encoder_estimator() param setting", {
 })
 
 test_that("ft_one_hot_encoder_estimator() works", {
-  test_requires_version("2.3.0",max_version = "3.0.0")
+  test_requires_version(min_version="2.3.0",max_version = "3.0.0")
   sc <- testthat_spark_connection()
   iris_tbl <- testthat_tbl("iris")
   expect_equal(

--- a/tests/testthat/test-ml-clustering-kmeans-ext.R
+++ b/tests/testthat/test-ml-clustering-kmeans-ext.R
@@ -85,7 +85,7 @@ test_that("ml_kmeans() works properly", {
 })
 
 test_that("ml_compute_cost() for kmeans works properly", {
-  skip_on_spark_master()
+  # skip_on_spark_master()
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0", "ml_compute_cost() requires Spark 2.0+")
   iris_tbl <- testthat_tbl("iris")

--- a/tests/testthat/test-ml-clustering-kmeans-ext.R
+++ b/tests/testthat/test-ml-clustering-kmeans-ext.R
@@ -85,7 +85,7 @@ test_that("ml_kmeans() works properly", {
 })
 
 test_that("ml_compute_cost() for kmeans works properly", {
-  # skip_on_spark_master()
+  skip_on_spark_master()
   sc <- testthat_spark_connection()
   test_requires_version("2.0.0", "ml_compute_cost() requires Spark 2.0+")
   iris_tbl <- testthat_tbl("iris")

--- a/tests/testthat/test-ml-feature-one-hot-encoder.R
+++ b/tests/testthat/test-ml-feature-one-hot-encoder.R
@@ -37,5 +37,27 @@ test_that("ft_one_hot_encoder() works", {
       list(c(0, 0), c(0, 1), c(1, 0))
     )
   }
+})
 
+test_that("ft_one_hot_encoder() with multiple columns", {
+  sc <- testthat_spark_connection()
+  df <- tibble(
+    id = 0:5L,
+    input1 = c(0, 1, 2, 0, 0, 2),
+    input2 = c(2, 3, 0, 1, 0, 2)
+  )
+  df_tbl <- copy_to(sc, df, overwrite = TRUE)
+
+  if (spark_version(sc) < "3.0.0") {
+    expect_error(df_tbl %>%
+                   ft_one_hot_encoder(c("input1", "input2"), c("output1", "output2")))
+  }
+  else {
+    expect_identical(
+      df_tbl %>%
+        ft_one_hot_encoder(c("input1", "input2"), c("output1", "output2")) %>%
+        colnames(),
+      c("id", "input1", "input2", "output1", "output2")
+    )
+  }
 })

--- a/tests/testthat/test-ml-feature-one-hot-encoder.R
+++ b/tests/testthat/test-ml-feature-one-hot-encoder.R
@@ -9,23 +9,13 @@ test_that("ft_one_hot_encoder() default params", {
 test_that("ft_one_hot_encoder() param setting", {
   test_requires_version("3.0.0")
   sc <- testthat_spark_connection()
-  version <- spark_version(sc)
-  if (version < "3.0.0") {
-    test_args <- list(
-      input_col = "foo",
-      output_col = "bar",
-      drop_last = FALSE
-    )
-  } else {
-    test_args <- list(
-      input_col = "foo",
-      output_col = "bar",
-      input_cols = c("foo", "foo1"),
-      output_cols = c("bar", "bar1"),
-      drop_last = FALSE
-    )
-  }
-
+  test_args <- list(
+    input_col = "foo",
+    output_col = "bar",
+    input_cols = c("foo", "foo1"),
+    output_cols = c("bar", "bar1"),
+    drop_last = FALSE
+  )
   test_param_setting(sc, ft_one_hot_encoder, test_args)
 })
 

--- a/tests/testthat/test-ml-feature-one-hot-encoder.R
+++ b/tests/testthat/test-ml-feature-one-hot-encoder.R
@@ -22,11 +22,22 @@ test_that("ft_one_hot_encoder() param setting", {
 test_that("ft_one_hot_encoder() works", {
   sc <- testthat_spark_connection()
   iris_tbl <- testthat_tbl("iris")
-  expect_equal(
-    iris_tbl %>%
-      ft_string_indexer("Species", "indexed", string_order_type = "alphabetDesc") %>%
-      ft_one_hot_encoder("indexed", "encoded") %>%
-      pull(encoded) %>% unique(),
-    list(c(0, 0), c(0, 1), c(1, 0))
-  )
+  if (spark_version(sc) < "2.3.0") {
+    expect_equal(
+      iris_tbl %>%
+        ft_string_indexer("Species", "indexed") %>%
+        ft_one_hot_encoder("indexed", "encoded") %>%
+        pull(encoded) %>% unique(),
+      list(c(0, 0), c(1, 0), c(0, 1))
+    )
+  } else {
+    expect_equal(
+      iris_tbl %>%
+        ft_string_indexer("Species", "indexed", string_order_type = "alphabetDesc") %>%
+        ft_one_hot_encoder("indexed", "encoded") %>%
+        pull(encoded) %>% unique(),
+      list(c(0, 0), c(0, 1), c(1, 0))
+    )
+  }
+
 })

--- a/tests/testthat/test-ml-feature-one-hot-encoder.R
+++ b/tests/testthat/test-ml-feature-one-hot-encoder.R
@@ -1,33 +1,42 @@
 context("ml feature one hot encoder")
 
 test_that("ft_one_hot_encoder() default params", {
-  skip_on_spark_master()
-  test_requires_latest_spark()
+  test_requires_version("3.0.0")
   sc <- testthat_spark_connection()
   test_default_args(sc, ft_one_hot_encoder)
 })
 
 test_that("ft_one_hot_encoder() param setting", {
-  skip_on_spark_master()
-  test_requires_latest_spark()
+  test_requires_version("3.0.0")
   sc <- testthat_spark_connection()
-  test_args <- list(
-    input_col = "foo",
-    output_col = "bar",
-    drop_last = FALSE
-  )
+  version <- spark_version(sc)
+  if (version < "3.0.0") {
+    test_args <- list(
+      input_col = "foo",
+      output_col = "bar",
+      drop_last = FALSE
+    )
+  } else {
+    test_args <- list(
+      input_col = "foo",
+      output_col = "bar",
+      input_cols = c("foo", "foo1"),
+      output_cols = c("bar", "bar1"),
+      drop_last = FALSE
+    )
+  }
+
   test_param_setting(sc, ft_one_hot_encoder, test_args)
 })
 
 test_that("ft_one_hot_encoder() works", {
-  skip_on_spark_master()
   sc <- testthat_spark_connection()
   iris_tbl <- testthat_tbl("iris")
   expect_equal(
     iris_tbl %>%
-      ft_string_indexer("Species", "indexed") %>%
+      ft_string_indexer("Species", "indexed", string_order_type = "alphabetDesc") %>%
       ft_one_hot_encoder("indexed", "encoded") %>%
       pull(encoded) %>% unique(),
-    list(c(0, 0), c(1, 0), c(0, 1))
-    )
+    list(c(0, 0), c(0, 1), c(1, 0))
+  )
 })

--- a/tests/testthat/test-ml-feature-one-hot-encoder.R
+++ b/tests/testthat/test-ml-feature-one-hot-encoder.R
@@ -10,8 +10,6 @@ test_that("ft_one_hot_encoder() param setting", {
   test_requires_version("3.0.0")
   sc <- testthat_spark_connection()
   test_args <- list(
-    input_col = "foo",
-    output_col = "bar",
     input_cols = c("foo", "foo1"),
     output_cols = c("bar", "bar1"),
     drop_last = FALSE


### PR DESCRIPTION
This is to fix the #2172 with spark 3.0.
- Update `ft_one_hot_encoder`with spark 3.0 to match the new API.
- Dreprecate `ft_one_hot_encoder_estimator` with spark 3.0 by updating `spark_require_version` with `required_max`
- Skip the tests with spark 3.0 in `test-feature-one-hot-encoder-estimator.R`
- Update the tests in `test-ml-feature-one-hot-encoder.R` only check the arg in spark 3.0 or later.