### PR TITLE
Do not use temporary directory in testthat_shell_connection

### DIFF
--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -74,7 +74,6 @@ testthat_shell_connection <- function() {
     config[["sparklyr.shell.driver-memory"]] <- "3G"
     config[["sparklyr.apply.env.foo"]] <- "env-test"
 
-    setwd(tempdir())
     sc <- spark_connect(master = "local", version = version, config = config)
     assign(".testthat_spark_connection", sc, envir = .GlobalEnv)
   }


### PR DESCRIPTION
I tried to run a specific test using:
```
$ R
> library(devtools)
> test_file('tests/testthat/test-feature-vector-indexer.R')
```
This didn't work because `testthat_spark_connection()` sets the working directory to a temporary directory, and then when [this line](https://github.com/rstudio/sparklyr/blob/master/tests/testthat/test-feature-vector-indexer.R#L22) attempts to find a file within `getwd()`, it cannot find the data file in the temporary directory.

Can we remove the code that sets the working directory to a temp directory? Or, is there any other way I can run this individual test without patching the code? My current workaround is to run `test_file('tests/testthat/test-feature-vector-indexer.R')` twice: it fails the first time, but because the spark connection has been set up already, it passes the second time. 

I am not sure how this affects other tests, so I'll keep an eye on the CI.