### PR TITLE
Add config to enable utc_timestamp in spark 3.0

### DIFF
--- a/inst/conf/config-template.yml
+++ b/inst/conf/config-template.yml
@@ -10,3 +10,6 @@ default:
 
   # command line arguments to spark-shell
   # sparklyr.shell.*
+
+  # Enable 'from_utc_timestamp' and 'to_utc_timestamp' for spark 3.0 and later
+  spark.sql.legacy.utcTimestampFunc.enabled: true

--- a/tests/testthat/test-serialization.R
+++ b/tests/testthat/test-serialization.R
@@ -126,7 +126,6 @@ test_that("copy_to() succeeds when last column contains missing / empty values",
 })
 
 test_that("collect() can retrieve all data types correctly", {
-  skip_on_spark_master()
   # https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Types#LanguageManualTypes
   library(dplyr)
 
@@ -300,7 +299,6 @@ test_that("collect() can retrieve as.POSIXct fields with timezones", {
 })
 
 test_that("collect() can retrieve specific dates without timezones", {
-  skip_on_spark_master()
   data_tbl <- sdf_copy_to(
     sc,
     data_frame(


### PR DESCRIPTION
This is to fix the issue #2182 .
