### PR TITLE
Expands coverage testing, and applies fixes issues found throughout 

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,9 +5,9 @@
 # before merging so R CMD check runs on main again.
 on:
   push:
-    branches: main
+    branches: pause
   pull_request:
-    branches: main
+    branches: pause
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -5,9 +5,9 @@
 # before merging so R CMD check runs on main again.
 on:
   push:
-    branches: pause
+    branches: main
   pull_request:
-    branches: pause
+    branches: main
 
 name: R-CMD-check
 

--- a/.github/workflows/spark-tests.yaml
+++ b/.github/workflows/spark-tests.yaml
@@ -5,9 +5,9 @@
 # before merging so the Spark integration tests run on main again.
 on:
   push:
-    branches: main
+    branches: pause
   pull_request:
-    branches: main
+    branches: pause
 
 name: Spark-Tests
 

--- a/.github/workflows/spark-tests.yaml
+++ b/.github/workflows/spark-tests.yaml
@@ -5,9 +5,9 @@
 # before merging so the Spark integration tests run on main again.
 on:
   push:
-    branches: pause
+    branches: main
   pull_request:
-    branches: pause
+    branches: main
 
 name: Spark-Tests
 
@@ -21,7 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {spark: '3.5.8', hadoop: '3',   arrow: '',        livy: '', dbplyr: '', name: 'Spark 3.5'}
+          - {spark: '4.1.2', hadoop: '3',   arrow: '',        livy: '', dbplyr: '', name: 'Spark 4.1'}
+          - {spark: '4.1.2', hadoop: '3',   arrow: 'release', livy: '', dbplyr: '', name: 'Spark 4.1 w Arrow'}
+
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/.github/workflows/spark-tests.yaml
+++ b/.github/workflows/spark-tests.yaml
@@ -5,9 +5,9 @@
 # before merging so the Spark integration tests run on main again.
 on:
   push:
-    branches: pause
+    branches: main
   pull_request:
-    branches: pause
+    branches: main
 
 name: Spark-Tests
 
@@ -22,9 +22,6 @@ jobs:
       matrix:
         config:
           - {spark: '3.5.8', hadoop: '3',   arrow: '',        livy: '', dbplyr: '', name: 'Spark 3.5'}
-          - {spark: '4.1.2', hadoop: '3',   arrow: '',        livy: '', dbplyr: '', name: 'Spark 4.1'}
-          - {spark: '4.1.2', hadoop: '3',   arrow: 'release', livy: '', dbplyr: '', name: 'Spark 4.1 w Arrow'}
-
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: pause
+    branches: main
   pull_request:
-    branches: pause
+    branches: main
 
 name: Test-Coverage
 
@@ -14,7 +14,6 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CODE_COVERAGE: 'true'
-      ARROW_VERSION: 'release'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -2,9 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: main
+    branches: pause
   pull_request:
-    branches: main
+    branches: pause
 
 name: Test-Coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ tests/testthat/foobar/
 
 # roborev snapshots
 /.roborev/
+
+# Compiled coverage estimates (regenerated locally)
+utils/coverage/compiled/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Sparklyr (dev)
 
+- Fixed `spark_write()` and `spark_write_table()` when passed a `spark_jobj`:
+the internal JVM class check only accepted `org.apache.spark.sql.DataFrame`,
+which has not been the concrete class since Spark 2.0 (it is now
+`org.apache.spark.sql.Dataset`, or `org.apache.spark.sql.classic.Dataset` on
+Spark 4.x), so these methods always errored. The check is now version-agnostic.
+
 - Internal reorganization of the package's R source files, consolidating
 related functions into a smaller, more cohesive set of scripts. No exported
 functions, behavior, or APIs change.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Sparklyr (dev)
 
+- Fixed the `sparklyr.stream.collect.timeout` and
+`sparklyr.stream.validate.timeout` configuration options being silently ignored.
+The internal code referenced a bare `config` that resolved to an unrelated
+imported function instead of the connection's configuration, so the timeouts
+always fell back to their defaults; they now read from the active connection.
+
+- Fixed `sdf_pivot()` so a multi-column pivot specification (the right-hand side
+of the formula, e.g. `a ~ b + c`) is now correctly rejected with a clear
+"pivot column is not length one" error. Previously the right-hand side was not
+split on `+`/`*` (an errant `fixed = TRUE`), so such a formula failed later with
+a confusing "missing variables in dataset" error instead.
+
 - Fixed `spark_write()` and `spark_write_table()` when passed a `spark_jobj`:
 the internal JVM class check only accepted `org.apache.spark.sql.DataFrame`,
 which has not been the concrete class since Spark 2.0 (it is now

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr (dev)
 
+- Fixed a spurious "NAs introduced by coercion to integer range" warning emitted
+when collecting with Arrow and `n = Inf` (e.g. `collect()` of all rows, or
+printing a large `tbl_spark`). The `Inf`/out-of-range row limit is handled
+correctly; only the warning was leaking.
+
 - Fixed `augment()` on a linear / generalized-linear-regression model when
 `type.residuals` is not `"working"` (e.g. `"deviance"`, `"pearson"`,
 `"response"`) and no `newdata` is supplied. It errored with "Can't rename

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr (dev)
 
+- Fixed `ml_gbt_classifier()` on Spark < 2.2 so a fitted classification model is
+classed `ml_gbt_classification_model` (it was mislabeled
+`ml_multilayer_perceptron_classification_model` due to a copy-paste error).
+
 - Fixed `ft_robust_scaler()` so a fitted model is now wrapped as an
 `ml_robust_scaler_model` object. `RobustScaler`/`RobustScalerModel` were missing
 from the JVM-class mapping, so a fitted robust scaler fell back to a generic

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Sparklyr (dev)
 
+- Fixed `names<-()` on a `tbl_spark` (e.g. `names(tbl) <- value`), which errored
+with "Can't escape back tick from string" on recent `dbplyr`. The replacement
+view is now re-registered using the bare remote table name instead of the
+back tick-quoted `table_path`.
+
 - Fixed `ml_gbt_classifier()` on Spark < 2.2 so a fitted classification model is
 classed `ml_gbt_classification_model` (it was mislabeled
 `ml_multilayer_perceptron_classification_model` due to a copy-paste error).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # Sparklyr (dev)
 
+- Fixed `ft_robust_scaler()` so a fitted model is now wrapped as an
+`ml_robust_scaler_model` object. `RobustScaler`/`RobustScalerModel` were missing
+from the JVM-class mapping, so a fitted robust scaler fell back to a generic
+`ml_transformer` (and the model constructor carried the estimator's class by
+mistake). Transformation worked, but the model's class was inconsistent with the
+other scalers.
+
 - Fixed the `sparklyr.stream.collect.timeout` and
 `sparklyr.stream.validate.timeout` configuration options being silently ignored.
 The internal code referenced a bare `config` that resolved to an unrelated

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Sparklyr (dev)
 
+- Fixed a spurious "one argument not used by format" warning raised alongside the
+error from `spark_require_version()` when a Spark version requirement isn't met
+(the error message passed an extra argument to `sprintf()`).
+
 - Fixed a spurious "NAs introduced by coercion to integer range" warning emitted
 when collecting with Arrow and `n = Inf` (e.g. `collect()` of all rows, or
 printing a large `tbl_spark`). The `Inf`/out-of-range row limit is handled

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # Sparklyr (dev)
 
+- Fixed `augment()` on a linear / generalized-linear-regression model when
+`type.residuals` is not `"working"` (e.g. `"deviance"`, `"pearson"`,
+`"response"`) and no `newdata` is supplied. It errored with "Can't rename
+columns that don't exist" because `ml_predict()` drops the residuals column;
+the residuals are now re-attached to the predictions.
+
 - Fixed `names<-()` on a `tbl_spark` (e.g. `names(tbl) <- value`), which errored
 with "Can't escape back tick from string" on recent `dbplyr`. The replacement
 view is now re-registered using the bare remote table name instead of the

--- a/R/arrow.R
+++ b/R/arrow.R
@@ -147,7 +147,9 @@ arrow_collect <- function(tbl, ...) {
   sc <- spark_connection(tbl)
   sdf <- spark_dataframe(tbl)
   if (!is.null(n)) {
-    n <- as.integer(n)
+    # `n` is often Inf (collect-all) or otherwise outside integer range; the
+    # resulting NA is handled below, so suppress the spurious coercion warning.
+    n <- suppressWarnings(as.integer(n))
     if (!is.na(n)) {
       # If n is Inf or any value outside of integer range, then ignore it
       sdf <- sdf %>% invoke("limit", n)

--- a/R/config.R
+++ b/R/config.R
@@ -314,6 +314,14 @@ spark_config_packages <- function(
       head(1) %>%
       unlist()
 
+    if (length(delta) == 0) {
+      stop(
+        "Delta Lake is not yet available for Spark ",
+        version,
+        "; the latest delta-spark release targets Spark 4.0."
+      )
+    }
+
     delta_version <- delta[2]
 
     if (version >= "3.5") {

--- a/R/connection_livy.R
+++ b/R/connection_livy.R
@@ -1,4 +1,3 @@
-# nocov start
 #' @include connection_shell.R
 
 #' @export
@@ -1064,8 +1063,6 @@ initialize_connection.livy_connection <- function(sc) {
     }
   )
 }
-
-# nocov end
 
 #' @importFrom rlang as_label abort
 assert_that <- function(x) {

--- a/R/connection_shell.R
+++ b/R/connection_shell.R
@@ -848,87 +848,15 @@ initialize_connection.spark_shell_connection <- function(sc) {
           invoke(session, "sparkContext")
       }
 
+      # sparklyr requires Spark 2.0+, so always create a SparkSession (which also
+      # sets sc$state$hive_context). The spark context may already be available
+      # in submit_batch, in which case we only need the SparkSession.
       if (is.null(spark_context(sc))) {
-        # create the spark context and assign the connection to it
-        # use spark home version since spark context is not yet initialized in shell connection
-        # but spark_home might not be initialized in submit_batch while spark context is available
-        if (
-          (!identical(sc$home_version, NULL) && sc$home_version >= "2.0") ||
-            (!identical(spark_context(sc), NULL) && spark_version(sc) >= "2.0")
-        ) {
-          init_hive_ctx_for_spark_2_plus()
-        } else {
-          sc$state$spark_context <- invoke_static(
-            sc,
-            "org.apache.spark.SparkContext",
-            "getOrCreate",
-            conf
-          )
-          # we might not be aware of the actual version of Spark that is running yet until now
-          actual_spark_version <- tryCatch(
-            invoke(sc$state$spark_context, "version"),
-            error = function(e) {
-              warning(paste(
-                "Failed to get version from SparkContext:",
-                e
-              ))
-              NULL
-            }
-          )
-          if (
-            !identical(actual_spark_version, NULL) &&
-              actual_spark_version >= "2.0"
-          ) {
-            init_hive_ctx_for_spark_2_plus()
-          }
-        }
-
+        init_hive_ctx_for_spark_2_plus()
         invoke(backend, "setSparkContext", spark_context(sc))
-      } else if (is.null(sc$state$hive_context) && spark_version(sc) >= "2.0") {
+      } else if (is.null(sc$state$hive_context)) {
         init_hive_ctx_for_spark_2_plus()
       }
-
-      # If Spark version is 2.0.0 or above, hive_context should be initialized by now.
-      # So if that's not the case, then attempt to initialize it assuming Spark version is below 2.0.0
-      sc$state$hive_context <- sc$state$hive_context %||%
-        tryCatch(
-          invoke_new(
-            sc,
-            if (identical(sc$state$hive_support_enabled, TRUE)) {
-              "org.apache.spark.sql.hive.HiveContext"
-            } else {
-              "org.apache.spark.sql.SQLContext"
-            },
-            sc$state$spark_context
-          ),
-          error = function(e) {
-            warning(e$message)
-            warning(
-              "Failed to create Hive context, falling back to SQL. Some operations, ",
-              "like window-functions, will not work"
-            )
-
-            jsc <- invoke_static(
-              sc,
-              "org.apache.spark.api.java.JavaSparkContext",
-              "fromSparkContext",
-              sc$state$spark_context
-            )
-
-            hive_context <- invoke_static(
-              sc,
-              "org.apache.spark.sql.api.r.SQLUtils",
-              "createSQLContext",
-              jsc
-            )
-
-            params <- connection_config(sc, "spark.sql.")
-            apply_config(hive_context, params, "setConf", "spark.sql.")
-
-            # return hive_context
-            hive_context
-          }
-        )
 
       # create the java spark context and assign the connection to it
       sc$state$java_context <- invoke_static(

--- a/R/data_read.R
+++ b/R/data_read.R
@@ -698,12 +698,6 @@ spark_read_orc.spark_connection <- function(
   name <- target$name
   path <- target$path
 
-  if (length(path) != 1L && (spark_version(sc) < "2.0.0")) {
-    stop(
-      "spark_read_orc is only suppored with path of length 1 for spark versions < 2.0.0"
-    )
-  }
-
   df <- spark_data_read_generic(
     sc,
     as.list(spark_normalize_path(path)),

--- a/R/data_write.R
+++ b/R/data_write.R
@@ -177,7 +177,12 @@ spark_write_json.spark_jobj <- spark_write_json.tbl_spark
 
 spark_expect_jobj_class <- function(jobj, expectedClassName) {
   className <- invoke(jobj, "%>%", list("getClass"), list("getName"))
-  if (!identical(className, expectedClassName)) {
+  # A Spark DataFrame is `Dataset[Row]`; the concrete JVM class is
+  # `org.apache.spark.sql.Dataset` on Spark 2.x/3.x and
+  # `org.apache.spark.sql.classic.Dataset` on Spark 4.x. Compare on the simple
+  # class name so the check is version-agnostic.
+  simple_name <- function(x) sub(".*\\.", "", x)
+  if (!simple_name(className) %in% simple_name(expectedClassName)) {
     stop(
       "This operation is only supported on ",
       expectedClassName,
@@ -193,7 +198,7 @@ spark_writable_dataframe <- function(x) {
   if (inherits(x, "tbl_spark")) {
     spark_sqlresult_from_dplyr(x)
   } else {
-    spark_expect_jobj_class(x, "org.apache.spark.sql.DataFrame")
+    spark_expect_jobj_class(x, "org.apache.spark.sql.Dataset")
     x
   }
 }
@@ -243,16 +248,6 @@ spark_write_table.tbl_spark <- function(
   ...
 ) {
   df <- spark_writable_dataframe(x)
-  sc <- spark_connection(x)
-
-  if (spark_version(sc) < "2.0.0" && spark_master_is_local(sc$master)) {
-    stop(
-      "spark_write_table is not supported in local clusters for Spark ",
-      spark_version(sc),
-      ". ",
-      "Upgrade to Spark 2.X or use this function in a non-local Spark cluster."
-    )
-  }
 
   fileMethod <- if (identical(mode, "append")) "insertInto" else "saveAsTable"
 
@@ -774,7 +769,7 @@ spark_write.tbl_spark <- function(x, writer, paths, packages = NULL) {
 
 #' @export
 spark_write.spark_jobj <- function(x, writer, paths, packages = NULL) {
-  spark_expect_jobj_class(x, "org.apache.spark.sql.DataFrame")
+  spark_expect_jobj_class(x, "org.apache.spark.sql.Dataset")
   x %>%
     sdf_register() %>%
     spark_write(writer, paths, packages)

--- a/R/dplyr_spark.R
+++ b/R/dplyr_spark.R
@@ -334,11 +334,7 @@ spark_partition_register_df <- function(sc, df, name, repartition, memory) {
   }
 
   if (!name %in% dbListTables(sc)) {
-    if (spark_version(sc) < "2.0.0") {
-      invoke(df, "registerTempTable", name)
-    } else {
-      invoke(df, "createOrReplaceTempView", name)
-    }
+    invoke(df, "createOrReplaceTempView", name)
   }
 
   if (memory) {
@@ -412,12 +408,6 @@ sample_n.tbl_spark <- function(
   .env = parent.frame(),
   ...
 ) {
-  if (spark_version(spark_connection(tbl)) < "2.0.0") {
-    stop(
-      "sample_n() is not supported until Spark 2.0 or later. Use sdf_sample instead."
-    )
-  }
-
   args <- list(
     size = size,
     replace = replace,
@@ -442,10 +432,6 @@ sample_frac.tbl_spark <- function(
   .env = parent.frame(),
   ...
 ) {
-  if (spark_version(spark_connection(tbl)) < "2.0.0") {
-    stop("sample_frac() is not supported until Spark 2.0 or later.")
-  }
-
   args <- list(
     size = size,
     replace = replace,

--- a/R/dplyr_verbs.R
+++ b/R/dplyr_verbs.R
@@ -624,7 +624,9 @@ mutate_names <- function(x, value) {
   # a derived tbl (e.g. a renamed `select()` result); collapse the resulting
   # `character(0)` back to NULL so `sdf_register()` falls back to a temp name.
   name <- as.character(dbplyr::remote_name(x))
-  if (length(name) == 0) name <- NULL
+  if (length(name) == 0) {
+    name <- NULL
+  }
   sdf_register(renamed, name = name)
 }
 

--- a/R/dplyr_verbs.R
+++ b/R/dplyr_verbs.R
@@ -620,8 +620,12 @@ mutate_names <- function(x, value) {
   renamed <- invoke(sdf, "toDF", as.list(value))
   # `remote_name()` yields the bare table name; `x$lazy_query$x` is a dbplyr
   # `table_path` whose `as.character()` adds back ticks that `sdf_register()`
-  # rejects ("Can't escape back tick from string").
-  sdf_register(renamed, name = as.character(dbplyr::remote_name(x)))
+  # rejects ("Can't escape back tick from string"). `remote_name()` is NULL for
+  # a derived tbl (e.g. a renamed `select()` result); collapse the resulting
+  # `character(0)` back to NULL so `sdf_register()` falls back to a temp name.
+  name <- as.character(dbplyr::remote_name(x))
+  if (length(name) == 0) name <- NULL
+  sdf_register(renamed, name = name)
 }
 
 #' @export

--- a/R/dplyr_verbs.R
+++ b/R/dplyr_verbs.R
@@ -618,7 +618,10 @@ sdf_bind_cols <- function(...) {
 mutate_names <- function(x, value) {
   sdf <- spark_dataframe(x)
   renamed <- invoke(sdf, "toDF", as.list(value))
-  sdf_register(renamed, name = as.character(x$lazy_query$x))
+  # `remote_name()` yields the bare table name; `x$lazy_query$x` is a dbplyr
+  # `table_path` whose `as.character()` adds back ticks that `sdf_register()`
+  # rejects ("Can't escape back tick from string").
+  sdf_register(renamed, name = as.character(dbplyr::remote_name(x)))
 }
 
 #' @export

--- a/R/ml_evaluation.R
+++ b/R/ml_evaluation.R
@@ -470,22 +470,14 @@ ml_multiclass_classification_evaluator.spark_connection <- function(
   ) %>%
     validator_ml_multiclass_classification_evaluator()
 
-  spark_metric <- list(
-    "1.6" = c(
-      "f1",
-      "precision",
-      "recall",
-      "weightedPrecision",
-      "weightedRecall"
-    ),
-    "2.0" = c("f1", "weightedPrecision", "weightedRecall", "accuracy")
+  supported_metrics <- c(
+    "f1",
+    "weightedPrecision",
+    "weightedRecall",
+    "accuracy"
   )
 
-  if (
-    spark_version(x) >= "2.0.0" &&
-      !metric_name %in% spark_metric[["2.0"]] ||
-      spark_version(x) < "2.0.0" && !metric_name %in% spark_metric[["1.6"]]
-  ) {
+  if (!metric_name %in% supported_metrics) {
     stop(
       "Metric `",
       metric_name,

--- a/R/ml_feature_scalers.R
+++ b/R/ml_feature_scalers.R
@@ -570,7 +570,7 @@ new_ml_robust_scaler <- function(jobj) {
 }
 
 new_ml_robust_scaler_model <- function(jobj) {
-  new_ml_transformer(jobj, class = "ml_robust_scaler")
+  new_ml_transformer(jobj, class = "ml_robust_scaler_model")
 }
 
 validator_ml_robust_scaler <- function(.args) {

--- a/R/ml_feature_string_indexer.R
+++ b/R/ml_feature_string_indexer.R
@@ -115,29 +115,10 @@ ft_string_indexer.tbl_spark <- function(
     uid = uid,
     ...
   )
-  # backwards compatibility for params argument
-  dots <- rlang::dots_list(...)
-  if (rlang::has_name(dots, "params") && is.environment(dots$params)) {
-    warning(
-      "`params` has been deprecated and will be removed in a future release.",
-      call. = FALSE
-    )
-    transformer <- if (is_ml_transformer(stage)) {
-      stage
-    } else {
-      ml_fit(stage, x)
-    }
-    dots$params$labels <- spark_jobj(transformer) %>%
-      invoke("labels") %>%
-      as.character()
-    transformer %>%
-      ml_transform(x)
+  if (is_ml_transformer(stage)) {
+    ml_transform(stage, x)
   } else {
-    if (is_ml_transformer(stage)) {
-      ml_transform(stage, x)
-    } else {
-      ml_fit_and_transform(stage, x)
-    }
+    ml_fit_and_transform(stage, x)
   }
 }
 

--- a/R/ml_gbt.R
+++ b/R/ml_gbt.R
@@ -325,7 +325,7 @@ new_ml_gbt_classification_model <- function(jobj) {
         invoke(jobj, "trees") %>%
           purrr::map(new_ml_decision_tree_regression_model)
       },
-      class = "ml_multilayer_perceptron_classification_model"
+      class = "ml_gbt_classification_model"
     )
   } else {
     new_ml_probabilistic_classification_model(

--- a/R/ml_model_constructors.R
+++ b/R/ml_model_constructors.R
@@ -253,27 +253,12 @@ ml_supervised_pipeline <- function(
 ml_clustering_pipeline <- function(predictor, dataset, formula, features_col) {
   sc <- spark_connection(predictor)
 
-  pipeline <- if (spark_version(sc) < "2.0.0") {
-    rdf <- sdf_schema(dataset) %>%
-      lapply(`[[`, "name") %>%
-      as.data.frame(stringsAsFactors = FALSE)
-    features <- stats::terms(as.formula(formula), data = rdf) %>%
-      attr("term.labels")
-
-    vector_assembler <- ft_vector_assembler(
-      sc,
-      input_cols = features,
-      output_col = features_col
-    )
-    ml_pipeline(vector_assembler, predictor)
-  } else {
-    r_formula <- ft_r_formula(
-      sc,
-      formula = formula,
-      features_col = features_col
-    )
-    ml_pipeline(r_formula, predictor)
-  }
+  r_formula <- ft_r_formula(
+    sc,
+    formula = formula,
+    features_col = features_col
+  )
+  pipeline <- ml_pipeline(r_formula, predictor)
 
   pipeline %>% ml_fit(dataset)
 }

--- a/R/ml_param_utils.R
+++ b/R/ml_param_utils.R
@@ -72,15 +72,10 @@ ml_set_param <- function(x, param, value, ...) {
 
 ml_get_param_map <- function(jobj) {
   sc <- spark_connection(jobj)
-  object <- if (spark_version(sc) < "2.0.0") {
-    "sparklyr.MLUtils"
-  } else {
-    "sparklyr.MLUtils2"
-  }
 
   invoke_static(
     sc,
-    object,
+    "sparklyr.MLUtils2",
     "getParamMap",
     jobj
   ) %>%

--- a/R/sdf_interface.R
+++ b/R/sdf_interface.R
@@ -172,11 +172,7 @@ sdf_register.spark_jobj <- function(x, name = NULL) {
     paste0("sparklyr_tmp_", gsub("-", "_", uuid::UUIDgenerate()))
   sc <- spark_connection(x)
 
-  if (spark_version(sc) < "2.0.0") {
-    invoke(x, "registerTempTable", name)
-  } else {
-    invoke(x, "createOrReplaceTempView", name)
-  }
+  invoke(x, "createOrReplaceTempView", name)
 
   on_connection_updated(sc, name)
   tbl(sc, name)
@@ -552,29 +548,18 @@ sdf_repartition <- function(x, partitions = NULL, partition_by = NULL) {
 
   partitions <- partitions %||% 0L %>% cast_scalar_integer()
 
-  if (spark_version(sc) >= "2.0.0") {
-    partition_by <- cast_string_list(partition_by, allow_null = TRUE) %||%
-      list()
+  partition_by <- cast_string_list(partition_by, allow_null = TRUE) %||%
+    list()
 
-    return(
-      invoke_static(
-        sc,
-        "sparklyr.Repartition",
-        "repartition",
-        sdf,
-        partitions,
-        partition_by
-      ) %>%
-        sdf_register()
-    )
-  } else {
-    if (!is.null(partition_by)) {
-      stop("partitioning by columns only supported for Spark 2.0.0 and later")
-    }
-
-    invoke(sdf, "repartition", partitions) %>%
-      sdf_register()
-  }
+  invoke_static(
+    sc,
+    "sparklyr.Repartition",
+    "repartition",
+    sdf,
+    partitions,
+    partition_by
+  ) %>%
+    sdf_register()
 }
 
 #' Gets number of partitions of a Spark DataFrame
@@ -774,10 +759,6 @@ sdf_expand_grid <- function(
   repartition = NULL,
   partition_by = NULL
 ) {
-  if (spark_version(sc) < "2.0.0") {
-    stop("`sdf_expand_grid()` requires Spark 2.0.0 or above")
-  }
-
   vars <- list(...)
   if (length(vars) == 0) {
     invoke(spark_session(sc), "emptyDataFrame") %>% sdf_register()

--- a/R/sdf_io.R
+++ b/R/sdf_io.R
@@ -29,17 +29,7 @@ sdf_save_table <- function(x, name, overwrite = FALSE, append = FALSE) {
     writer <- invoke(writer, "mode", "append")
   }
 
-  # Spark < 2.0.0 doesn't respect the metastore directory when
-  # using the 'saveAsTable' API, so we directly call 'save'.
-  sc <- spark_connection(sdf)
-  if (spark_version(sc) < "2.0.0") {
-    hc <- hive_context(sc)
-    metastore <- invoke(hc, "getConf", "hive.metastore.warehouse.dir")
-    path <- path.expand(file.path(metastore, name))
-    invoke(writer, "save", path)
-  } else {
-    invoke(writer, "saveAsTable", name)
-  }
+  invoke(writer, "saveAsTable", name)
 }
 
 #' @rdname sdf-saveload
@@ -50,17 +40,8 @@ sdf_load_table <- function(sc, name) {
   session <- spark_session(sc)
   name <- cast_string(name)
 
-  # NOTE: need to explicitly provide path to metastore for
-  # Spark < 2.0.0
   reader <- invoke(session, "read")
-  sdf <- if (spark_version(sc) < "2.0.0") {
-    hc <- hive_context(sc)
-    metastore <- invoke(hc, "getConf", "hive.metastore.warehouse.dir")
-    path <- file.path(metastore, name)
-    invoke(reader, "load", path)
-  } else {
-    invoke(reader, "table", name)
-  }
+  sdf <- invoke(reader, "table", name)
 
   sdf_register(sdf)
 }

--- a/R/sdf_wrapper.R
+++ b/R/sdf_wrapper.R
@@ -328,84 +328,57 @@ sdf_collect_static <- function(object, impl, ...) {
 
   separator <- split_separator(sc)
 
-  # for some reason, we appear to receive invalid results when
-  # collecting Spark DataFrames with many columns. empirically,
-  # having more than 50 columns seems to trigger the buggy behavior
-  # collect the data set in chunks, and then join those chunks.
-  # note that this issue should be resolved with Spark >2.0.0
-  collected <- if (spark_version(sc) > "2.0.0") {
-    if (!identical(args$callback, NULL)) {
-      batch_size <- spark_config_value(
-        sc$config,
-        "sparklyr.collect.batch",
-        as.integer(10^5L)
-      )
-      ctx <- invoke_static(
+  collected <- if (!identical(args$callback, NULL)) {
+    batch_size <- spark_config_value(
+      sc$config,
+      "sparklyr.collect.batch",
+      as.integer(10^5L)
+    )
+    ctx <- invoke_static(
+      sc,
+      "sparklyr.DFCollectionUtils",
+      "prepareDataFrameForCollection",
+      sdf
+    )
+    sdf <- invoke(ctx, "_1")
+    dtypes <- invoke(ctx, "_2")
+    sdf_iter <- invoke(sdf, "toLocalIterator")
+
+    iter <- 1
+    while (invoke(sdf_iter, "hasNext")) {
+      raw_df <- invoke_static(
         sc,
-        "sparklyr.DFCollectionUtils",
-        "prepareDataFrameForCollection",
-        sdf
+        "sparklyr.Utils",
+        "collectIter",
+        invoke(sdf_iter, "underlying"),
+        dtypes,
+        batch_size,
+        separator$regexp
       )
-      sdf <- invoke(ctx, "_1")
-      dtypes <- invoke(ctx, "_2")
-      sdf_iter <- invoke(sdf, "toLocalIterator")
-
-      iter <- 1
-      while (invoke(sdf_iter, "hasNext")) {
-        raw_df <- invoke_static(
-          sc,
-          "sparklyr.Utils",
-          "collectIter",
-          invoke(sdf_iter, "underlying"),
-          dtypes,
-          batch_size,
-          separator$regexp
-        )
-        df <- sdf_collect_data_frame(sdf, raw_df)
-        cb <- args$callback
-        if (is.language(cb)) {
-          cb <- rlang::as_closure(cb)
-        }
-
-        if (length(formals(cb)) >= 2) {
-          cb(df, iter)
-        } else {
-          cb(df)
-        }
-        iter <- iter + 1
+      df <- sdf_collect_data_frame(sdf, raw_df)
+      cb <- args$callback
+      if (is.language(cb)) {
+        cb <- rlang::as_closure(cb)
       }
 
-      NULL
-    } else {
-      invoke_static(
-        sc,
-        "sparklyr.Utils",
-        "collect",
-        sdf,
-        separator$regexp,
-        impl
-      )
-    }
-  } else {
-    if (!identical(args$callback, NULL)) {
-      stop("Parameter 'callback' requires Spark 2.0+")
+      if (length(formals(cb)) >= 2) {
+        cb(df, iter)
+      } else {
+        cb(df)
+      }
+      iter <- iter + 1
     }
 
-    columns <- invoke(sdf, "columns") %>% as.character()
-    chunk_size <- getOption("sparklyr.collect.chunk.size", default = 50L)
-    chunks <- split_chunks(columns, as.integer(chunk_size))
-    pieces <- lapply(chunks, function(chunk) {
-      subset <- sdf %>% invoke("selectExpr", as.list(chunk))
-      invoke_static(
-        sc,
-        "sparklyr.Utils",
-        "collect",
-        subset,
-        separator$regexp,
-        impl
-      )
-    })
-    do.call(c, pieces)
+    NULL
+  } else {
+    invoke_static(
+      sc,
+      "sparklyr.Utils",
+      "collect",
+      sdf,
+      separator$regexp,
+      impl
+    )
   }
 
   sdf_collect_data_frame(sdf, collected)
@@ -471,7 +444,7 @@ sdf_pivot <- function(x, formula, fun.aggregate = "count") {
   }
 
   grouped_cols <- trim_whitespace(strsplit(splat[[1]], "[+*]")[[1]])
-  pivot_cols <- trim_whitespace(strsplit(splat[[2]], "[+*]", fixed = TRUE)[[1]])
+  pivot_cols <- trim_whitespace(strsplit(splat[[2]], "[+*]")[[1]])
 
   # ensure no duplication of variables on each side
   intersection <- intersect(grouped_cols, pivot_cols)

--- a/R/spark_compat.R
+++ b/R/spark_compat.R
@@ -14,12 +14,12 @@ spark_require_version <- function(
   version <- spark_version(sc)
   if (version < required) {
     fmt <- "%s requires Spark %s or higher."
-    msg <- sprintf(fmt, module, required, version)
+    msg <- sprintf(fmt, module, required)
     stop(msg, call. = FALSE)
   } else if (!is.null(required_max)) {
     if (version >= required_max) {
       fmt <- "%s is removed in Spark %s."
-      msg <- sprintf(fmt, module, required_max, version)
+      msg <- sprintf(fmt, module, required_max)
       stop(msg, call. = FALSE)
     }
   }

--- a/R/spark_ide.R
+++ b/R/spark_ide.R
@@ -1,5 +1,3 @@
-# nocov start
-
 #' Set of functions to provide integration with the RStudio IDE
 #' @details These function are meant for downstream packages, that provide additional
 #' backends to `sparklyr`, to override the opening, closing, update, and preview
@@ -476,8 +474,6 @@ external_viewer <- function() {
     viewer
   }
 }
-
-# nocov end
 
 browse_url <- function(url) {
   if (url != "") {

--- a/R/stream.R
+++ b/R/stream.R
@@ -142,8 +142,9 @@ stream_stop <- function(stream) {
 }
 
 stream_validate <- function(stream) {
+  sc <- spark_connection(stream)
   waitSeconds <- cast_scalar_integer(spark_config_value(
-    config,
+    sc$config,
     "sparklyr.stream.validate.timeout",
     3
   )) %>%
@@ -275,7 +276,7 @@ sdf_collect_stream <- function(x, ...) {
   data <- data.frame()
 
   waitSeconds <- cast_scalar_integer(spark_config_value(
-    config,
+    sc$config,
     "sparklyr.stream.collect.timeout",
     5
   ))

--- a/R/tidiers_ml_regression.R
+++ b/R/tidiers_ml_regression.R
@@ -198,12 +198,19 @@ augment.ml_model_generalized_linear_regression <- function(
   # order to guarantee row order presevation.
   residuals <- sdf_residuals(x, type = type.residuals)
   # 'ml_predict()' only carries the model's training-schema columns through, so
-  # the 'residuals' column added by 'sdf_residuals()' is dropped; re-attach it
-  # positionally (both frames derive from 'residuals', preserving row order).
+  # the 'residuals' column added by 'sdf_residuals()' is dropped; re-attach it.
+  # 'sdf_bind_cols()' aligns the two frames via a sequential-id join, which is
+  # correct here because 'predictions' is a narrow transform of 'residuals' and
+  # preserves its row order. The residuals column is given a unique intermediate
+  # name so it can't collide with a same-named column carried through from data.
   predictions <- ml_predict(x, newdata = residuals) %>%
     dplyr::rename(fitted = !!"prediction")
-  sdf_bind_cols(predictions, dplyr::select(residuals, !!"residuals")) %>%
-    dplyr::rename(resid = !!"residuals")
+  resid_col <- random_string("sparklyr_resid_")
+  sdf_bind_cols(
+    predictions,
+    dplyr::transmute(residuals, !!resid_col := !!rlang::sym("residuals"))
+  ) %>%
+    dplyr::rename(resid = !!rlang::sym(resid_col))
 }
 
 #' @rdname ml_glm_tidiers

--- a/R/tidiers_ml_regression.R
+++ b/R/tidiers_ml_regression.R
@@ -197,9 +197,12 @@ augment.ml_model_generalized_linear_regression <- function(
   # training data. We call 'sdf_residuals()' first and then 'ml_predict()' in
   # order to guarantee row order presevation.
   residuals <- sdf_residuals(x, type = type.residuals)
-  ml_predict(x, newdata = residuals) %>%
-    # Two calls to 'rename': https://github.com/sparklyr/sparklyr/issues/678
-    dplyr::rename(fitted = !!"prediction") %>%
+  # 'ml_predict()' only carries the model's training-schema columns through, so
+  # the 'residuals' column added by 'sdf_residuals()' is dropped; re-attach it
+  # positionally (both frames derive from 'residuals', preserving row order).
+  predictions <- ml_predict(x, newdata = residuals) %>%
+    dplyr::rename(fitted = !!"prediction")
+  sdf_bind_cols(predictions, dplyr::select(residuals, !!"residuals")) %>%
     dplyr::rename(resid = !!"residuals")
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -296,30 +296,6 @@ infer_active_package_name <- function() {
 }
 
 
-split_chunks <- function(x, chunk_size) {
-  # return early when chunk_size > length of vector
-  n <- length(x)
-  if (n <= chunk_size) {
-    return(list(x))
-  }
-
-  # compute ranges for subsetting
-  starts <- seq(1, n, by = chunk_size)
-  ends <- c(seq(chunk_size, n - 1, by = chunk_size), n)
-
-  # apply our subsetter
-  mapply(
-    function(start, end) {
-      x[start:end]
-    },
-    starts,
-    ends,
-    SIMPLIFY = FALSE,
-    USE.NAMES = FALSE
-  )
-}
-
-
 remove_class <- function(object, class) {
   classes <- attr(object, "class")
   newClasses <- classes[!classes %in% c(class)]

--- a/inst/rstudio/connections/Livy.R
+++ b/inst/rstudio/connections/Livy.R
@@ -1,6 +1,10 @@
 library(sparklyr)
-sc <- spark_connect(master = "${1:Livy URL=http$colon$//server/livy/}",
-                    version = "${2:Version=2.4.0}",
-                    method = "livy", config = livy_config(
-                      username = "${3:User}",
-                      password = rstudioapi::askForPassword("Livy password:")))
+sc <- spark_connect(
+  master = "${1:Livy URL=http$colon$//server/livy/}",
+  version = "${2:Version=2.4.0}",
+  method = "livy",
+  config = livy_config(
+    username = "${3:User}",
+    password = rstudioapi::askForPassword("Livy password:")
+  )
+)

--- a/inst/rstudio/shinycon/app.R
+++ b/inst/rstudio/shinycon/app.R
@@ -60,18 +60,22 @@ is_java_available <- function() {
 
 spark_home <- function() {
   home <- Sys.getenv("SPARK_HOME", unset = NA)
-  if (is.na(home))
+  if (is.na(home)) {
     home <- NULL
+  }
   home
 }
 
 spark_ui_avaliable_versions <- function() {
-  tryCatch({
-    spark_available_versions(show_hadoop = TRUE, show_minor = TRUE)
-  }, error = function(e) {
-    warning(e)
-    spark_installed_versions()[,c("spark","hadoop")]
-  })
+  tryCatch(
+    {
+      spark_available_versions(show_hadoop = TRUE, show_minor = TRUE)
+    },
+    error = function(e) {
+      warning(e)
+      spark_installed_versions()[, c("spark", "hadoop")]
+    }
+  )
 }
 
 spark_ui_spark_choices <- function() {
@@ -93,13 +97,20 @@ spark_ui_spark_choices <- function() {
 spark_ui_hadoop_choices <- function(sparkVersion) {
   availableVersions <- spark_ui_avaliable_versions()
 
-  selected <- spark_install_find(version = sparkVersion, installed_only = FALSE)$hadoopVersion
+  selected <- spark_install_find(
+    version = sparkVersion,
+    installed_only = FALSE
+  )$hadoopVersion
 
-  choiceValues <- unique(availableVersions[availableVersions$spark == sparkVersion,][["hadoop"]])
+  choiceValues <- unique(availableVersions[
+    availableVersions$spark == sparkVersion,
+  ][["hadoop"]])
   choiceNames <- choiceValues
   choiceNames <- lapply(
     choiceNames,
-    function(e) if (length(selected) > 0 && e == selected) paste(e, "(Default)") else e
+    function(e) {
+      if (length(selected) > 0 && e == selected) paste(e, "(Default)") else e
+    }
   )
 
   names(choiceValues) <- choiceNames
@@ -121,7 +132,8 @@ connection_spark_ui <- function() {
   tags$div(
     tags$head(
       tags$style(
-        HTML(paste("
+        HTML(paste(
+          "
           body {
             background: none;
 
@@ -142,7 +154,9 @@ connection_spark_ui <- function() {
 
           .shiny-input-container {
             min-width: 100%;
-            margin-bottom: ", elementSpacing, "px;
+            margin-bottom: ",
+          elementSpacing,
+          "px;
           }
 
           .shiny-input-container > .control-label {
@@ -158,51 +172,55 @@ connection_spark_ui <- function() {
           #shiny-disconnected-overlay {
             display: none;
           }
-        ", sep = ""))
+        ",
+          sep = ""
+        ))
       )
     ),
-    div(style = "table-row",
-        selectInput(
-          "master",
-          "Master:",
-          choices = c(
-            list("local" = "local"),
-            spark_ui_default_connections(),
-            list("Cluster..." = "cluster")
-          ),
-          selectize = FALSE
+    div(
+      style = "table-row",
+      selectInput(
+        "master",
+        "Master:",
+        choices = c(
+          list("local" = "local"),
+          spark_ui_default_connections(),
+          list("Cluster..." = "cluster")
         ),
-        selectInput(
-          "dbinterface",
-          "DB Interface:",
-          choices = c(
-            "dplyr" = "dplyr",
-            "(None)" = "none"
-          ),
-          selectize = FALSE,
-          selected = rsApiReadPreference("sparklyr_dbinterface", "dplyr")
-        )
+        selectize = FALSE
+      ),
+      selectInput(
+        "dbinterface",
+        "DB Interface:",
+        choices = c(
+          "dplyr" = "dplyr",
+          "(None)" = "none"
+        ),
+        selectize = FALSE,
+        selected = rsApiReadPreference("sparklyr_dbinterface", "dplyr")
+      )
     ),
     div(
       style = paste("display: table-row; height: 10px")
     ),
     conditionalPanel(
       condition = "!output.notShowVersionsUi",
-      div(style = "table-row",
-          selectInput(
-            "sparkversion",
-            "Spark version:",
-            choices = spark_ui_spark_choices(),
-            selected = spark_default_version()$spark,
-            selectize = FALSE
-          ),
-          selectInput(
-            "hadoopversion",
-            "Hadoop version:",
-            choices = spark_ui_hadoop_choices(spark_default_version()$spark),
-            selected = spark_default_version()$hadoop,
-            selectize = FALSE
-          )
+      div(
+        style = "table-row",
+        selectInput(
+          "sparkversion",
+          "Spark version:",
+          choices = spark_ui_spark_choices(),
+          selected = spark_default_version()$spark,
+          selectize = FALSE
+        ),
+        selectInput(
+          "hadoopversion",
+          "Hadoop version:",
+          choices = spark_ui_hadoop_choices(spark_default_version()$spark),
+          selected = spark_default_version()$hadoop,
+          selectize = FALSE
+        )
       )
     )
   )
@@ -222,13 +240,21 @@ connection_spark_server <- function(input, output, session) {
   })
 
   userInstallPreference <- NULL
-  checkUserInstallPreference <- function(master, sparkSelection, hadoopSelection, prompt) {
-    if (identical(master, "local") &&
+  checkUserInstallPreference <- function(
+    master,
+    sparkSelection,
+    hadoopSelection,
+    prompt
+  ) {
+    if (
+      identical(master, "local") &&
         identical(rsApiVersionInfo()$mode, "desktop") &&
-        identical(spark_home(), NULL)) {
-
+        identical(spark_home(), NULL)
+    ) {
       installed <- spark_installed_versions()
-      isInstalled <- nrow(installed[installed$spark == sparkSelection & installed$hadoop == hadoopSelection, ])
+      isInstalled <- nrow(installed[
+        installed$spark == sparkSelection & installed$hadoop == hadoopSelection,
+      ])
 
       if (!isInstalled) {
         if (prompt && identical(userInstallPreference, NULL)) {
@@ -249,28 +275,30 @@ connection_spark_server <- function(input, output, session) {
           )
 
           userInstallPreference
-        }
-        else if (identical(userInstallPreference, NULL)) {
+        } else if (identical(userInstallPreference, NULL)) {
           FALSE
-        }
-        else {
+        } else {
           userInstallPreference
         }
-      }
-      else {
+      } else {
         FALSE
       }
-    }
-    else {
+    } else {
       FALSE
     }
   }
 
-  generateCode <- function(master, dbInterface, sparkVersion, hadoopVersion, installSpark) {
+  generateCode <- function(
+    master,
+    dbInterface,
+    sparkVersion,
+    hadoopVersion,
+    installSpark
+  ) {
     paste(
       "library(sparklyr)\n",
-      if(dbInterface == "dplyr") "library(dplyr)\n" else "",
-      if(installSpark)
+      if (dbInterface == "dplyr") "library(dplyr)\n" else "",
+      if (installSpark) {
         paste(
           "spark_install(version = \"",
           sparkVersion,
@@ -279,28 +307,34 @@ connection_spark_server <- function(input, output, session) {
           "\")\n",
           sep = ""
         )
-      else "",
+      } else {
+        ""
+      },
       "sc ",
       "<- ",
       "spark_connect(master = \"",
       master,
       "\"",
-      if (!hasDefaultSparkVersion())
+      if (!hasDefaultSparkVersion()) {
         paste(
           ", version = \"",
           sparkVersion,
           "\"",
           sep = ""
         )
-      else "",
-      if (!hasDefaultHadoopVersion())
+      } else {
+        ""
+      },
+      if (!hasDefaultHadoopVersion()) {
         paste(
           ", hadoop_version = \"",
           hadoopVersion,
           "\"",
           sep = ""
         )
-      else "",
+      } else {
+        ""
+      },
       ")",
       sep = ""
     )
@@ -315,7 +349,12 @@ connection_spark_server <- function(input, output, session) {
     hadoopVersion <- input$hadoopversion
     codeInvalidated <- stateValuesReactive$codeInvalidated
 
-    installSpark <- checkUserInstallPreference(master, sparkVersion, hadoopVersion, FALSE)
+    installSpark <- checkUserInstallPreference(
+      master,
+      sparkVersion,
+      hadoopVersion,
+      FALSE
+    )
 
     generateCode(master, dbInterface, sparkVersion, hadoopVersion, installSpark)
   })
@@ -324,7 +363,8 @@ connection_spark_server <- function(input, output, session) {
     master <- input$master
     sparkVersion <- input$sparkversion
     hadoopVersion <- input$hadoopversion
-  }) %>% debounce(200)
+  }) %>%
+    debounce(200)
 
   observe({
     installLater()
@@ -362,8 +402,7 @@ connection_spark_server <- function(input, output, session) {
           "master",
           selected = "local"
         )
-      }
-      else if (identical(spark_home(), NULL)) {
+      } else if (identical(spark_home(), NULL)) {
         rsApiShowDialog(
           "Connect to Spark",
           paste(
@@ -385,8 +424,7 @@ connection_spark_server <- function(input, output, session) {
           "master",
           selected = "local"
         )
-      }
-      else {
+      } else {
         master <- rsApiShowPrompt(
           "Connect to Cluster",
           "Spark master:",
@@ -426,7 +464,8 @@ connection_spark_server <- function(input, output, session) {
           message,
           "<p>Please contact your server administrator to request the ",
           "installation of Java on this system.</p>",
-          sep = "")
+          sep = ""
+        )
 
         url <- java_install_url()
       } else {
@@ -434,7 +473,8 @@ connection_spark_server <- function(input, output, session) {
           message,
           "<p>Please contact your server administrator to request the ",
           "installation of Java on this system.</p>",
-          sep = "")
+          sep = ""
+        )
       }
 
       rsApiShowDialog(
@@ -456,7 +496,10 @@ connection_spark_server <- function(input, output, session) {
     if (!identical(currentSparkSelection, NULL)) {
       currentSparkSelection <<- sparkVersion
 
-      hadoopDefault <- spark_install_find(version = currentSparkSelection, installed_only = FALSE)$hadoopVersion
+      hadoopDefault <- spark_install_find(
+        version = currentSparkSelection,
+        installed_only = FALSE
+      )$hadoopVersion
 
       updateSelectInput(
         session,

--- a/inst/sparkml/class_mapping.json
+++ b/inst/sparkml/class_mapping.json
@@ -27,6 +27,8 @@
   "org.apache.spark.ml.feature.MinMaxScalerModel": "ml_min_max_scaler_model",
   "org.apache.spark.ml.feature.MaxAbsScaler": "ml_max_abs_scaler",
   "org.apache.spark.ml.feature.MaxAbsScalerModel": "ml_max_abs_scaler_model",
+  "org.apache.spark.ml.feature.RobustScaler": "ml_robust_scaler",
+  "org.apache.spark.ml.feature.RobustScalerModel": "ml_robust_scaler_model",
   "org.apache.spark.ml.feature.Imputer": "ml_imputer",
   "org.apache.spark.ml.feature.ImputerModel": "ml_imputer_model",
   "org.apache.spark.ml.feature.ChiSqSelector": "ml_chisq_selector",

--- a/java/embedded_sources.R
+++ b/java/embedded_sources.R
@@ -1,406 +1,3 @@
-# Changing this file requires running update_embedded_sources.R to rebuild sources and jars.
-
-arrow_write_record_batch <- function(df, spark_version_number = NULL) {
-  arrow_env_vars <- list()
-  if (!is.null(spark_version_number) && spark_version_number < "3.0") {
-    # Spark < 3 uses an old version of Arrow, so send data in the legacy format
-    arrow_env_vars$ARROW_PRE_0_15_IPC_FORMAT <- 1
-  }
-
-  withr::with_envvar(arrow_env_vars, {
-    # Set the local timezone to any POSIXt columns that don't have one set
-    # https://github.com/sparklyr/sparklyr/issues/2439
-    df[] <- lapply(df, function(x) {
-      if (inherits(x, "POSIXt") && is.null(attr(x, "tzone"))) {
-        attr(x, "tzone") <- Sys.timezone()
-      }
-      x
-    })
-    arrow::write_to_raw(df, format = "stream")
-  })
-}
-
-arrow_record_stream_reader <- function(stream) {
-  arrow::RecordBatchStreamReader$create(stream)
-}
-
-arrow_read_record_batch <- function(reader) reader$read_next_batch()
-
-arrow_as_tibble <- function(record) as.data.frame(record)
-#' A helper function to retrieve values from \code{spark_config()}
-#'
-#' @param config The configuration list from \code{spark_config()}
-#' @param name The name of the configuration entry
-#' @param default The default value to use when entry is not present
-#'
-#' @keywords internal
-#' @export
-spark_config_value <- function(config, name, default = NULL) {
-  if (
-    getOption("sparklyr.test.enforce.config", FALSE) &&
-      any(grepl("^sparklyr.", name))
-  ) {
-    settings <- get("spark_config_settings")()
-    if (
-      !any(name %in% settings$name) &&
-        !grepl("^sparklyr\\.shell\\.", name)
-    ) {
-      stop(
-        "Config value '",
-        name[[1]],
-        "' not described in spark_config_settings()"
-      )
-    }
-  }
-
-  name_exists <- name %in% names(config)
-  if (!any(name_exists)) {
-    name_exists <- name %in% names(options())
-    if (!any(name_exists)) {
-      value <- default
-    } else {
-      name_primary <- name[name_exists][[1]]
-      value <- getOption(name_primary)
-    }
-  } else {
-    name_primary <- name[name_exists][[1]]
-    value <- config[[name_primary]]
-  }
-
-  if (is.language(value)) {
-    value <- rlang::as_closure(value)
-  }
-  if (is.function(value)) {
-    value <- value()
-  }
-  value
-}
-
-spark_config_integer <- function(config, name, default = NULL) {
-  as.integer(spark_config_value(config, name, default))
-}
-
-spark_config_logical <- function(config, name, default = NULL) {
-  as.logical(spark_config_value(config, name, default))
-}
-#' Check whether the connection is open
-#'
-#' @param sc \code{spark_connection}
-#'
-#' @keywords internal
-#'
-#' @export
-connection_is_open <- function(sc) {
-  UseMethod("connection_is_open")
-}
-read_bin <- function(con, what, n, endian = NULL) {
-  UseMethod("read_bin")
-}
-
-#' @export
-read_bin.default <- function(con, what, n, endian = NULL) {
-  if (is.null(endian)) {
-    readBin(con, what, n)
-  } else {
-    readBin(con, what, n, endian = endian)
-  }
-}
-
-read_bin_wait <- function(con, what, n, endian = NULL) {
-  sc <- con
-  con <- if (!is.null(sc$state) && identical(sc$state$use_monitoring, TRUE)) {
-    sc$monitoring
-  } else {
-    sc$backend
-  }
-
-  timeout <- spark_config_value(
-    sc$config,
-    "sparklyr.backend.timeout",
-    30 * 24 * 60 * 60
-  )
-  progressInterval <- spark_config_value(
-    sc$config,
-    "sparklyr.progress.interval",
-    3
-  )
-
-  result <- if (is.null(endian)) {
-    readBin(con, what, n)
-  } else {
-    readBin(con, what, n, endian = endian)
-  }
-
-  progressTimeout <- Sys.time() + progressInterval
-  if (is.null(sc$state$progress)) {
-    sc$state$progress <- new.env()
-  }
-  progressUpdated <- FALSE
-
-  waitInterval <- 0
-  commandStart <- Sys.time()
-  while (length(result) == 0 && commandStart + timeout > Sys.time()) {
-    Sys.sleep(waitInterval)
-    waitInterval <- min(0.1, waitInterval + 0.01)
-
-    result <- if (is.null(endian)) {
-      readBin(con, what, n)
-    } else {
-      readBin(con, what, n, endian = endian)
-    }
-
-    if (Sys.time() > progressTimeout) {
-      progressTimeout <- Sys.time() + progressInterval
-      if (exists("connection_progress")) {
-        connection_progress(sc)
-        progressUpdated <- TRUE
-      }
-    }
-  }
-
-  if (progressUpdated) {
-    connection_progress_terminated(sc)
-  }
-
-  if (commandStart + timeout <= Sys.time()) {
-    stop(
-      "Operation timed out, increase config option sparklyr.backend.timeout if needed."
-    )
-  }
-
-  result
-}
-
-read_bin.spark_connection <- function(con, what, n, endian = NULL) {
-  read_bin_wait(con, what, n, endian)
-}
-
-#' @export
-read_bin.spark_worker_connection <- function(con, what, n, endian = NULL) {
-  read_bin_wait(con, what, n, endian)
-}
-
-#' @export
-read_bin.livy_backend <- function(con, what, n, endian = NULL) {
-  read_bin.default(con$rc, what, n, endian)
-}
-
-readObject <- function(con) {
-  # Read type first
-  type <- readType(con)
-  readTypedObject(con, type)
-}
-
-readTypedObject <- function(con, type) {
-  switch(
-    type,
-    "i" = readInt(con),
-    "c" = readString(con),
-    "b" = readBoolean(con),
-    "d" = readDouble(con),
-    "r" = readRaw(con),
-    "D" = readDate(con),
-    "t" = readTime(con),
-    "a" = readArray(con),
-    "l" = readList(con),
-    "e" = readMap(con),
-    "s" = readStruct(con),
-    "f" = readStringArray(con),
-    "n" = NULL,
-    "j" = getJobj(con, readString(con)),
-    "J" = jsonlite::fromJSON(
-      readString(con),
-      simplifyDataFrame = FALSE,
-      simplifyMatrix = FALSE
-    ),
-    stop(paste("Unsupported type for deserialization", type))
-  )
-}
-
-readString <- function(con) {
-  stringLen <- readInt(con)
-
-  string <- (if (stringLen > 0) {
-    raw <- read_bin(con, raw(), stringLen, endian = "big")
-    if (is.element("00", raw)) {
-      warning("Input contains embedded nuls, removing.")
-      raw <- raw[raw != "00"]
-    }
-    rawToChar(raw)
-  } else if (stringLen == 0) {
-    ""
-  } else {
-    NA_character_
-  })
-
-  Encoding(string) <- "UTF-8"
-  string
-}
-
-readStringArray <- function(con) {
-  joined <- readString(con)
-  arr <- as.list(strsplit(joined, "\u0019")[[1]])
-  lapply(
-    arr,
-    function(x) {
-      if (x == "<NA>") NA_character_ else x
-    }
-  )
-}
-
-readDateArray <- function(con, n = 1) {
-  if (n == 0) {
-    as.Date(NA)
-  } else {
-    do.call(c, lapply(seq(n), function(x) readDate(con)))
-  }
-}
-
-readInt <- function(con, n = 1) {
-  if (n == 0) {
-    integer(0)
-  } else {
-    read_bin(con, integer(), n = n, endian = "big")
-  }
-}
-
-readDouble <- function(con, n = 1) {
-  if (n == 0) {
-    double(0)
-  } else {
-    read_bin(con, double(), n = n, endian = "big")
-  }
-}
-
-readBoolean <- function(con, n = 1) {
-  if (n == 0) {
-    logical(0)
-  } else {
-    as.logical(readInt(con, n = n))
-  }
-}
-
-readType <- function(con) {
-  rawToChar(read_bin(con, "raw", n = 1L))
-}
-
-readDate <- function(con) {
-  n <- readInt(con)
-  if (is.na(n)) {
-    as.Date(NA)
-  } else {
-    d <- as.Date(n, origin = "1970-01-01")
-    if (getOption("sparklyr.collect.datechars", FALSE)) {
-      as.character(d)
-    } else {
-      d
-    }
-  }
-}
-
-readTime <- function(con, n = 1) {
-  if (identical(n, 0)) {
-    as.POSIXct(character(0))
-  } else {
-    t <- readDouble(con, n)
-
-    r <- as.POSIXct(t, origin = "1970-01-01")
-    if (getOption("sparklyr.collect.datechars", FALSE)) {
-      as.character(r)
-    } else {
-      r
-    }
-  }
-}
-
-readArray <- function(con) {
-  type <- readType(con)
-  len <- readInt(con)
-
-  if (type == "d") {
-    return(readDouble(con, n = len))
-  } else if (type == "i") {
-    return(readInt(con, n = len))
-  } else if (type == "b") {
-    return(readBoolean(con, n = len))
-  } else if (type == "t") {
-    return(readTime(con, n = len))
-  } else if (type == "D") {
-    return(readDateArray(con, n = len))
-  }
-
-  if (len > 0) {
-    l <- vector("list", len)
-    for (i in seq_len(len)) {
-      l[[i]] <- readTypedObject(con, type)
-    }
-    l
-  } else {
-    list()
-  }
-}
-
-# Read a list. Types of each element may be different.
-# Null objects are read as NA.
-readList <- function(con) {
-  len <- readInt(con)
-  if (len > 0) {
-    l <- vector("list", len)
-    for (i in seq_len(len)) {
-      elem <- readObject(con)
-      if (is.null(elem)) {
-        elem <- NA
-      }
-      l[[i]] <- elem
-    }
-    l
-  } else {
-    list()
-  }
-}
-
-readMap <- function(con) {
-  map <- list()
-  len <- readInt(con)
-  if (len > 0) {
-    for (i in seq_len(len)) {
-      key <- readString(con)
-      value <- readObject(con)
-      map[[key]] <- value
-    }
-  }
-
-  map
-}
-
-# Convert a named list to struct so that
-# SerDe won't confuse between a normal named list and struct
-listToStruct <- function(list) {
-  stopifnot(class(list) == "list")
-  stopifnot(!is.null(names(list)))
-  class(list) <- "struct"
-  list
-}
-
-# Read a field of StructType from DataFrame
-# into a named list in R whose class is "struct"
-readStruct <- function(con) {
-  names <- readObject(con)
-  fields <- readObject(con)
-  names(fields) <- names
-  listToStruct(fields)
-}
-
-readRaw <- function(con) {
-  dataLen <- readInt(con)
-  if (dataLen == -1) {
-    NA
-  } else if (dataLen == 0) {
-    raw()
-  } else {
-    read_bin(con, raw(), as.integer(dataLen), endian = "big")
-  }
-}
 sparklyr_gateway_trouble_shooting_msg <- function() {
   c(
     "\n\n\nTry running `options(sparklyr.log.console = TRUE)` followed by ",
@@ -608,6 +205,147 @@ spark_connect_gateway <- function(
     }
   }
 }
+
+#' @include connection_shell.R
+
+master_is_gateway <- function(master) {
+  length(grep("^(sparklyr://)?[^:]+:[0-9]+(/[0-9]+)?$", master)) > 0
+}
+
+gateway_connection <- function(master, config) {
+  if (!master_is_gateway(master)) {
+    stop(
+      "sparklyr gateway master expected to be formatted as sparklyr://address:port"
+    )
+  }
+
+  protocol <- strsplit(master, "//")[[1]]
+  components <- strsplit(protocol[[2]], ":")[[1]]
+  gatewayAddress <- components[[1]]
+  portAndSesssion <- strsplit(components[[2]], "/")[[1]]
+  gatewayPort <- as.integer(portAndSesssion[[1]])
+  sessionId <- if (length(portAndSesssion) > 1) {
+    as.integer(portAndSesssion[[2]])
+  } else {
+    0
+  }
+
+  gatewayInfo <- spark_connect_gateway(
+    gatewayAddress = gatewayAddress,
+    gatewayPort = gatewayPort,
+    sessionId = sessionId,
+    config = config
+  )
+
+  if (is.null(gatewayInfo)) {
+    stop("Failed to connect to gateway: ", master)
+  }
+
+  sc <- spark_gateway_connection(master, config, gatewayInfo, gatewayAddress)
+
+  if (is.null(gatewayInfo)) {
+    stop("Failed to open connection from gateway: ", master)
+  }
+
+  sc
+}
+
+spark_gateway_connection <- function(
+  master,
+  config,
+  gatewayInfo,
+  gatewayAddress
+) {
+  tryCatch(
+    {
+      interval <- spark_config_value(config, "sparklyr.backend.interval", 1)
+
+      backend <- socketConnection(
+        host = gatewayAddress,
+        port = gatewayInfo$backendPort,
+        server = FALSE,
+        blocking = interval > 0,
+        open = "wb",
+        timeout = interval
+      )
+      class(backend) <- c(class(backend), "shell_backend")
+
+      monitoring <- socketConnection(
+        host = gatewayAddress,
+        port = gatewayInfo$backendPort,
+        server = FALSE,
+        blocking = interval > 0,
+        open = "wb",
+        timeout = interval
+      )
+      class(monitoring) <- c(class(monitoring), "shell_backend")
+    },
+    error = function(err) {
+      close(gatewayInfo$gateway)
+      stop("Failed to open connection to backend:", err$message)
+    }
+  )
+
+  # create the shell connection
+  sc <- new_spark_gateway_connection(list(
+    # spark_connection
+    master = master,
+    method = "gateway",
+    app_name = "sparklyr",
+    config = config,
+    state = new.env(),
+    # spark_gateway_connection : spark_shell_connection
+    spark_home = NULL,
+    backend = backend,
+    monitoring = monitoring,
+    gateway = gatewayInfo$gateway,
+    output_file = NULL
+  ))
+
+  # stop shell on R exit
+  reg.finalizer(
+    baseenv(),
+    function(x) {
+      if (connection_is_open(sc)) {
+        stop_shell(sc)
+      }
+    },
+    onexit = TRUE
+  )
+
+  sc
+}
+
+#' @export
+connection_is_open.spark_gateway_connection <- connection_is_open.spark_shell_connection
+
+#' @export
+spark_log.spark_gateway_connection <- function(
+  sc,
+  n = 100,
+  filter = NULL,
+  ...
+) {
+  stop(
+    "spark_log is not available while connecting through an sparklyr gateway"
+  )
+}
+
+#' @export
+spark_web.spark_gateway_connection <- function(sc, ...) {
+  stop(
+    "spark_web is not available while connecting through an sparklyr gateway"
+  )
+}
+
+#' @export
+invoke_method.spark_gateway_connection <- invoke_method.spark_shell_connection
+
+#' @export
+j_invoke_method.spark_gateway_connection <- j_invoke_method.spark_shell_connection
+
+#' @export
+print_jobj.spark_gateway_connection <- print_jobj.spark_shell_connection
 core_invoke_sync_socket <- function(sc) {
   flush <- c(1)
   while (length(flush) > 0) {
@@ -1009,6 +747,146 @@ spark_last_error <- function() {
     rlang::inform(last_error)
   } else {
     rlang::inform("No error found")
+  }
+}
+
+#' Invoke a Method on a JVM Object
+#'
+#' Invoke methods on Java object references. These functions provide a
+#' mechanism for invoking various Java object methods directly from \R.
+#'
+#' Use each of these functions in the following scenarios:
+#'
+#' \tabular{lll}{
+#' \code{invoke} \tab Execute a method on a Java object reference (typically, a \code{spark_jobj}). \cr
+#' \code{invoke_static} \tab Execute a static method associated with a Java class. \cr
+#' \code{invoke_new} \tab Invoke a constructor associated with a Java class. \cr
+#' }
+#'
+#' @param sc A \code{spark_connection}.
+#' @param jobj An \R object acting as a Java object reference (typically, a \code{spark_jobj}).
+#' @param class The name of the Java class whose methods should be invoked.
+#' @param method The name of the method to be invoked.
+#' @param ... Optional arguments, currently unused.
+#'
+#' @name invoke
+NULL
+
+#' @name invoke
+#' @export
+invoke <- function(jobj, method, ...) {
+  invoke_trace(spark_connection(jobj), "Invoking", method)
+  UseMethod("invoke")
+}
+
+#' Invoke a Java function.
+#'
+#' Invoke a Java function and force return value of the call to be retrieved
+#' as a Java object reference.
+#'
+#' @inheritParams invoke
+#'
+#' @name j_invoke
+NULL
+
+#' @name j_invoke
+#' @export
+j_invoke <- function(jobj, method, ...) {
+  invoke_trace(spark_connection(jobj), "Invoking", method)
+  UseMethod("j_invoke")
+}
+
+#' @name invoke
+#' @export
+invoke_static <- function(sc, class, method, ...) {
+  invoke_trace(sc, "Invoking", class, method)
+  UseMethod("invoke_static")
+}
+
+#' @name j_invoke
+#' @export
+j_invoke_static <- function(sc, class, method, ...) {
+  UseMethod("j_invoke_static")
+}
+
+#' @name invoke
+#' @export
+invoke_new <- function(sc, class, ...) {
+  invoke_trace(sc, "Invoking", class)
+  UseMethod("invoke_new")
+}
+
+#' @name j_invoke
+#' @export
+j_invoke_new <- function(sc, class, ...) {
+  UseMethod("j_invoke_new")
+}
+
+#' Generic Call Interface
+#'
+#' @param sc \code{spark_connection}
+#' @param static Is this a static method call (including a constructor). If so
+#'   then the \code{object} parameter should be the name of a class (otherwise
+#'   it should be a spark_jobj instance).
+#' @param object Object instance or name of class (for \code{static})
+#' @param method Name of method
+#' @param ... Call parameters
+#'
+#' @name generic_call_interface
+NULL
+
+#' Generic Call Interface
+#'
+#' @inheritParams generic_call_interface
+#'
+#' @keywords internal
+#'
+#' @export
+invoke_method <- function(sc, static, object, method, ...) {
+  UseMethod("invoke_method")
+}
+
+#' Generic Call Interface
+#'
+#' Call a Java method and retrieve the return value through a JVM object
+#' reference.
+#'
+#' @inheritParams generic_call_interface
+#'
+#' @keywords internal
+#'
+#' @export
+j_invoke_method <- function(sc, static, object, method, ...) {
+  UseMethod("j_invoke_method")
+}
+
+invoke_trace <- function(sc, ...) {
+  invoke_config <- spark_config_value(sc$config, "sparklyr.log.invoke", FALSE)
+  if (invoke_config %in% c(TRUE, "callstack", "cat")) {
+    args <- list(...)
+    trace_message <- paste(args, collapse = " ")
+
+    if (identical(invoke_config, "cat")) {
+      cat(paste0(trace_message, "\n"))
+    } else {
+      message(trace_message)
+    }
+
+    if (identical(invoke_config, "callstack")) {
+      frame_names <- list()
+      for (i in 1:sys.nframe()) {
+        current_call <- sys.call(i)
+        frame_names[[i]] <- paste(
+          i,
+          ": ",
+          paste(head(deparse(current_call), 5), collapse = "\n"),
+          sep = ""
+        )
+      }
+
+      message(paste(frame_names, collapse = "\n"))
+      message()
+    }
   }
 }
 #' Retrieve a Spark JVM Object Reference
@@ -1431,6 +1309,315 @@ writeArgs <- function(con, args) {
     }
   }
 }
+
+read_bin <- function(con, what, n, endian = NULL) {
+  UseMethod("read_bin")
+}
+
+#' @export
+read_bin.default <- function(con, what, n, endian = NULL) {
+  if (is.null(endian)) {
+    readBin(con, what, n)
+  } else {
+    readBin(con, what, n, endian = endian)
+  }
+}
+
+read_bin_wait <- function(con, what, n, endian = NULL) {
+  sc <- con
+  con <- if (!is.null(sc$state) && identical(sc$state$use_monitoring, TRUE)) {
+    sc$monitoring
+  } else {
+    sc$backend
+  }
+
+  timeout <- spark_config_value(
+    sc$config,
+    "sparklyr.backend.timeout",
+    30 * 24 * 60 * 60
+  )
+  progressInterval <- spark_config_value(
+    sc$config,
+    "sparklyr.progress.interval",
+    3
+  )
+
+  result <- if (is.null(endian)) {
+    readBin(con, what, n)
+  } else {
+    readBin(con, what, n, endian = endian)
+  }
+
+  progressTimeout <- Sys.time() + progressInterval
+  if (is.null(sc$state$progress)) {
+    sc$state$progress <- new.env()
+  }
+  progressUpdated <- FALSE
+
+  waitInterval <- 0
+  commandStart <- Sys.time()
+  while (length(result) == 0 && commandStart + timeout > Sys.time()) {
+    Sys.sleep(waitInterval)
+    waitInterval <- min(0.1, waitInterval + 0.01)
+
+    result <- if (is.null(endian)) {
+      readBin(con, what, n)
+    } else {
+      readBin(con, what, n, endian = endian)
+    }
+
+    if (Sys.time() > progressTimeout) {
+      progressTimeout <- Sys.time() + progressInterval
+      if (exists("connection_progress")) {
+        connection_progress(sc)
+        progressUpdated <- TRUE
+      }
+    }
+  }
+
+  if (progressUpdated) {
+    connection_progress_terminated(sc)
+  }
+
+  if (commandStart + timeout <= Sys.time()) {
+    stop(
+      "Operation timed out, increase config option sparklyr.backend.timeout if needed."
+    )
+  }
+
+  result
+}
+
+read_bin.spark_connection <- function(con, what, n, endian = NULL) {
+  read_bin_wait(con, what, n, endian)
+}
+
+#' @export
+read_bin.spark_worker_connection <- function(con, what, n, endian = NULL) {
+  read_bin_wait(con, what, n, endian)
+}
+
+#' @export
+read_bin.livy_backend <- function(con, what, n, endian = NULL) {
+  read_bin.default(con$rc, what, n, endian)
+}
+
+readObject <- function(con) {
+  # Read type first
+  type <- readType(con)
+  readTypedObject(con, type)
+}
+
+readTypedObject <- function(con, type) {
+  switch(
+    type,
+    "i" = readInt(con),
+    "c" = readString(con),
+    "b" = readBoolean(con),
+    "d" = readDouble(con),
+    "r" = readRaw(con),
+    "D" = readDate(con),
+    "t" = readTime(con),
+    "a" = readArray(con),
+    "l" = readList(con),
+    "e" = readMap(con),
+    "s" = readStruct(con),
+    "f" = readStringArray(con),
+    "n" = NULL,
+    "j" = getJobj(con, readString(con)),
+    "J" = jsonlite::fromJSON(
+      readString(con),
+      simplifyDataFrame = FALSE,
+      simplifyMatrix = FALSE
+    ),
+    stop(paste("Unsupported type for deserialization", type))
+  )
+}
+
+readString <- function(con) {
+  stringLen <- readInt(con)
+
+  string <- (if (stringLen > 0) {
+    raw <- read_bin(con, raw(), stringLen, endian = "big")
+    if (is.element("00", raw)) {
+      warning("Input contains embedded nuls, removing.")
+      raw <- raw[raw != "00"]
+    }
+    rawToChar(raw)
+  } else if (stringLen == 0) {
+    ""
+  } else {
+    NA_character_
+  })
+
+  Encoding(string) <- "UTF-8"
+  string
+}
+
+readStringArray <- function(con) {
+  joined <- readString(con)
+  arr <- as.list(strsplit(joined, "\u0019")[[1]])
+  lapply(
+    arr,
+    function(x) {
+      if (x == "<NA>") NA_character_ else x
+    }
+  )
+}
+
+readDateArray <- function(con, n = 1) {
+  if (n == 0) {
+    as.Date(NA)
+  } else {
+    do.call(c, lapply(seq(n), function(x) readDate(con)))
+  }
+}
+
+readInt <- function(con, n = 1) {
+  if (n == 0) {
+    integer(0)
+  } else {
+    read_bin(con, integer(), n = n, endian = "big")
+  }
+}
+
+readDouble <- function(con, n = 1) {
+  if (n == 0) {
+    double(0)
+  } else {
+    read_bin(con, double(), n = n, endian = "big")
+  }
+}
+
+readBoolean <- function(con, n = 1) {
+  if (n == 0) {
+    logical(0)
+  } else {
+    as.logical(readInt(con, n = n))
+  }
+}
+
+readType <- function(con) {
+  rawToChar(read_bin(con, "raw", n = 1L))
+}
+
+readDate <- function(con) {
+  n <- readInt(con)
+  if (is.na(n)) {
+    as.Date(NA)
+  } else {
+    d <- as.Date(n, origin = "1970-01-01")
+    if (getOption("sparklyr.collect.datechars", FALSE)) {
+      as.character(d)
+    } else {
+      d
+    }
+  }
+}
+
+readTime <- function(con, n = 1) {
+  if (identical(n, 0)) {
+    as.POSIXct(character(0))
+  } else {
+    t <- readDouble(con, n)
+
+    r <- as.POSIXct(t, origin = "1970-01-01")
+    if (getOption("sparklyr.collect.datechars", FALSE)) {
+      as.character(r)
+    } else {
+      r
+    }
+  }
+}
+
+readArray <- function(con) {
+  type <- readType(con)
+  len <- readInt(con)
+
+  if (type == "d") {
+    return(readDouble(con, n = len))
+  } else if (type == "i") {
+    return(readInt(con, n = len))
+  } else if (type == "b") {
+    return(readBoolean(con, n = len))
+  } else if (type == "t") {
+    return(readTime(con, n = len))
+  } else if (type == "D") {
+    return(readDateArray(con, n = len))
+  }
+
+  if (len > 0) {
+    l <- vector("list", len)
+    for (i in seq_len(len)) {
+      l[[i]] <- readTypedObject(con, type)
+    }
+    l
+  } else {
+    list()
+  }
+}
+
+# Read a list. Types of each element may be different.
+# Null objects are read as NA.
+readList <- function(con) {
+  len <- readInt(con)
+  if (len > 0) {
+    l <- vector("list", len)
+    for (i in seq_len(len)) {
+      elem <- readObject(con)
+      if (is.null(elem)) {
+        elem <- NA
+      }
+      l[[i]] <- elem
+    }
+    l
+  } else {
+    list()
+  }
+}
+
+readMap <- function(con) {
+  map <- list()
+  len <- readInt(con)
+  if (len > 0) {
+    for (i in seq_len(len)) {
+      key <- readString(con)
+      value <- readObject(con)
+      map[[key]] <- value
+    }
+  }
+
+  map
+}
+
+# Convert a named list to struct so that
+# SerDe won't confuse between a normal named list and struct
+listToStruct <- function(list) {
+  stopifnot(class(list) == "list")
+  stopifnot(!is.null(names(list)))
+  class(list) <- "struct"
+  list
+}
+
+# Read a field of StructType from DataFrame
+# into a named list in R whose class is "struct"
+readStruct <- function(con) {
+  names <- readObject(con)
+  fields <- readObject(con)
+  names(fields) <- names
+  listToStruct(fields)
+}
+
+readRaw <- function(con) {
+  dataLen <- readInt(con)
+  if (dataLen == -1) {
+    NA
+  } else if (dataLen == 0) {
+    raw()
+  } else {
+    read_bin(con, raw(), as.integer(dataLen), endian = "big")
+  }
+}
 core_get_package_function <- function(packageName, functionName) {
   if (
     packageName %in%
@@ -1442,36 +1629,186 @@ core_get_package_function <- function(packageName, functionName) {
     NULL
   }
 }
-worker_config_serialize <- function(config) {
-  paste(
-    if (isTRUE(config$debug)) "TRUE" else "FALSE",
-    spark_config_value(config, "sparklyr.worker.gateway.port", "8880"),
-    spark_config_value(config, "sparklyr.worker.gateway.address", "localhost"),
-    if (isTRUE(config$profile)) "TRUE" else "FALSE",
-    if (isTRUE(config$schema)) "TRUE" else "FALSE",
-    if (isTRUE(config$arrow)) "TRUE" else "FALSE",
-    if (isTRUE(config$fetch_result_as_sdf)) "TRUE" else "FALSE",
-    if (isTRUE(config$single_binary_column)) "TRUE" else "FALSE",
-    if (isTRUE(config$spark_read)) "TRUE" else "FALSE",
-    config$spark_version,
-    sep = ";"
-  )
+
+# Changing this file requires running update_embedded_sources.R to rebuild sources and jars.
+
+arrow_write_record_batch <- function(df, spark_version_number = NULL) {
+  arrow_env_vars <- list()
+  if (!is.null(spark_version_number) && spark_version_number < "3.0") {
+    # Spark < 3 uses an old version of Arrow, so send data in the legacy format
+    arrow_env_vars$ARROW_PRE_0_15_IPC_FORMAT <- 1
+  }
+
+  withr::with_envvar(arrow_env_vars, {
+    # Set the local timezone to any POSIXt columns that don't have one set
+    # https://github.com/sparklyr/sparklyr/issues/2439
+    df[] <- lapply(df, function(x) {
+      if (inherits(x, "POSIXt") && is.null(attr(x, "tzone"))) {
+        attr(x, "tzone") <- Sys.timezone()
+      }
+      x
+    })
+    arrow::write_to_raw(df, format = "stream")
+  })
 }
 
-worker_config_deserialize <- function(raw) {
-  parts <- strsplit(raw, ";")[[1]]
-  list(
-    debug = as.logical(parts[[1]]),
-    sparklyr.gateway.port = as.integer(parts[[2]]),
-    sparklyr.gateway.address = parts[[3]],
-    profile = as.logical(parts[[4]]),
-    schema = as.logical(parts[[5]]),
-    arrow = as.logical(parts[[6]]),
-    fetch_result_as_sdf = as.logical(parts[[7]]),
-    single_binary_column = as.logical(parts[[8]]),
-    spark_read = as.logical(parts[[9]]),
-    spark_version = parts[[10]]
+arrow_record_stream_reader <- function(stream) {
+  arrow::RecordBatchStreamReader$create(stream)
+}
+
+arrow_read_record_batch <- function(reader) reader$read_next_batch()
+
+arrow_as_tibble <- function(record) as.data.frame(record)
+
+#' Find path to Java
+#'
+#' Finds the path to \code{JAVA_HOME}.
+#'
+#' @param throws Throw an error when path not found?
+#'
+#' @export
+#' @keywords internal
+spark_get_java <- function(throws = FALSE) {
+  java_home <- Sys.getenv("JAVA_HOME", unset = NA)
+  if (!is.na(java_home)) {
+    java <- file.path(java_home, "bin", "java")
+    if (identical(.Platform$OS.type, "windows")) {
+      java <- paste0(java, ".exe")
+    }
+    if (!file.exists(java)) {
+      if (throws) {
+        stop(
+          "Java is required to connect to Spark. ",
+          "JAVA_HOME is set to '",
+          java_home,
+          "' but does not point to a valid version. ",
+          "Please fix JAVA_HOME or reinstall from: ",
+          java_install_url()
+        )
+      }
+      java <- ""
+    }
+  } else {
+    java <- Sys.which("java")
+  }
+  java
+}
+
+validate_java_version <- function(master, spark_home) {
+  # if someone sets SPARK_HOME and we are not in local more, assume Java
+  # is available since some systems.
+  # (e.g. CDH) use versions of java not discoverable through JAVA_HOME.
+  if (
+    !spark_master_is_local(master) &&
+      !is.null(spark_home) &&
+      nchar(spark_home) > 0
+  ) {
+    return(TRUE)
+  }
+
+  # find the active java executable
+  java <- spark_get_java(throws = TRUE)
+  if (!nzchar(java)) {
+    stop(
+      "Java is required to connect to Spark. Please download and install Java from ",
+      java_install_url()
+    )
+  }
+
+  # query its version
+  version <- system2(java, "-version", stderr = TRUE, stdout = TRUE)
+  java_version <- validate_java_version_line(master, version)
+
+  spark_version <- spark_version_from_home(spark_home)
+  if (
+    compareVersion(java_version, "11") >= 0 &&
+      compareVersion(spark_version, "3.0.0") < 0
+  ) {
+    stop("Java 11 is only supported for Spark 3.0.0+", call. = FALSE)
+  }
+
+  TRUE
+}
+
+java_is_x64 <- function() {
+  java <- spark_get_java(throws = TRUE)
+  if (!nzchar(java)) {
+    return(FALSE)
+  }
+
+  version <- system2(java, "-version", stderr = TRUE, stdout = TRUE)
+  any(grepl("64-Bit", version))
+}
+
+java_install_url <- function() {
+  "https://www.java.com/en/"
+}
+
+validate_java_version_line <- function(master, version) {
+  if (length(version) < 1) {
+    stop(
+      "Java version not detected. Please download and install Java from ",
+      java_install_url()
+    )
+  }
+
+  # find line with version info
+  versionLine <- version[grepl("version", version)]
+  if (length(versionLine) != 1) {
+    stop(
+      "Java version detected but couldn't parse version from ",
+      paste(version, collapse = " - ")
+    )
+  }
+
+  splatVersion <- if (grepl("openjdk version", versionLine)) {
+    strsplit(versionLine, "\"")[[1]][[2]]
+  } else {
+    splat <- strsplit(versionLine, "\\s+", perl = TRUE)[[1]]
+    #Getting rid of dates when present before parsing version from 'java -version'
+    splat <- splat[!grepl("[0-9]{4}-[0-9]{2}-[0-9]{2}", splat)]
+    splat[grepl("[0-9]{1,2}(\\.[0-9]+\\.[0-9]+)?", splat)]
+  }
+
+  if (length(splatVersion) != 1) {
+    stop("Java version detected but couldn't parse version from: ", versionLine)
+  }
+
+  parsedVersion <- regex_replace(
+    splatVersion,
+    "^\"|\"$" = "",
+    "_" = ".",
+    "[^0-9.]+" = ""
   )
+
+  if (!is.character(parsedVersion) || nchar(parsedVersion) < 1) {
+    stop("Java version detected but couldn't parse version from: ", versionLine)
+  }
+
+  # ensure Java 1.7 or higher
+  if (compareVersion(parsedVersion, "1.7") == -1) {
+    stop(
+      "Java version",
+      parsedVersion,
+      " detected but 1.7+ is required. Please download and install Java from ",
+      java_install_url()
+    )
+  }
+
+  if (
+    compareVersion(parsedVersion, "1.9") >= 0 &&
+      compareVersion(parsedVersion, "11") == -1 &&
+      spark_master_is_local(master) &&
+      !getOption("sparklyr.java9", FALSE)
+  ) {
+    stop(
+      "Java 9 is currently unsupported in Spark distributions unless you manually install Hadoop 2.8 ",
+      "and manually configure Spark. Please consider uninstalling Java 9 and reinstalling Java 8. ",
+      "To override this failure set 'options(sparklyr.java9 = TRUE)'."
+    )
+  }
+
+  parsedVersion
 }
 # nocov start
 
@@ -2097,197 +2434,6 @@ worker_spark_apply_unbundle <- function(bundle_path, base_path, bundle_name) {
 # nocov end
 # nocov start
 
-spark_worker_connect <- function(
-  sessionId,
-  backendPort = 8880,
-  config = list()
-) {
-  gatewayPort <- spark_config_value(
-    config,
-    "sparklyr.worker.gateway.port",
-    backendPort
-  )
-
-  gatewayAddress <- spark_config_value(
-    config,
-    "sparklyr.worker.gateway.address",
-    "localhost"
-  )
-  config <- list()
-
-  worker_log("is connecting to backend using port ", gatewayPort)
-
-  gatewayInfo <- spark_connect_gateway(
-    gatewayAddress,
-    gatewayPort,
-    sessionId,
-    config = config,
-    isStarting = TRUE
-  )
-
-  worker_log("is connected to backend")
-  worker_log("is connecting to backend session")
-
-  tryCatch(
-    {
-      interval <- spark_config_value(config, "sparklyr.backend.interval", 1)
-
-      backend <- socketConnection(
-        host = "localhost",
-        port = gatewayInfo$backendPort,
-        server = FALSE,
-        blocking = interval > 0,
-        open = "wb",
-        timeout = interval
-      )
-
-      class(backend) <- c(class(backend), "shell_backend")
-    },
-    error = function(err) {
-      close(gatewayInfo$gateway)
-
-      stop(
-        "Failed to open connection to backend:",
-        err$message
-      )
-    }
-  )
-
-  worker_log("is connected to backend session")
-
-  sc <- structure(
-    class = c("spark_worker_connection"),
-    list(
-      # spark_connection
-      master = "",
-      method = "shell",
-      app_name = NULL,
-      config = NULL,
-      state = new.env(),
-      # spark_shell_connection
-      spark_home = NULL,
-      backend = backend,
-      gateway = gatewayInfo$gateway,
-      output_file = NULL
-    )
-  )
-
-  worker_log("created connection")
-
-  sc
-}
-
-# nocov end
-# nocov start
-#' @export
-connection_is_open.spark_worker_connection <- function(sc) {
-  bothOpen <- FALSE
-  if (!identical(sc, NULL)) {
-    tryCatch(
-      {
-        bothOpen <- isOpen(sc$backend) && isOpen(sc$gateway)
-      },
-      error = function(e) {}
-    )
-  }
-  bothOpen
-}
-
-worker_connection <- function(x, ...) {
-  UseMethod("worker_connection")
-}
-
-worker_connection.spark_jobj <- function(x, ...) {
-  x$connection
-}
-
-# nocov end
-# nocov start
-
-worker_invoke_method <- function(sc, static, object, method, ...) {
-  core_invoke_method(sc, static, object, method, FALSE, ...)
-}
-
-worker_invoke <- function(jobj, method, ...) {
-  UseMethod("worker_invoke")
-}
-
-#' @export
-worker_invoke.shell_jobj <- function(jobj, method, ...) {
-  worker_invoke_method(worker_connection(jobj), FALSE, jobj, method, ...)
-}
-
-worker_invoke_static <- function(sc, class, method, ...) {
-  worker_invoke_method(sc, TRUE, class, method, ...)
-}
-
-worker_invoke_new <- function(sc, class, ...) {
-  worker_invoke_method(sc, TRUE, class, "<init>", ...)
-}
-
-# nocov end
-# nocov start
-
-worker_log_env <- new.env()
-
-worker_log_session <- function(sessionId) {
-  assign("sessionId", sessionId, envir = worker_log_env)
-}
-
-worker_log_format <- function(
-  message,
-  session,
-  level = "INFO",
-  component = "RScript"
-) {
-  paste(
-    format(Sys.time(), "%y/%m/%d %H:%M:%S"),
-    " ",
-    level,
-    " sparklyr: ",
-    component,
-    " (",
-    session,
-    ") ",
-    message,
-    sep = ""
-  )
-}
-
-worker_log_level <- function(..., level, component = "RScript") {
-  if (is.null(worker_log_env$sessionId)) {
-    worker_log_env <- get0("worker_log_env", envir = .GlobalEnv)
-    if (is.null(worker_log_env$sessionId)) {
-      return()
-    }
-  }
-
-  args <- list(...)
-  message <- paste(args, sep = "", collapse = "")
-  formatted <- worker_log_format(
-    message,
-    worker_log_env$sessionId,
-    level = level,
-    component = component
-  )
-  cat(formatted, "\n")
-}
-
-worker_log <- function(...) {
-  worker_log_level(..., level = "INFO")
-}
-
-worker_log_warning <- function(...) {
-  worker_log_level(..., level = "WARN")
-}
-
-worker_log_error <- function(...) {
-  worker_log_level(..., level = "ERROR")
-}
-
-# nocov end
-# nocov start
-
 .worker_globals <- new.env(parent = emptyenv())
 
 spark_worker_main <- function(
@@ -2389,6 +2535,201 @@ spark_worker_hooks <- function() {
     as.environment("package:base")
   )
   lock("stop", as.environment("package:base"))
+}
+
+# nocov end
+
+# nocov start
+
+worker_log_env <- new.env()
+
+worker_log_session <- function(sessionId) {
+  assign("sessionId", sessionId, envir = worker_log_env)
+}
+
+worker_log_format <- function(
+  message,
+  session,
+  level = "INFO",
+  component = "RScript"
+) {
+  paste(
+    format(Sys.time(), "%y/%m/%d %H:%M:%S"),
+    " ",
+    level,
+    " sparklyr: ",
+    component,
+    " (",
+    session,
+    ") ",
+    message,
+    sep = ""
+  )
+}
+
+worker_log_level <- function(..., level, component = "RScript") {
+  if (is.null(worker_log_env$sessionId)) {
+    worker_log_env <- get0("worker_log_env", envir = .GlobalEnv)
+    if (is.null(worker_log_env$sessionId)) {
+      return()
+    }
+  }
+
+  args <- list(...)
+  message <- paste(args, sep = "", collapse = "")
+  formatted <- worker_log_format(
+    message,
+    worker_log_env$sessionId,
+    level = level,
+    component = component
+  )
+  cat(formatted, "\n")
+}
+
+worker_log <- function(...) {
+  worker_log_level(..., level = "INFO")
+}
+
+worker_log_warning <- function(...) {
+  worker_log_level(..., level = "WARN")
+}
+
+worker_log_error <- function(...) {
+  worker_log_level(..., level = "ERROR")
+}
+
+# nocov end
+
+# nocov start
+#' @export
+connection_is_open.spark_worker_connection <- function(sc) {
+  bothOpen <- FALSE
+  if (!identical(sc, NULL)) {
+    tryCatch(
+      {
+        bothOpen <- isOpen(sc$backend) && isOpen(sc$gateway)
+      },
+      error = function(e) {}
+    )
+  }
+  bothOpen
+}
+
+worker_connection <- function(x, ...) {
+  UseMethod("worker_connection")
+}
+
+worker_connection.spark_jobj <- function(x, ...) {
+  x$connection
+}
+
+# nocov end
+
+# nocov start
+
+spark_worker_connect <- function(
+  sessionId,
+  backendPort = 8880,
+  config = list()
+) {
+  gatewayPort <- spark_config_value(
+    config,
+    "sparklyr.worker.gateway.port",
+    backendPort
+  )
+
+  gatewayAddress <- spark_config_value(
+    config,
+    "sparklyr.worker.gateway.address",
+    "localhost"
+  )
+  config <- list()
+
+  worker_log("is connecting to backend using port ", gatewayPort)
+
+  gatewayInfo <- spark_connect_gateway(
+    gatewayAddress,
+    gatewayPort,
+    sessionId,
+    config = config,
+    isStarting = TRUE
+  )
+
+  worker_log("is connected to backend")
+  worker_log("is connecting to backend session")
+
+  tryCatch(
+    {
+      interval <- spark_config_value(config, "sparklyr.backend.interval", 1)
+
+      backend <- socketConnection(
+        host = "localhost",
+        port = gatewayInfo$backendPort,
+        server = FALSE,
+        blocking = interval > 0,
+        open = "wb",
+        timeout = interval
+      )
+
+      class(backend) <- c(class(backend), "shell_backend")
+    },
+    error = function(err) {
+      close(gatewayInfo$gateway)
+
+      stop(
+        "Failed to open connection to backend:",
+        err$message
+      )
+    }
+  )
+
+  worker_log("is connected to backend session")
+
+  sc <- structure(
+    class = c("spark_worker_connection"),
+    list(
+      # spark_connection
+      master = "",
+      method = "shell",
+      app_name = NULL,
+      config = NULL,
+      state = new.env(),
+      # spark_shell_connection
+      spark_home = NULL,
+      backend = backend,
+      gateway = gatewayInfo$gateway,
+      output_file = NULL
+    )
+  )
+
+  worker_log("created connection")
+
+  sc
+}
+
+# nocov end
+
+# nocov start
+
+worker_invoke_method <- function(sc, static, object, method, ...) {
+  core_invoke_method(sc, static, object, method, FALSE, ...)
+}
+
+worker_invoke <- function(jobj, method, ...) {
+  UseMethod("worker_invoke")
+}
+
+#' @export
+worker_invoke.shell_jobj <- function(jobj, method, ...) {
+  worker_invoke_method(worker_connection(jobj), FALSE, jobj, method, ...)
+}
+
+worker_invoke_static <- function(sc, class, method, ...) {
+  worker_invoke_method(sc, TRUE, class, method, ...)
+}
+
+worker_invoke_new <- function(sc, class, ...) {
+  worker_invoke_method(sc, TRUE, class, "<init>", ...)
 }
 
 # nocov end

--- a/java/embedded_sources.R
+++ b/java/embedded_sources.R
@@ -36,11 +36,20 @@ arrow_as_tibble <- function(record) as.data.frame(record)
 #' @keywords internal
 #' @export
 spark_config_value <- function(config, name, default = NULL) {
-  if (getOption("sparklyr.test.enforce.config", FALSE) && any(grepl("^sparklyr.", name))) {
+  if (
+    getOption("sparklyr.test.enforce.config", FALSE) &&
+      any(grepl("^sparklyr.", name))
+  ) {
     settings <- get("spark_config_settings")()
-    if (!any(name %in% settings$name) &&
-      !grepl("^sparklyr\\.shell\\.", name)) {
-      stop("Config value '", name[[1]], "' not described in spark_config_settings()")
+    if (
+      !any(name %in% settings$name) &&
+        !grepl("^sparklyr\\.shell\\.", name)
+    ) {
+      stop(
+        "Config value '",
+        name[[1]],
+        "' not described in spark_config_settings()"
+      )
     }
   }
 
@@ -58,8 +67,12 @@ spark_config_value <- function(config, name, default = NULL) {
     value <- config[[name_primary]]
   }
 
-  if (is.language(value)) value <- rlang::as_closure(value)
-  if (is.function(value)) value <- value()
+  if (is.language(value)) {
+    value <- rlang::as_closure(value)
+  }
+  if (is.function(value)) {
+    value <- value()
+  }
   value
 }
 
@@ -86,17 +99,37 @@ read_bin <- function(con, what, n, endian = NULL) {
 
 #' @export
 read_bin.default <- function(con, what, n, endian = NULL) {
-  if (is.null(endian)) readBin(con, what, n) else readBin(con, what, n, endian = endian)
+  if (is.null(endian)) {
+    readBin(con, what, n)
+  } else {
+    readBin(con, what, n, endian = endian)
+  }
 }
 
 read_bin_wait <- function(con, what, n, endian = NULL) {
   sc <- con
-  con <- if (!is.null(sc$state) && identical(sc$state$use_monitoring, TRUE)) sc$monitoring else sc$backend
+  con <- if (!is.null(sc$state) && identical(sc$state$use_monitoring, TRUE)) {
+    sc$monitoring
+  } else {
+    sc$backend
+  }
 
-  timeout <- spark_config_value(sc$config, "sparklyr.backend.timeout", 30 * 24 * 60 * 60)
-  progressInterval <- spark_config_value(sc$config, "sparklyr.progress.interval", 3)
+  timeout <- spark_config_value(
+    sc$config,
+    "sparklyr.backend.timeout",
+    30 * 24 * 60 * 60
+  )
+  progressInterval <- spark_config_value(
+    sc$config,
+    "sparklyr.progress.interval",
+    3
+  )
 
-  result <- if (is.null(endian)) readBin(con, what, n) else readBin(con, what, n, endian = endian)
+  result <- if (is.null(endian)) {
+    readBin(con, what, n)
+  } else {
+    readBin(con, what, n, endian = endian)
+  }
 
   progressTimeout <- Sys.time() + progressInterval
   if (is.null(sc$state$progress)) {
@@ -110,7 +143,11 @@ read_bin_wait <- function(con, what, n, endian = NULL) {
     Sys.sleep(waitInterval)
     waitInterval <- min(0.1, waitInterval + 0.01)
 
-    result <- if (is.null(endian)) readBin(con, what, n) else readBin(con, what, n, endian = endian)
+    result <- if (is.null(endian)) {
+      readBin(con, what, n)
+    } else {
+      readBin(con, what, n, endian = endian)
+    }
 
     if (Sys.time() > progressTimeout) {
       progressTimeout <- Sys.time() + progressInterval
@@ -121,10 +158,14 @@ read_bin_wait <- function(con, what, n, endian = NULL) {
     }
   }
 
-  if (progressUpdated) connection_progress_terminated(sc)
+  if (progressUpdated) {
+    connection_progress_terminated(sc)
+  }
 
   if (commandStart + timeout <= Sys.time()) {
-    stop("Operation timed out, increase config option sparklyr.backend.timeout if needed.")
+    stop(
+      "Operation timed out, increase config option sparklyr.backend.timeout if needed."
+    )
   }
 
   result
@@ -151,7 +192,8 @@ readObject <- function(con) {
 }
 
 readTypedObject <- function(con, type) {
-  switch(type,
+  switch(
+    type,
     "i" = readInt(con),
     "c" = readString(con),
     "b" = readBoolean(con),
@@ -168,7 +210,8 @@ readTypedObject <- function(con, type) {
     "j" = getJobj(con, readString(con)),
     "J" = jsonlite::fromJSON(
       readString(con),
-      simplifyDataFrame = FALSE, simplifyMatrix = FALSE
+      simplifyDataFrame = FALSE,
+      simplifyMatrix = FALSE
     ),
     stop(paste("Unsupported type for deserialization", type))
   )
@@ -177,20 +220,18 @@ readTypedObject <- function(con, type) {
 readString <- function(con) {
   stringLen <- readInt(con)
 
-  string <- (
-    if (stringLen > 0) {
-      raw <- read_bin(con, raw(), stringLen, endian = "big")
-      if (is.element("00", raw)) {
-        warning("Input contains embedded nuls, removing.")
-        raw <- raw[raw != "00"]
-      }
-      rawToChar(raw)
-    } else if (stringLen == 0) {
-      ""
-    } else {
-      NA_character_
+  string <- (if (stringLen > 0) {
+    raw <- read_bin(con, raw(), stringLen, endian = "big")
+    if (is.element("00", raw)) {
+      warning("Input contains embedded nuls, removing.")
+      raw <- raw[raw != "00"]
     }
-  )
+    rawToChar(raw)
+  } else if (stringLen == 0) {
+    ""
+  } else {
+    NA_character_
+  })
 
   Encoding(string) <- "UTF-8"
   string
@@ -367,7 +408,12 @@ sparklyr_gateway_trouble_shooting_msg <- function() {
   )
 }
 
-wait_connect_gateway <- function(gatewayAddress, gatewayPort, config, isStarting) {
+wait_connect_gateway <- function(
+  gatewayAddress,
+  gatewayPort,
+  config,
+  isStarting
+) {
   waitSeconds <- if (isStarting) {
     spark_config_value(config, "sparklyr.connect.timeout", 60)
   } else {
@@ -392,8 +438,7 @@ wait_connect_gateway <- function(gatewayAddress, gatewayPort, config, isStarting
           )
         })
       },
-      error = function(err) {
-      }
+      error = function(err) {}
     )
 
     startWait <- spark_config_value(config, "sparklyr.gateway.wait", 50 / 1000)
@@ -425,7 +470,9 @@ query_gateway_for_port <- function(gateway, sessionId, config, isStarting) {
   redirectGatewayPort <- NULL
 
   commandStart <- Sys.time()
-  while (length(backendSessionId) == 0 && commandStart + waitSeconds > Sys.time()) {
+  while (
+    length(backendSessionId) == 0 && commandStart + waitSeconds > Sys.time()
+  ) {
     backendSessionId <- readInt(gateway)
     Sys.sleep(0.1)
   }
@@ -433,7 +480,11 @@ query_gateway_for_port <- function(gateway, sessionId, config, isStarting) {
   redirectGatewayPort <- readInt(gateway)
   backendPort <- readInt(gateway)
 
-  if (length(backendSessionId) == 0 || length(redirectGatewayPort) == 0 || length(backendPort) == 0) {
+  if (
+    length(backendSessionId) == 0 ||
+      length(redirectGatewayPort) == 0 ||
+      length(backendPort) == 0
+  ) {
     if (isStarting) {
       stop(
         "Sparklyr gateway did not respond while retrieving ports information after ",
@@ -454,33 +505,45 @@ query_gateway_for_port <- function(gateway, sessionId, config, isStarting) {
 }
 
 spark_connect_gateway <- function(
-                                  gatewayAddress,
-                                  gatewayPort,
-                                  sessionId,
-                                  config,
-                                  isStarting = FALSE) {
-
+  gatewayAddress,
+  gatewayPort,
+  sessionId,
+  config,
+  isStarting = FALSE
+) {
   # try connecting to existing gateway
-  gateway <- wait_connect_gateway(gatewayAddress, gatewayPort, config, isStarting)
+  gateway <- wait_connect_gateway(
+    gatewayAddress,
+    gatewayPort,
+    config,
+    isStarting
+  )
 
   if (is.null(gateway)) {
     if (isStarting) {
       stop(
-        "Gateway in ", gatewayAddress, ":", gatewayPort, " did not respond.",
+        "Gateway in ",
+        gatewayAddress,
+        ":",
+        gatewayPort,
+        " did not respond.",
         sparklyr_gateway_trouble_shooting_msg()
       )
     }
 
     NULL
-  }
-  else {
+  } else {
     worker_log("is querying ports from backend using port ", gatewayPort)
 
     gateway_ports_query_attempts <- as.integer(
       spark_config_value(config, "sparklyr.gateway.port.query.attempts", 3L)
     )
     gateway_ports_query_retry_interval_s <- as.integer(
-      spark_config_value(config, "sparklyr.gateway.port.query.retry.interval.seconds", 4L)
+      spark_config_value(
+        config,
+        "sparklyr.gateway.port.query.retry.interval.seconds",
+        4L
+      )
     )
     while (gateway_ports_query_attempts > 0) {
       gateway_ports_query_attempts <- gateway_ports_query_attempts - 1
@@ -517,16 +580,27 @@ spark_connect_gateway <- function(
       close(gateway)
 
       if (isStarting) {
-        stop("Gateway in ", gatewayAddress, ":", gatewayPort, " does not have the requested session registered")
+        stop(
+          "Gateway in ",
+          gatewayAddress,
+          ":",
+          gatewayPort,
+          " does not have the requested session registered"
+        )
       }
 
       NULL
     } else if (redirectGatewayPort != gatewayPort) {
       close(gateway)
 
-      spark_connect_gateway(gatewayAddress, redirectGatewayPort, sessionId, config, isStarting)
-    }
-    else {
+      spark_connect_gateway(
+        gatewayAddress,
+        redirectGatewayPort,
+        sessionId,
+        config,
+        isStarting
+      )
+    } else {
       list(
         gateway = gateway,
         backendPort = backendPort
@@ -574,10 +648,19 @@ core_invoke_cancel_running <- function(sc) {
     invoke(spark_context(sc), "cancelAllJobs")
   })
 
-  if (exists("connection_progress_terminated")) connection_progress_terminated(sc)
+  if (exists("connection_progress_terminated")) {
+    connection_progress_terminated(sc)
+  }
 }
 
-write_bin_args <- function(backend, object, static, method, args, return_jobj_ref = FALSE) {
+write_bin_args <- function(
+  backend,
+  object,
+  static,
+  method,
+  args,
+  return_jobj_ref = FALSE
+) {
   rc <- rawConnection(raw(), "r+")
   writeString(rc, object)
   writeBoolean(rc, static)
@@ -635,14 +718,45 @@ core_invoke_socket_name <- function(sc) {
 }
 
 core_remove_jobjs <- function(sc, ids) {
-  core_invoke_method_impl(sc, static = TRUE, noreply = TRUE, "Handler", "rm", FALSE, as.list(ids))
+  core_invoke_method_impl(
+    sc,
+    static = TRUE,
+    noreply = TRUE,
+    "Handler",
+    "rm",
+    FALSE,
+    as.list(ids)
+  )
 }
 
-core_invoke_method <- function(sc, static, object, method, return_jobj_ref, ...) {
-  core_invoke_method_impl(sc, static, noreply = FALSE, object, method, return_jobj_ref, ...)
+core_invoke_method <- function(
+  sc,
+  static,
+  object,
+  method,
+  return_jobj_ref,
+  ...
+) {
+  core_invoke_method_impl(
+    sc,
+    static,
+    noreply = FALSE,
+    object,
+    method,
+    return_jobj_ref,
+    ...
+  )
 }
 
-core_invoke_method_impl <- function(sc, static, noreply, object, method, return_jobj_ref, ...) {
+core_invoke_method_impl <- function(
+  sc,
+  static,
+  noreply,
+  object,
+  method,
+  return_jobj_ref,
+  ...
+) {
   # N.B.: the reference to `object` must be retained until after a value or exception is returned to us
   # from the invoked method here (i.e., cannot have `object <- something_else` before that), because any
   # re-assignment could cause the last reference to `object` to be destroyed and the underlying JVM object
@@ -673,8 +787,14 @@ core_invoke_method_impl <- function(sc, static, noreply, object, method, return_
     }
   }
 
-  if (!identical(object, "Handler") &&
-    spark_config_value(sc$config, c("sparklyr.cancellable", "sparklyr.connection.cancellable"), TRUE)) {
+  if (
+    !identical(object, "Handler") &&
+      spark_config_value(
+        sc$config,
+        c("sparklyr.cancellable", "sparklyr.connection.cancellable"),
+        TRUE
+      )
+  ) {
     # if connection still running, sync to valid state
     if (identical(sc$state$status[[connection_name]], "running")) {
       core_invoke_sync(sc)
@@ -691,8 +811,11 @@ core_invoke_method_impl <- function(sc, static, noreply, object, method, return_
 
   write_bin_args(backend, objId, static, method, args, return_jobj_ref)
 
-  if (identical(object, "Handler") &&
-    (identical(method, "terminateBackend") || identical(method, "stopBackend"))) {
+  if (
+    identical(object, "Handler") &&
+      (identical(method, "terminateBackend") ||
+        identical(method, "stopBackend"))
+  ) {
     # by the time we read response, backend might be already down.
     return(NULL)
   }
@@ -706,30 +829,36 @@ core_invoke_method_impl <- function(sc, static, noreply, object, method, return_
       # read the spark log
       msg <- core_read_spark_log_error(sc)
 
-      withr::with_options(list(
-        warning.length = 8000
-      ), {
-        stop(
-          "Unexpected state in sparklyr backend: ",
-          msg,
-          call. = FALSE
-        )
-      })
+      withr::with_options(
+        list(
+          warning.length = 8000
+        ),
+        {
+          stop(
+            "Unexpected state in sparklyr backend: ",
+            msg,
+            call. = FALSE
+          )
+        }
+      )
     }
 
     if (returnStatus != 0) {
       # get error message from backend and report to R
       msg <- readString(sc)
-      withr::with_options(list(
-        warning.length = 8000
-      ), {
-        if (nzchar(msg)) {
-          core_handle_known_errors(sc, msg)
-        } else {
-          # read the spark log
-          msg <- core_read_spark_log_error(sc)
+      withr::with_options(
+        list(
+          warning.length = 8000
+        ),
+        {
+          if (nzchar(msg)) {
+            core_handle_known_errors(sc, msg)
+          } else {
+            # read the spark log
+            msg <- core_read_spark_log_error(sc)
+          }
         }
-      })
+      )
       spark_error(msg)
     }
 
@@ -765,11 +894,16 @@ core_handle_known_errors <- function(sc, msg) {
       "Failed to retrieve localhost, please validate that the hostname is correctly mapped. ",
       "Consider running `hostname` and adding that entry to your `/etc/hosts` file."
     )
-  } else if (grepl("check worker logs for details", msg, ignore.case = TRUE) &&
-    spark_master_is_local(sc$master)) {
+  } else if (
+    grepl("check worker logs for details", msg, ignore.case = TRUE) &&
+      spark_master_is_local(sc$master)
+  ) {
     abort_shell(
       "sparklyr worker rscript failure, check worker logs for details",
-      NULL, NULL, sc$output_file, sc$error_file
+      NULL,
+      NULL,
+      sc$output_file,
+      sc$error_file
     )
   }
 }
@@ -830,14 +964,25 @@ spark_error <- function(message) {
     }
 
     msg_fun <- paste0(
-      msg_l, scheme, ":", msg_fn, msg_r, "`", msg_fn, "`", msg_l, msg_r
+      msg_l,
+      scheme,
+      ":",
+      msg_fn,
+      msg_r,
+      "`",
+      msg_fn,
+      "`",
+      msg_l,
+      msg_r
     )
   } else {
     msg_fun <- paste0("`", msg_fn, "`")
   }
 
   last_err <- paste0(
-    "Run ", msg_fun, " to see the full Spark error (multiple lines)"
+    "Run ",
+    msg_fun,
+    " to see the full Spark error (multiple lines)"
   )
 
   option_msg <- paste(
@@ -890,7 +1035,8 @@ spark_jobj_id <- function(x) {
 
 #' @export
 spark_jobj.default <- function(x, ...) {
-  stop("Unable to retrieve a spark_jobj from object of class ",
+  stop(
+    "Unable to retrieve a spark_jobj from object of class ",
     paste(class(x), collapse = " "),
     call. = FALSE
   )
@@ -934,7 +1080,8 @@ get_to_remove_jobjs <- function(con) {
 
 # Check if jobj points to a valid external JVM object
 isValidJobj <- function(jobj) {
-  exists("connection", jobj) && exists(jobj$id, get_valid_jobjs(jobj$connection))
+  exists("connection", jobj) &&
+    exists(jobj$id, get_valid_jobjs(jobj$connection))
 }
 
 getJobj <- function(con, objId) {
@@ -956,7 +1103,10 @@ jobj_create <- function(con, objId) {
   }
   # NOTE: We need a new env for a jobj as we can only register
   # finalizers for environments or external references pointers.
-  obj <- structure(new.env(parent = emptyenv()), class = c("spark_jobj", jobj_subclass(con)))
+  obj <- structure(
+    new.env(parent = emptyenv()),
+    class = c("spark_jobj", jobj_subclass(con))
+  )
   obj$id <- objId
 
   # Register a finalizer to remove the Java object when this reference
@@ -980,15 +1130,13 @@ jobj_info <- function(jobj) {
         class <- invoke(class, "getName")
       }
     },
-    error = function(e) {
-    }
+    error = function(e) {}
   )
   tryCatch(
     {
       repr <- invoke(jobj, "toString")
     },
-    error = function(e) {
-    }
+    error = function(e) {}
   )
   list(
     class = class,
@@ -1052,13 +1200,11 @@ clear_jobjs <- function() {
 attach_connection <- function(jobj, connection) {
   if (inherits(jobj, "spark_jobj")) {
     jobj$connection <- connection
-  }
-  else if (is.list(jobj) || inherits(jobj, "struct")) {
+  } else if (is.list(jobj) || inherits(jobj, "struct")) {
     jobj <- lapply(jobj, function(e) {
       attach_connection(e, connection)
     })
-  }
-  else if (is.environment(jobj)) {
+  } else if (is.environment(jobj)) {
     jobj <- eapply(jobj, function(e) {
       attach_connection(e, connection)
     })
@@ -1096,7 +1242,6 @@ getSerdeType <- function(object) {
       getSerdeType(elem)
     }))
     if (length(elemType) <= 1) {
-
       # Check that there are no NAs in arrays since they are unsupported in scala
       hasNAs <- any(is.na(object))
 
@@ -1114,7 +1259,19 @@ getSerdeType <- function(object) {
 writeObject <- function(con, object, writeType = TRUE) {
   type <- class(object)[[1]]
 
-  if (type %in% c("integer", "character", "logical", "double", "numeric", "factor", "Date", "POSIXct")) {
+  if (
+    type %in%
+      c(
+        "integer",
+        "character",
+        "logical",
+        "double",
+        "numeric",
+        "factor",
+        "Date",
+        "POSIXct"
+      )
+  ) {
     if (is.na(object) && !is.nan(object)) {
       object <- NULL
       type <- "NULL"
@@ -1125,7 +1282,8 @@ writeObject <- function(con, object, writeType = TRUE) {
   if (writeType) {
     writeType(con, serdeType)
   }
-  switch(serdeType,
+  switch(
+    serdeType,
     NULL = writeVoid(con),
     integer = writeInt(con, object),
     character = writeString(con, object),
@@ -1184,7 +1342,8 @@ writeRaw <- function(con, batch) {
 }
 
 writeType <- function(con, class) {
-  type <- switch(class,
+  type <- switch(
+    class,
     NULL = "n",
     integer = "i",
     character = "c",
@@ -1273,8 +1432,11 @@ writeArgs <- function(con, args) {
   }
 }
 core_get_package_function <- function(packageName, functionName) {
-  if (packageName %in% rownames(installed.packages()) &&
-    exists(functionName, envir = asNamespace(packageName))) {
+  if (
+    packageName %in%
+      rownames(installed.packages()) &&
+      exists(functionName, envir = asNamespace(packageName))
+  ) {
     get(functionName, envir = asNamespace(packageName))
   } else {
     NULL
@@ -1335,7 +1497,11 @@ spark_worker_init_packages <- function(sc, context) {
     bundleName <- basename(bundlePath)
     worker_log("using bundle name ", bundleName)
 
-    workerRootDir <- worker_invoke_static(sc, "org.apache.spark.SparkFiles", "getRootDirectory")
+    workerRootDir <- worker_invoke_static(
+      sc,
+      "org.apache.spark.SparkFiles",
+      "getRootDirectory"
+    )
     sparkBundlePath <- file.path(workerRootDir, bundleName)
 
     worker_log("using bundle path ", normalizePath(sparkBundlePath))
@@ -1352,10 +1518,14 @@ spark_worker_init_packages <- function(sc, context) {
 
     .libPaths(unbundlePath)
     worker_log("updated .libPaths with bundle packages")
-  }
-  else {
+  } else {
     spark_env <- worker_invoke_static(sc, "org.apache.spark.SparkEnv", "get")
-    spark_libpaths <- worker_invoke(worker_invoke(spark_env, "conf"), "get", "spark.r.libpaths", NULL)
+    spark_libpaths <- worker_invoke(
+      worker_invoke(spark_env, "conf"),
+      "get",
+      "spark.r.libpaths",
+      NULL
+    )
     if (!is.null(spark_libpaths)) {
       spark_libpaths <- unlist(strsplit(spark_libpaths, split = ","))
       .libPaths(spark_libpaths)
@@ -1364,14 +1534,15 @@ spark_worker_init_packages <- function(sc, context) {
 }
 
 spark_worker_execute_closure <- function(
-                                         sc,
-                                         closure,
-                                         df,
-                                         funcContext,
-                                         grouped_by,
-                                         barrier_map,
-                                         fetch_result_as_sdf,
-                                         partition_index) {
+  sc,
+  closure,
+  df,
+  funcContext,
+  grouped_by,
+  barrier_map,
+  fetch_result_as_sdf,
+  partition_index
+) {
   if (nrow(df) == 0) {
     worker_log("found that source has no rows to be proceesed")
     return(NULL)
@@ -1384,14 +1555,18 @@ spark_worker_execute_closure <- function(
     barrier_arg <- list(barrier = barrier_map)
   }
   closure_params <- length(formals(closure))
-  has_partition_index_param <- (
-    !is.null(funcContext$partition_index_param) &&
-      nchar(funcContext$partition_index_param) > 0
-  )
-  if (has_partition_index_param) closure_params <- closure_params - 1
+  has_partition_index_param <- (!is.null(funcContext$partition_index_param) &&
+    nchar(funcContext$partition_index_param) > 0)
+  if (has_partition_index_param) {
+    closure_params <- closure_params - 1
+  }
   closure_args <- c(
     list(df),
-    if (!is.null(funcContext$user_context)) list(funcContext$user_context) else NULL,
+    if (!is.null(funcContext$user_context)) {
+      list(funcContext$user_context)
+    } else {
+      NULL
+    },
     lapply(grouped_by, function(group_by_name) df[[group_by_name]][[1]]),
     barrier_arg
   )[0:closure_params]
@@ -1421,16 +1596,21 @@ spark_worker_execute_closure <- function(
 
 spark_worker_clean_factors <- function(result) {
   if (any(sapply(result, is.factor))) {
-    result <- as.data.frame(lapply(result, function(x) if (is.factor(x)) as.character(x) else x), stringsAsFactors = FALSE)
+    result <- as.data.frame(
+      lapply(result, function(x) if (is.factor(x)) as.character(x) else x),
+      stringsAsFactors = FALSE
+    )
   }
 
   result
 }
 
 spark_worker_maybe_serialize_list_cols_as_json <- function(config, result) {
-  if (identical(config$fetch_result_as_sdf, TRUE) &&
-    config$spark_version >= "2.4.0" &&
-    any(sapply(result, is.list))) {
+  if (
+    identical(config$fetch_result_as_sdf, TRUE) &&
+      config$spark_version >= "2.4.0" &&
+      any(sapply(result, is.list))
+  ) {
     result <- do.call(
       dplyr::tibble,
       lapply(
@@ -1499,22 +1679,27 @@ spark_worker_build_types <- function(context, columns) {
 
 spark_worker_get_group_batch <- function(batch) {
   worker_invoke(
-    batch, "get", 0L
+    batch,
+    "get",
+    0L
   )
 }
 
 spark_worker_add_group_by_column <- function(df, result, grouped, grouped_by) {
   if (grouped) {
     if (nrow(result) > 0) {
-      new_column_values <- lapply(grouped_by, function(grouped_by_name) df[[grouped_by_name]][[1]])
+      new_column_values <- lapply(grouped_by, function(grouped_by_name) {
+        df[[grouped_by_name]][[1]]
+      })
       names(new_column_values) <- grouped_by
 
-      if ("AsIs" %in% class(result)) class(result) <- class(result)[-match("AsIs", class(result))]
+      if ("AsIs" %in% class(result)) {
+        class(result) <- class(result)[-match("AsIs", class(result))]
+      }
       result <- do.call("cbind", list(new_column_values, result))
 
       names(result) <- gsub("\\.", "_", make.unique(names(result)))
-    }
-    else {
+    } else {
       result <- NULL
     }
   }
@@ -1559,7 +1744,9 @@ spark_worker_apply_arrow <- function(sc, config) {
   if (grouped) {
     record_batch_raw_groups <- worker_invoke(context, "getSourceArray")
     record_batch_raw_groups_idx <- 1
-    record_batch_raw <- spark_worker_get_group_batch(record_batch_raw_groups[[record_batch_raw_groups_idx]])
+    record_batch_raw <- spark_worker_get_group_batch(record_batch_raw_groups[[
+      record_batch_raw_groups_idx
+    ]])
   } else {
     row_iterator <- worker_invoke(context, "getIterator")
     arrow_converters_impl <- get_arrow_converters_impl(context, config)
@@ -1603,7 +1790,12 @@ spark_worker_apply_arrow <- function(sc, config) {
         partition_index
       )
 
-      result <- spark_worker_add_group_by_column(df, result, grouped, grouped_by)
+      result <- spark_worker_add_group_by_column(
+        df,
+        result,
+        grouped,
+        grouped_by
+      )
 
       result <- spark_worker_clean_factors(result)
 
@@ -1614,7 +1806,10 @@ spark_worker_apply_arrow <- function(sc, config) {
 
     if (!is.null(result)) {
       if (is.null(schema_output)) {
-        schema_output <- spark_worker_build_types(context, lapply(result, class))
+        schema_output <- spark_worker_build_types(
+          context,
+          lapply(result, class)
+        )
       }
       raw_batch <- arrow_write_record_batch(result, config$spark_version)
 
@@ -1624,9 +1819,15 @@ spark_worker_apply_arrow <- function(sc, config) {
 
     record_entry <- arrow_read_record_batch(reader)
 
-    if (grouped && is.null(record_entry) && record_batch_raw_groups_idx < length(record_batch_raw_groups)) {
+    if (
+      grouped &&
+        is.null(record_entry) &&
+        record_batch_raw_groups_idx < length(record_batch_raw_groups)
+    ) {
       record_batch_raw_groups_idx <- record_batch_raw_groups_idx + 1
-      record_batch_raw <- spark_worker_get_group_batch(record_batch_raw_groups[[record_batch_raw_groups_idx]])
+      record_batch_raw <- spark_worker_get_group_batch(record_batch_raw_groups[[
+        record_batch_raw_groups_idx
+      ]])
 
       reader <- arrow_record_stream_reader(record_batch_raw)
       record_entry <- arrow_read_record_batch(reader)
@@ -1634,13 +1835,30 @@ spark_worker_apply_arrow <- function(sc, config) {
   }
 
   if (length(all_batches) > 0) {
-    worker_log("updating ", total_rows, " rows using ", length(all_batches), " row batches")
+    worker_log(
+      "updating ",
+      total_rows,
+      " rows using ",
+      length(all_batches),
+      " row batches"
+    )
 
     arrow_converters <- get_arrow_converters(context, config)
-    row_iter <- worker_invoke(arrow_converters, "fromPayloadArray", all_batches, schema_output)
+    row_iter <- worker_invoke(
+      arrow_converters,
+      "fromPayloadArray",
+      all_batches,
+      schema_output
+    )
 
     worker_invoke(context, "setResultIter", row_iter)
-    worker_log("updated ", total_rows, " rows using ", length(all_batches), " row batches")
+    worker_log(
+      "updated ",
+      total_rows,
+      " rows using ",
+      length(all_batches),
+      " row batches"
+    )
   } else {
     worker_log("found no rows in closure result")
   }
@@ -1649,7 +1867,10 @@ spark_worker_apply_arrow <- function(sc, config) {
 }
 
 spark_worker_get_serializer <- function(sc) {
-  serializer <- unserialize(worker_invoke(spark_worker_context(sc), "getSerializer"))
+  serializer <- unserialize(worker_invoke(
+    spark_worker_context(sc),
+    "getSerializer"
+  ))
   if (is.list(serializer)) {
     function(x, ...) serializer$serializer(x)
   } else {
@@ -1667,14 +1888,16 @@ spark_worker_apply <- function(sc, config) {
 
   grouped_by <- worker_invoke(context, "getGroupBy")
   grouped <- !is.null(grouped_by) && length(grouped_by) > 0
-  if (grouped) worker_log("working over grouped data")
+  if (grouped) {
+    worker_log("working over grouped data")
+  }
 
   length <- worker_invoke(context, "getSourceArrayLength")
   worker_log("found ", length, " rows")
 
   is_read <- ifelse(!is.null(config$spark_read), config$spark_read, FALSE)
 
-  groups_func <- if(grouped) {
+  groups_func <- if (grouped) {
     "getSourceArrayGroupedSeq"
   } else if (is_read && config$spark_version >= "4") {
     "getSourceArraySeq2"
@@ -1710,42 +1933,53 @@ spark_worker_apply <- function(sc, config) {
   barrier_map <- as.list(worker_invoke(context, "getBarrier"))
   partition_index <- worker_invoke(context, "getPartitionIndex")
 
-  if (!grouped) groups <- list(list(groups))
+  if (!grouped) {
+    groups <- list(list(groups))
+  }
 
   all_results <- NULL
 
   for (group_entry in groups) {
     # serialized groups are wrapped over single lists
     data <- group_entry[[1]]
-    if(config$spark_version >= "4" && !grouped && !is_read) {
+    if (config$spark_version >= "4" && !grouped && !is_read) {
       data <- lapply(data, unlist, recursive = FALSE)
     }
-    df <- (
-      if (config$single_binary_column) {
-        dplyr::tibble(encoded = lapply(data, function(x) x[[1]]))
-      } else {
-        bind_rows <- core_get_package_function("dplyr", "bind_rows")
-        as_tibble <- core_get_package_function("tibble", "as_tibble")
-        if (!is.null(bind_rows) && !is.null(as_tibble)) {
-          do.call(
-            bind_rows,
-            lapply(
-              data, function(x) { as_tibble(x, .name_repair = "universal") }
-            )
+    df <- (if (config$single_binary_column) {
+      dplyr::tibble(encoded = lapply(data, function(x) x[[1]]))
+    } else {
+      bind_rows <- core_get_package_function("dplyr", "bind_rows")
+      as_tibble <- core_get_package_function("tibble", "as_tibble")
+      if (!is.null(bind_rows) && !is.null(as_tibble)) {
+        do.call(
+          bind_rows,
+          lapply(
+            data,
+            function(x) {
+              as_tibble(x, .name_repair = "universal")
+            }
           )
-        } else {
-          warning("dplyr::bind_rows or dplyr::as_tibble is unavailable, ",
-                  "falling back to rbind implementation in base R. ",
-                  "Inputs with list column(s) will not work.")
+        )
+      } else {
+        warning(
+          "dplyr::bind_rows or dplyr::as_tibble is unavailable, ",
+          "falling back to rbind implementation in base R. ",
+          "Inputs with list column(s) will not work."
+        )
 
-          do.call(rbind.data.frame, c(data, list(stringsAsFactors = FALSE)))
-        }
-      })
+        do.call(rbind.data.frame, c(data, list(stringsAsFactors = FALSE)))
+      }
+    })
 
     if (!config$single_binary_column) {
       # rbind removes Date classes so we re-assign them here
       if (length(data) > 0 && ncol(df) > 0 && nrow(df) > 0) {
-        if (any(sapply(data[[1]], function(e) class(e)[[1]]) %in% c("Date", "POSIXct"))) {
+        if (
+          any(
+            sapply(data[[1]], function(e) class(e)[[1]]) %in%
+              c("Date", "POSIXct")
+          )
+        ) {
           first_row <- data[[1]]
           for (idx in seq_along(first_row)) {
             first_class <- class(first_row[[idx]])[[1]]
@@ -1761,7 +1995,10 @@ spark_worker_apply <- function(sc, config) {
         for (i in seq_along(df)) {
           target_type <- funcContext$column_types[[i]]
           if (!is.null(target_type) && class(df[[i]]) != target_type) {
-            df[[i]] <- do.call(paste("as", target_type, sep = "."), args = list(df[[i]]))
+            df[[i]] <- do.call(
+              paste("as", target_type, sep = "."),
+              args = list(df[[i]])
+            )
           }
         }
       }
@@ -1794,7 +2031,9 @@ spark_worker_apply <- function(sc, config) {
   if (!is.null(all_results) && nrow(all_results) > 0) {
     worker_log("updating ", nrow(all_results), " rows")
 
-    all_data <- lapply(seq_len(nrow(all_results)), function(i) as.list(all_results[i, ]))
+    all_data <- lapply(seq_len(nrow(all_results)), function(i) {
+      as.list(all_results[i, ])
+    })
 
     worker_invoke(context, "setResultArraySeq", all_data)
     worker_log("updated ", nrow(all_results), " rows")
@@ -1829,10 +2068,15 @@ worker_spark_apply_unbundle <- function(bundle_path, base_path, bundle_name) {
   extractPath <- file.path(base_path, spark_worker_unbundle_path(), bundle_name)
   lockFile <- file.path(extractPath, "sparklyr.lock")
 
-  if (!dir.exists(extractPath)) dir.create(extractPath, recursive = TRUE)
+  if (!dir.exists(extractPath)) {
+    dir.create(extractPath, recursive = TRUE)
+  }
 
   if (length(dir(extractPath)) == 0) {
-    worker_log("found that the unbundle path is empty, extracting:", extractPath)
+    worker_log(
+      "found that the unbundle path is empty, extracting:",
+      extractPath
+    )
 
     writeLines("", lockFile)
     system2("tar", c("-xf", bundle_path, "-C", extractPath))
@@ -1854,17 +2098,27 @@ worker_spark_apply_unbundle <- function(bundle_path, base_path, bundle_name) {
 # nocov start
 
 spark_worker_connect <- function(
-                                 sessionId,
-                                 backendPort = 8880,
-                                 config = list()) {
-  gatewayPort <- spark_config_value(config, "sparklyr.worker.gateway.port", backendPort)
+  sessionId,
+  backendPort = 8880,
+  config = list()
+) {
+  gatewayPort <- spark_config_value(
+    config,
+    "sparklyr.worker.gateway.port",
+    backendPort
+  )
 
-  gatewayAddress <- spark_config_value(config, "sparklyr.worker.gateway.address", "localhost")
+  gatewayAddress <- spark_config_value(
+    config,
+    "sparklyr.worker.gateway.address",
+    "localhost"
+  )
   config <- list()
 
   worker_log("is connecting to backend using port ", gatewayPort)
 
-  gatewayInfo <- spark_connect_gateway(gatewayAddress,
+  gatewayInfo <- spark_connect_gateway(
+    gatewayAddress,
     gatewayPort,
     sessionId,
     config = config,
@@ -1893,26 +2147,30 @@ spark_worker_connect <- function(
       close(gatewayInfo$gateway)
 
       stop(
-        "Failed to open connection to backend:", err$message
+        "Failed to open connection to backend:",
+        err$message
       )
     }
   )
 
   worker_log("is connected to backend session")
 
-  sc <- structure(class = c("spark_worker_connection"), list(
-    # spark_connection
-    master = "",
-    method = "shell",
-    app_name = NULL,
-    config = NULL,
-    state = new.env(),
-    # spark_shell_connection
-    spark_home = NULL,
-    backend = backend,
-    gateway = gatewayInfo$gateway,
-    output_file = NULL
-  ))
+  sc <- structure(
+    class = c("spark_worker_connection"),
+    list(
+      # spark_connection
+      master = "",
+      method = "shell",
+      app_name = NULL,
+      config = NULL,
+      state = new.env(),
+      # spark_shell_connection
+      spark_home = NULL,
+      backend = backend,
+      gateway = gatewayInfo$gateway,
+      output_file = NULL
+    )
+  )
 
   worker_log("created connection")
 
@@ -1929,8 +2187,7 @@ connection_is_open.spark_worker_connection <- function(sc) {
       {
         bothOpen <- isOpen(sc$backend) && isOpen(sc$gateway)
       },
-      error = function(e) {
-      }
+      error = function(e) {}
     )
   }
   bothOpen
@@ -1977,7 +2234,12 @@ worker_log_session <- function(sessionId) {
   assign("sessionId", sessionId, envir = worker_log_env)
 }
 
-worker_log_format <- function(message, session, level = "INFO", component = "RScript") {
+worker_log_format <- function(
+  message,
+  session,
+  level = "INFO",
+  component = "RScript"
+) {
   paste(
     format(Sys.time(), "%y/%m/%d %H:%M:%S"),
     " ",
@@ -2002,8 +2264,11 @@ worker_log_level <- function(..., level, component = "RScript") {
 
   args <- list(...)
   message <- paste(args, sep = "", collapse = "")
-  formatted <- worker_log_format(message, worker_log_env$sessionId,
-    level = level, component = component
+  formatted <- worker_log_format(
+    message,
+    worker_log_env$sessionId,
+    level = level,
+    component = component
   )
   cat(formatted, "\n")
 }
@@ -2026,20 +2291,28 @@ worker_log_error <- function(...) {
 .worker_globals <- new.env(parent = emptyenv())
 
 spark_worker_main <- function(
-                              sessionId,
-                              backendPort = 8880,
-                              configRaw = NULL) {
+  sessionId,
+  backendPort = 8880,
+  configRaw = NULL
+) {
   spark_worker_hooks()
   tryCatch(
     {
       worker_log_session(sessionId)
 
-      if (is.null(configRaw)) configRaw <- worker_config_serialize(list())
+      if (is.null(configRaw)) {
+        configRaw <- worker_config_serialize(list())
+      }
 
       config <- worker_config_deserialize(configRaw)
 
       if (identical(config$profile, TRUE)) {
-        profile_name <- paste("spark-apply-", as.numeric(Sys.time()), ".Rprof", sep = "")
+        profile_name <- paste(
+          "spark-apply-",
+          as.numeric(Sys.time()),
+          ".Rprof",
+          sep = ""
+        )
         worker_log("starting new profile in ", file.path(getwd(), profile_name))
         utils::Rprof(profile_name)
       }
@@ -2061,8 +2334,7 @@ spark_worker_main <- function(
 
       if (config$arrow) {
         spark_worker_apply_arrow(sc, config)
-      }
-      else {
+      } else {
         spark_worker_apply(sc, config)
       }
 
@@ -2074,7 +2346,10 @@ spark_worker_main <- function(
     error = function(e) {
       worker_log_error("terminated unexpectedly: ", e$message)
       if (exists(".stopLastError", envir = .worker_globals)) {
-        worker_log_error("collected callstack: \n", get(".stopLastError", envir = .worker_globals))
+        worker_log_error(
+          "collected callstack: \n",
+          get(".stopLastError", envir = .worker_globals)
+        )
       }
       quit(status = -1)
     }
@@ -2089,17 +2364,30 @@ spark_worker_hooks <- function() {
 
   originalStop <- stop
   unlock("stop", as.environment("package:base"))
-  assign("stop", function(...) {
-    frame_names <- list()
-    frame_start <- max(1, sys.nframe() - 5)
-    for (i in frame_start:sys.nframe()) {
-      current_call <- sys.call(i)
-      frame_names[[1 + i - frame_start]] <- paste(i, ": ", paste(head(deparse(current_call), 5), collapse = "\n"), sep = "")
-    }
+  assign(
+    "stop",
+    function(...) {
+      frame_names <- list()
+      frame_start <- max(1, sys.nframe() - 5)
+      for (i in frame_start:sys.nframe()) {
+        current_call <- sys.call(i)
+        frame_names[[1 + i - frame_start]] <- paste(
+          i,
+          ": ",
+          paste(head(deparse(current_call), 5), collapse = "\n"),
+          sep = ""
+        )
+      }
 
-    assign(".stopLastError", paste(rev(frame_names), collapse = "\n"), envir = .worker_globals)
-    originalStop(...)
-  }, as.environment("package:base"))
+      assign(
+        ".stopLastError",
+        paste(rev(frame_names), collapse = "\n"),
+        envir = .worker_globals
+      )
+      originalStop(...)
+    },
+    as.environment("package:base")
+  )
   lock("stop", as.environment("package:base"))
 }
 

--- a/man-roxygen/roxlate-ml-checkpoint-interval.R
+++ b/man-roxygen/roxlate-ml-checkpoint-interval.R
@@ -1,2 +1,2 @@
-  #' @param checkpoint_interval Set checkpoint interval (>= 1) or disable checkpoint (-1).
-  #'   E.g. 10 means that the cache will get checkpointed every 10 iterations, defaults to 10.
+#' @param checkpoint_interval Set checkpoint interval (>= 1) or disable checkpoint (-1).
+#'   E.g. 10 means that the cache will get checkpointed every 10 iterations, defaults to 10.

--- a/man-roxygen/roxlate-ml-clustering-algo.R
+++ b/man-roxygen/roxlate-ml-clustering-algo.R
@@ -7,4 +7,3 @@
 #' appended to it. If a \code{tbl_spark}, it will return a \code{tbl_spark} with
 #' the predictions added to it.
 
-

--- a/tests/testthat/helper-initialize.R
+++ b/tests/testthat/helper-initialize.R
@@ -72,11 +72,14 @@ testthat_shell_connection <- function(method = "shell") {
     }
     config$`sparklyr.sdf_collect.persistence_level` <- "NONE"
     packages <- NULL
-    if (spark_version < "4.1.0") {
-      if (spark_version >= "2.4.0") {
-        packages <- "avro"
-      }
-      if (spark_version >= "2.4.2") packages <- c(packages, "delta")
+    if (spark_version >= "2.4.0") {
+      packages <- "avro"
+    }
+    # Delta has no Spark 4.1+ compatible release yet: delta-spark 4.0.0 (the
+    # latest) throws NoSuchMethodError on Spark 4.1, so only load it where a
+    # compatible build exists (Spark 2.4.2 .. 4.0.x).
+    if (spark_version >= "2.4.2" && spark_version < "4.1.0") {
+      packages <- c(packages, "delta")
     }
     sc <- spark_connect(
       master = "local",

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -21,10 +21,13 @@ test_that("arrow_enabled_object predicates classify objects", {
   expect_false(enabled)
 })
 
-test_that("arrow_enabled is FALSE when {arrow} is not attached", {
-  # test-arrow.R sorts before test-zzz-spark_apply.R, so arrow is not on the
-  # search path here -> arrow_enabled() short-circuits to FALSE
-  expect_false(arrow_enabled(list(config = list()), data.frame(a = 1)))
+test_that("arrow_enabled short-circuits when disabled via config", {
+  # Deterministic regardless of whether {arrow} is attached (the arrow/coverage
+  # CI jobs attach it at session init): sparklyr.arrow = FALSE makes
+  # spark_config_value() return FALSE, short-circuiting arrow_enabled().
+  expect_false(
+    arrow_enabled(list(config = list(sparklyr.arrow = FALSE)), data.frame(a = 1))
+  )
 })
 
 test_clear_cache()

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -26,7 +26,10 @@ test_that("arrow_enabled short-circuits when disabled via config", {
   # CI jobs attach it at session init): sparklyr.arrow = FALSE makes
   # spark_config_value() return FALSE, short-circuiting arrow_enabled().
   expect_false(
-    arrow_enabled(list(config = list(sparklyr.arrow = FALSE)), data.frame(a = 1))
+    arrow_enabled(
+      list(config = list(sparklyr.arrow = FALSE)),
+      data.frame(a = 1)
+    )
   )
 })
 

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -30,4 +30,25 @@ test_that("arrow_enabled short-circuits when disabled via config", {
   )
 })
 
+test_that("spark_avro_package_name maps versions and rejects unsupported", {
+  expect_equal(
+    spark_avro_package_name("3.5.0"),
+    "org.apache.spark:spark-avro_2.12:3.5.0"
+  )
+  expect_equal(
+    spark_avro_package_name("4.0.0"),
+    "org.apache.spark:spark-avro_2.13:4.0.0"
+  )
+  expect_equal(
+    spark_avro_package_name("2.4.8"),
+    "org.apache.spark:spark-avro_2.11:2.4.8"
+  )
+  expect_match(
+    spark_avro_package_name("4.1.0-preview1"),
+    "spark-avro_2.13:4.1.0-preview1"
+  )
+  expect_error(spark_avro_package_name(NULL), "requires Spark version")
+  expect_error(spark_avro_package_name("2.3.0"), "2.4.0 or newer")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-arrow.R
+++ b/tests/testthat/test-arrow.R
@@ -1,0 +1,30 @@
+skip_connection("arrow")
+skip_on_livy()
+skip_on_arrow_devel()
+
+sc <- testthat_spark_connection()
+
+# NB: the arrow serialization round-trip (arrow_copy_to / arrow_collect /
+# arrow_read_stream) requires {arrow} to be attached and is exercised by the
+# dedicated arrow CI job + test-zzz-spark_apply.R. Here we cover the pure
+# arrow_enabled* predicates, which decide whether that path is taken.
+
+test_that("arrow_enabled_object predicates classify objects", {
+  expect_true(arrow_enabled_object(1)) # default
+
+  sdf <- spark_dataframe(testthat_tbl("iris"))
+  expect_type(arrow_enabled_object(sdf), "logical") # spark_jobj (schema check)
+
+  # a data frame with an unsupported list-of-raw column disables arrow + warns
+  df <- dplyr::tibble(a = list(as.raw(1:2), as.raw(3:4)))
+  expect_warning(enabled <- arrow_enabled_object(df), "Arrow disabled")
+  expect_false(enabled)
+})
+
+test_that("arrow_enabled is FALSE when {arrow} is not attached", {
+  # test-arrow.R sorts before test-zzz-spark_apply.R, so arrow is not on the
+  # search path here -> arrow_enabled() short-circuits to FALSE
+  expect_false(arrow_enabled(list(config = list()), data.frame(a = 1)))
+})
+
+test_clear_cache()

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -178,4 +178,360 @@ test_that("spark_config_packages() defaults to latest veresion", {
   )
 })
 
+test_that("spark_config_settings() returns a data frame of named settings", {
+  settings <- spark_config_settings()
+  expect_s3_class(settings, "data.frame")
+  expect_named(settings, c("name", "description"))
+  expect_true(nrow(settings) > 0)
+  expect_true("sparklyr.arrow" %in% settings$name)
+  expect_true(all(nchar(settings$description) > 0))
+})
+
+test_that("spark_config() picks up SPARK_DRIVER_CLASSPATH", {
+  withr::with_envvar(
+    list(SPARK_DRIVER_CLASSPATH = "/some/classpath"),
+    {
+      config <- spark_config()
+      expect_equal(
+        config$master$`sparklyr.shell.driver-class-path`,
+        "/some/classpath"
+      )
+    }
+  )
+})
+
+test_that("spark_config() reads SPARKLYR_CONFIG_FILE when set", {
+  configFilePath <- tempfile(pattern = "envconfig_", fileext = ".yml")
+  writeLines(
+    c("default:", "  sparklyr.env.entry: 99"),
+    con = configFilePath
+  )
+  withr::with_envvar(
+    list(SPARKLYR_CONFIG_FILE = configFilePath),
+    {
+      config <- spark_config()
+      expect_equal(config$sparklyr.env.entry, 99)
+    }
+  )
+})
+
+test_that("merge_lists() handles empty, recursive, and overwrite cases", {
+  # empty base returns overlay
+  expect_equal(merge_lists(list(), list(a = 1)), list(a = 1))
+  # empty overlay returns base
+  expect_equal(merge_lists(list(a = 1), list()), list(a = 1))
+  # recursive merge of nested lists
+  merged <- merge_lists(
+    list(outer = list(a = 1, b = 2)),
+    list(outer = list(b = 3, c = 4))
+  )
+  expect_equal(merged$outer$a, 1)
+  expect_equal(merged$outer$b, 3)
+  expect_equal(merged$outer$c, 4)
+  # non-list overlay overwrites scalar
+  merged2 <- merge_lists(list(a = 1, b = 2), list(a = 10))
+  expect_equal(merged2$a, 10)
+  expect_equal(merged2$b, 2)
+})
+
+test_that("spark_config_value() enforces documented settings when option is on", {
+  withr::with_options(
+    list(sparklyr.test.enforce.config = TRUE),
+    {
+      # documented setting passes through
+      expect_equal(
+        spark_config_value(
+          list(sparklyr.arrow = TRUE),
+          "sparklyr.arrow",
+          FALSE
+        ),
+        TRUE
+      )
+      # sparklyr.shell.* is exempt from the documented-settings check
+      expect_equal(
+        spark_config_value(
+          list("sparklyr.shell.packages" = "x"),
+          "sparklyr.shell.packages"
+        ),
+        "x"
+      )
+      # an undocumented sparklyr.* name errors
+      expect_error(
+        spark_config_value(list(), "sparklyr.not.a.real.setting", FALSE),
+        "not described in spark_config_settings"
+      )
+    }
+  )
+})
+
+test_that("spark_config_value() falls back to global options", {
+  withr::with_options(
+    list(
+      sparklyr.test.enforce.config = FALSE,
+      sparklyr.value.from.option = 42
+    ),
+    {
+      expect_equal(
+        spark_config_value(list(), "sparklyr.value.from.option", 0),
+        42
+      )
+    }
+  )
+})
+
+test_that("spark_config_value() evaluates function and language values", {
+  withr::with_options(
+    list(sparklyr.test.enforce.config = FALSE),
+    {
+      # function value gets called
+      expect_equal(
+        spark_config_value(
+          list(sparklyr.fn = function() 7),
+          "sparklyr.fn"
+        ),
+        7
+      )
+      # a formula lambda (a language object) is converted to a closure
+      # via rlang::as_closure() and then called
+      expect_equal(
+        spark_config_value(
+          list(sparklyr.lang = ~ 3 + 4),
+          "sparklyr.lang"
+        ),
+        7
+      )
+    }
+  )
+})
+
+test_that("spark_config_integer() and spark_config_logical() coerce values", {
+  withr::with_options(
+    list(sparklyr.test.enforce.config = FALSE),
+    {
+      expect_identical(
+        spark_config_integer(list(sparklyr.x = "5"), "sparklyr.x"),
+        5L
+      )
+      expect_identical(
+        spark_config_logical(list(sparklyr.x = "TRUE"), "sparklyr.x"),
+        TRUE
+      )
+      expect_identical(
+        spark_config_logical(list(), "sparklyr.x", FALSE),
+        FALSE
+      )
+    }
+  )
+})
+
+test_that("spark_config_value_retries() returns value on success", {
+  expect_equal(
+    spark_config_value_retries(
+      list(sparklyr.x = 11),
+      "sparklyr.x",
+      default = 0,
+      retries = 3
+    ),
+    11
+  )
+})
+
+test_that("spark_config_value_retries() retries and eventually stops on failure", {
+  attempts <- 0
+  with_mocked_bindings(
+    spark_config_value = function(config, name, default = NULL) {
+      # allow the verbose lookup to resolve normally
+      if (identical(name, "sparklyr.verbose")) {
+        return(FALSE)
+      }
+      attempts <<- attempts + 1
+      stop("boom")
+    },
+    {
+      expect_error(
+        spark_config_value_retries(list(), "sparklyr.x", 0, retries = 2),
+        "Failed after"
+      )
+    },
+    .package = "sparklyr"
+  )
+  expect_true(attempts >= 1)
+})
+
+test_that("spark_config_value_retries() emits verbose error message", {
+  with_mocked_bindings(
+    spark_config_value = function(config, name, default = NULL) {
+      if (identical(name, "sparklyr.verbose")) {
+        return(TRUE)
+      }
+      stop("kapow")
+    },
+    {
+      expect_message(
+        expect_error(
+          spark_config_value_retries(list(), "sparklyr.x", 0, retries = 1),
+          "Failed after"
+        ),
+        "failed with error: kapow"
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("spark_config_packages() builds delta packages across versions", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    {
+      # Spark 3.5 uses delta-spark and sets sql extensions
+      cfg_35 <- spark_config_packages(list(), "delta", "3.5.0")
+      expect_match(
+        cfg_35$sparklyr.shell.packages,
+        "io.delta:delta-spark_2.12:3.0.0"
+      )
+      expect_equal(
+        cfg_35$`spark.sql.extensions`,
+        "io.delta.sql.DeltaSparkSessionExtension"
+      )
+      expect_equal(
+        cfg_35$`spark.sql.catalog.spark_catalog`,
+        "org.apache.spark.sql.delta.catalog.DeltaCatalog"
+      )
+
+      # Spark 4.0 uses scala 2.13 and delta-spark 4.0.0
+      cfg_40 <- spark_config_packages(list(), "delta", "4.0.0")
+      expect_match(
+        cfg_40$sparklyr.shell.packages,
+        "io.delta:delta-spark_2.13:4.0.0"
+      )
+
+      # Spark 3.0 uses delta-core (pre 3.5) and scala 2.12
+      cfg_30 <- spark_config_packages(list(), "delta", "3.0.0")
+      expect_match(
+        cfg_30$sparklyr.shell.packages,
+        "io.delta:delta-core_2.12:0.8.0"
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("spark_config_packages() errors on delta below 2.4.2", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    {
+      expect_error(
+        spark_config_packages(list(), "delta", "2.3.0"),
+        "Delta Lake requires Spark 2.4.2 or newer"
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("spark_config_packages() errors on kafka below 2.0", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    {
+      expect_error(
+        spark_config_packages(list(), "kafka", "1.6.0"),
+        "Kafka requires Spark 2.x"
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("spark_config_packages() supports avro", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    {
+      cfg <- spark_config_packages(list(), "avro", "3.0.0")
+      expect_match(
+        cfg$sparklyr.shell.packages,
+        "org.apache.spark:spark-avro_2.12:3.0.0"
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("spark_config_packages() supports rapids in both methods", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    {
+      cfg <- spark_config_packages(
+        list(),
+        "rapids",
+        "3.0.0",
+        method = "local"
+      )
+      expect_true(
+        "com.nvidia:rapids-4-spark_2.12:0.1.0" %in%
+          cfg$sparklyr.shell.packages
+      )
+      expect_true(
+        "ai.rapids:cudf:0.14" %in% cfg$sparklyr.shell.packages
+      )
+      expect_true(
+        "spark.plugins=com.nvidia.spark.SQLPlugin" %in%
+          cfg$sparklyr.shell.conf
+      )
+
+      cfg_db <- spark_config_packages(
+        list(),
+        "rapids",
+        "3.0.0",
+        method = "databricks"
+      )
+      expect_true(
+        "com.nvidia:rapids-4-spark_2.12:0.1.0-databricks" %in%
+          cfg_db$sparklyr.shell.packages
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("spark_config_packages() errors on rapids below 3.0", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    {
+      expect_error(
+        spark_config_packages(list(), "rapids", "2.4.0", method = "local"),
+        "RAPIDS library requires Spark 3.0.0 or higher"
+      )
+    },
+    .package = "sparklyr"
+  )
+})
+
+test_that("worker_config_serialize()/deserialize() round-trip", {
+  config <- list(
+    debug = TRUE,
+    profile = FALSE,
+    schema = TRUE,
+    arrow = FALSE,
+    fetch_result_as_sdf = TRUE,
+    single_binary_column = FALSE,
+    spark_read = TRUE,
+    spark_version = "3.5.0"
+  )
+  serialized <- worker_config_serialize(config)
+  expect_type(serialized, "character")
+
+  deserialized <- worker_config_deserialize(serialized)
+  expect_true(deserialized$debug)
+  expect_false(deserialized$profile)
+  expect_true(deserialized$schema)
+  expect_false(deserialized$arrow)
+  expect_true(deserialized$fetch_result_as_sdf)
+  expect_false(deserialized$single_binary_column)
+  expect_true(deserialized$spark_read)
+  expect_equal(deserialized$spark_version, "3.5.0")
+  # defaults for gateway port / address
+  expect_equal(deserialized$sparklyr.gateway.port, 8880L)
+  expect_equal(deserialized$sparklyr.gateway.address, "localhost")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -416,6 +416,17 @@ test_that("spark_config_packages() builds delta packages across versions", {
   )
 })
 
+test_that("spark_config_packages() errors for delta on an unsupported Spark version", {
+  with_mocked_bindings(
+    spark_version_latest = function(version = NULL) version,
+    expect_error(
+      spark_config_packages(list(), "delta", "4.1.0"),
+      "Delta Lake is not yet available for Spark 4.1.0"
+    ),
+    .package = "sparklyr"
+  )
+})
+
 test_that("spark_config_packages() errors on delta below 2.4.2", {
   with_mocked_bindings(
     spark_version_latest = function(version = NULL) version,

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -1,3 +1,300 @@
+# ---------------------------------------------------------------------------
+# Connection-free unit tests for the pure helpers in R/connection.R. These run
+# without a live Spark session, so they are placed ABOVE the aborting
+# skip_connection() call below. They exercise master/url predicates, version
+# parsing, the in-memory connection registry, and the small validation/error
+# branches via crafted inputs and `with_mocked_bindings`.
+# ---------------------------------------------------------------------------
+
+# A lightweight, fully in-memory connection object. It carries the
+# `test_connection` class so that `connection_is_open()` dispatches to the
+# method in connection_test.R and reads `state$open`, which we control.
+fake_scon <- function(
+  master = "local",
+  open = TRUE,
+  method = NULL,
+  app_name = NULL,
+  config = list()
+) {
+  st <- new.env()
+  st$open <- open
+  structure(
+    list(
+      master = master,
+      method = method,
+      app_name = app_name,
+      config = config,
+      state = st
+    ),
+    class = c("test_connection", "spark_connection")
+  )
+}
+
+test_that("spark_master_is_local() matches only local master strings", {
+  expect_true(spark_master_is_local("local"))
+  expect_true(spark_master_is_local("local[4]"))
+  expect_true(spark_master_is_local("local[*]"))
+  expect_false(spark_master_is_local("yarn"))
+  expect_false(spark_master_is_local("spark://HOST:PORT"))
+  expect_false(spark_master_is_local("local-cluster"))
+  # NULL master is tolerated and reported as FALSE
+  expect_false(spark_master_is_local(NULL))
+})
+
+test_that("spark_master_is_gateway() detects the sparklyr:// scheme", {
+  expect_true(spark_master_is_gateway("sparklyr://localhost:8880/0"))
+  expect_false(spark_master_is_gateway("local"))
+  expect_false(spark_master_is_gateway("yarn"))
+})
+
+test_that("spark_master_is_yarn_cluster() honors master and deploy-mode", {
+  expect_true(spark_master_is_yarn_cluster("yarn-cluster", list()))
+  expect_true(spark_master_is_yarn_cluster("YARN-CLUSTER", list()))
+  # yarn + cluster deploy-mode counts as a yarn cluster
+  expect_true(spark_master_is_yarn_cluster(
+    "yarn",
+    list(`sparklyr.shell.deploy-mode` = "cluster")
+  ))
+  # plain yarn (client deploy) does not
+  expect_false(spark_master_is_yarn_cluster("yarn", list()))
+  expect_false(spark_master_is_yarn_cluster("local", list()))
+})
+
+test_that("spark_connection_is_yarn() recognizes yarn variants", {
+  expect_true(spark_connection_is_yarn(fake_scon(master = "yarn")))
+  expect_true(spark_connection_is_yarn(fake_scon(master = "yarn-client")))
+  expect_true(spark_connection_is_yarn(fake_scon(master = "yarn-cluster")))
+  expect_true(spark_connection_is_yarn(fake_scon(master = "YARN")))
+  expect_false(spark_connection_is_yarn(fake_scon(master = "local")))
+})
+
+test_that("spark_connection_is_yarn_client() distinguishes client vs cluster", {
+  expect_true(spark_connection_is_yarn_client(fake_scon(
+    master = "yarn-client"
+  )))
+  # bare yarn with no cluster deploy-mode is treated as client
+  expect_true(spark_connection_is_yarn_client(fake_scon(master = "yarn")))
+  # bare yarn with cluster deploy-mode is NOT a client
+  expect_false(spark_connection_is_yarn_client(
+    fake_scon(
+      master = "yarn",
+      config = list(`sparklyr.shell.deploy-mode` = "cluster")
+    )
+  ))
+  expect_false(spark_connection_is_yarn_client(fake_scon(
+    master = "yarn-cluster"
+  )))
+  expect_false(spark_connection_is_yarn_client(fake_scon(master = "local")))
+})
+
+test_that("spark_connection_is_local() excludes databricks-connect", {
+  expect_true(spark_connection_is_local(fake_scon(master = "local")))
+  expect_true(spark_connection_is_local(fake_scon(master = "local[2]")))
+  expect_false(spark_connection_is_local(fake_scon(master = "yarn")))
+  # local master but databricks-connect method -> not "local"
+  expect_false(spark_connection_is_local(
+    fake_scon(master = "local", method = "databricks-connect")
+  ))
+})
+
+test_that("spark_connection_in_driver() is TRUE for local and yarn-client", {
+  expect_true(spark_connection_in_driver(fake_scon(master = "local")))
+  expect_true(spark_connection_in_driver(fake_scon(master = "yarn-client")))
+  expect_false(spark_connection_in_driver(fake_scon(master = "yarn-cluster")))
+})
+
+test_that("spark_version_numeric() strips non-numeric decorations", {
+  expect_equal(spark_version_numeric("3.5.0"), numeric_version("3.5.0"))
+  expect_equal(spark_version_numeric("3.5.0-preview"), numeric_version("3.5.0"))
+  expect_equal(spark_version_numeric("v2.4.7"), numeric_version("2.4.7"))
+})
+
+test_that("spark_default_app_jar() resolves a shipped jar and defaults version", {
+  jar <- spark_default_app_jar("3.5.0")
+  expect_true(grepl("sparklyr-3\\.5-.*\\.jar$", jar))
+  expect_true(file.exists(jar))
+
+  # version = NULL falls back to .spark_default_version (1.6.2) without error
+  expect_type(spark_default_app_jar(NULL), "character")
+})
+
+test_that("spark_master_local_cores() injects cores only for plain local", {
+  cfg <- list(sparklyr.cores.local = 4)
+  expect_equal(spark_master_local_cores("local", cfg), "local[4]")
+  # already-decorated local is left untouched (regex only matches "local")
+  expect_equal(spark_master_local_cores("local[2]", cfg), "local[2]")
+  expect_equal(spark_master_local_cores("yarn", cfg), "yarn")
+  # no cores configured -> master unchanged
+  expect_equal(spark_master_local_cores("local", list()), "local")
+})
+
+test_that("spark_config_shell_args() flattens sparklyr.shell.* into --flag pairs", {
+  config <- list(
+    sparklyr.shell.packages = c("a", "b"),
+    `sparklyr.shell.driver-memory` = "2g",
+    spark.some.other = "ignored"
+  )
+  args <- spark_config_shell_args(config, "local")
+  args <- unlist(args)
+  # packages collapsed to a comma-separated value behind --packages
+  expect_true("--packages" %in% args)
+  expect_true("a,b" %in% args)
+  # other sparklyr.shell.* entries surface as their own --flag value pairs
+  expect_true("--driver-memory" %in% args)
+  expect_true("2g" %in% args)
+  # non sparklyr.shell.* keys are not emitted
+  expect_false("--some.other" %in% args)
+})
+
+test_that("as_spark_method() builds a dispatch-only S3 object", {
+  m <- as_spark_method("livy")
+  expect_s3_class(m, "spark_method_livy")
+  expect_identical(unclass(m), list())
+})
+
+test_that("no_databricks_guid() reflects the global DATABRICKS_GUID", {
+  # Ensure clean baseline
+  if (exists("DATABRICKS_GUID", envir = .GlobalEnv)) {
+    rm("DATABRICKS_GUID", envir = .GlobalEnv)
+  }
+  expect_true(no_databricks_guid())
+
+  withr::defer({
+    if (exists("DATABRICKS_GUID", envir = .GlobalEnv)) {
+      rm("DATABRICKS_GUID", envir = .GlobalEnv)
+    }
+  })
+  assign("DATABRICKS_GUID", "abc", envir = .GlobalEnv)
+  expect_false(no_databricks_guid())
+})
+
+test_that("connection_is_open() dispatches and reads test_connection state", {
+  expect_true(connection_is_open(fake_scon(open = TRUE)))
+  expect_false(connection_is_open(fake_scon(open = FALSE)))
+})
+
+test_that("in-memory connection registry adds, finds, and removes connections", {
+  # Snapshot and restore the shared registry so we don't leak fakes.
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  a <- fake_scon(master = "local[1]", app_name = "appA", method = "test")
+  b <- fake_scon(
+    master = "local[2]",
+    app_name = "appB",
+    method = "test",
+    open = FALSE
+  )
+
+  spark_connections_add(a)
+  spark_connections_add(b)
+  expect_length(spark_connection_instances(), 2)
+
+  # find filters on open + matching master/app_name/method
+  found <- spark_connection_find(
+    master = "local[1]",
+    app_name = "appA",
+    method = "test"
+  )
+  expect_length(found, 1)
+  expect_identical(found[[1]]$master, "local[1]")
+
+  # closed connection (b) is not returned by find even on an exact match
+  expect_length(
+    spark_connection_find(
+      master = "local[2]",
+      app_name = "appB",
+      method = "test"
+    ),
+    0
+  )
+
+  # NULL filters match anything that is open
+  expect_length(spark_connection_find(), 1)
+
+  # remove drops the matching master entry
+  spark_connections_remove(a)
+  expect_length(spark_connection_instances(), 1)
+  expect_identical(spark_connection_instances()[[1]]$master, "local[2]")
+})
+
+test_that("spark_connection_instances() initializes an empty list when unset", {
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- NULL
+  expect_identical(spark_connection_instances(), list())
+})
+
+test_that("spark_disconnect.character() returns count of disconnected matches", {
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  # No matching registered connection -> 0 disconnected
+  expect_equal(spark_disconnect("spark://nope:7077"), 0)
+
+  # A registered, open connection whose master matches (cores stripped) -> 1
+  conn <- fake_scon(master = "local[4]", app_name = "appX")
+  spark_connections_add(conn)
+  n <- spark_disconnect("local", master = "local")
+  expect_equal(n, 1)
+  # spark_disconnect.test_connection flips the open flag
+  expect_false(conn$state$open)
+})
+
+test_that("spark_disconnect_all() disconnects every open connection", {
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  open1 <- fake_scon(master = "local[1]")
+  open2 <- fake_scon(master = "local[2]")
+  closed <- fake_scon(master = "local[3]", open = FALSE)
+  spark_connections_add(open1)
+  spark_connections_add(open2)
+  spark_connections_add(closed)
+
+  expect_equal(spark_disconnect_all(), 2)
+  expect_false(open1$state$open)
+  expect_false(open2$state$open)
+})
+
+test_that("spark_log_file() errors when the connection is closed", {
+  expect_error(
+    spark_log_file(fake_scon(open = FALSE)),
+    "not open"
+  )
+})
+
+test_that("spark_connect_method.default() rejects unsupported methods", {
+  # spark_config_shell_args is exercised first; stub it so we reach the
+  # unsupported-method branch deterministically without touching real config.
+  with_mocked_bindings(
+    spark_config_shell_args = function(config, master) list(),
+    .package = "sparklyr",
+    expect_error(
+      spark_connect_method(
+        x = as_spark_method("bogus"),
+        method = "bogus",
+        master = "local",
+        spark_home = "",
+        config = list(),
+        app_name = "sparklyr",
+        version = NULL,
+        extensions = list(),
+        scala_version = NULL
+      ),
+      "Unsupported connection method"
+    )
+  )
+})
+
+test_that("spark_connection_is_open() delegates to connection_is_open()", {
+  expect_true(spark_connection_is_open(fake_scon(open = TRUE)))
+  expect_false(spark_connection_is_open(fake_scon(open = FALSE)))
+})
+
 skip_connection("connection")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-connection.R
+++ b/tests/testthat/test-connection.R
@@ -295,6 +295,294 @@ test_that("spark_connection_is_open() delegates to connection_is_open()", {
   expect_false(spark_connection_is_open(fake_scon(open = FALSE)))
 })
 
+test_that("requireNamespace2() forwards to base requireNamespace", {
+  expect_true(requireNamespace2("stats", quietly = TRUE))
+  expect_false(requireNamespace2("nonexistentpkgxyz123", quietly = TRUE))
+})
+
+test_that("spark_connect() aborts for pysparklyr methods when it is missing", {
+  # The databricks_connect / spark_connect methods are provided by pysparklyr;
+  # with the package "absent" spark_connect must abort before doing any work.
+  with_mocked_bindings(
+    requireNamespace2 = function(...) FALSE,
+    .package = "sparklyr",
+    {
+      expect_error(
+        spark_connect(master = "local", method = "spark_connect"),
+        "pysparklyr"
+      )
+      expect_error(
+        spark_connect(master = "local", method = "databricks_connect"),
+        "pysparklyr"
+      )
+    }
+  )
+})
+
+# ---------------------------------------------------------------------------
+# spark_connect() orchestration. The real body negotiates master/method,
+# short-circuits on a re-used connection, and otherwise hands off to
+# spark_connect_method(). We drive the *resolution logic* with all the live
+# machinery stubbed out: spark_connect_method captures the master/method it is
+# handed, and the post-connect helpers are neutralized so nothing touches a real
+# JVM. This covers the branch selection without a live session.
+# ---------------------------------------------------------------------------
+
+# Build a spark_connect() caller that stubs the connection machinery and returns
+# the (master, method) that spark_connect resolved and passed downstream.
+make_connect_capture <- function(captured_env) {
+  function(...) {
+    captured_env$value <- NULL
+    with_mocked_bindings(
+      spark_connect_method = function(x, method, master, ...) {
+        captured_env$value <- list(master = master, method = method)
+        structure(
+          list(
+            master = master,
+            method = method,
+            # open = FALSE so the real reg.finalizer registered by spark_connect()
+            # sees a closed connection at exit and skips its Sys.sleep() guard.
+            state = list(open = FALSE),
+            extensions = list()
+          ),
+          class = c("test_connection", "spark_connection")
+        )
+      },
+      initialize_connection = function(scon) scon,
+      initialize_method = function(method, scon) scon,
+      register_mapping_tables = function() invisible(NULL),
+      spark_web = function(scon, ...) NULL,
+      spark_ide_connection_open = function(...) invisible(NULL),
+      spark_connections_add = function(sc) invisible(NULL),
+      .package = "sparklyr",
+      spark_connect(...)
+    )
+    captured_env$value
+  }
+}
+
+test_that("spark_connect() resolves master/method then routes downstream", {
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  cap <- new.env()
+  do_connect <- make_connect_capture(cap)
+
+  # master overridden via config$sparklyr.connect.master
+  res <- do_connect(
+    master = "local",
+    method = "test",
+    config = list(sparklyr.connect.master = "local[7]")
+  )
+  expect_equal(res$master, "local[7]")
+
+  # qubole with a missing master defaults master + spark_home
+  res <- do_connect(method = "qubole", config = list())
+  expect_equal(res$master, "yarn-client")
+  expect_equal(res$method, "qubole")
+
+  # missing master with no spark.master leaves master NULL (default shell)
+  res <- do_connect(config = list())
+  expect_null(res$master)
+  expect_equal(res$method, "shell")
+
+  # the documentation example master switches to the in-memory test method
+  res <- do_connect(master = "spark://HOST:PORT", config = list())
+  expect_equal(res$method, "test")
+
+  # on a Databricks cluster (a DATABRICKS_GUID exists) method = "databricks" is
+  # NOT remapped to databricks-connect, so a missing master defaults to
+  # "databricks".
+  withr::defer({
+    if (exists("DATABRICKS_GUID", envir = .GlobalEnv)) {
+      rm("DATABRICKS_GUID", envir = .GlobalEnv)
+    }
+  })
+  assign("DATABRICKS_GUID", "abc", envir = .GlobalEnv)
+  res <- do_connect(method = "databricks", config = list())
+  expect_equal(res$master, "databricks")
+  expect_equal(res$method, "databricks")
+})
+
+test_that("spark_connect() maps databricks -> databricks-connect off-cluster", {
+  # No DATABRICKS_GUID in the global env means method = "databricks" refers to
+  # Databricks Connect, so master is forced local and the client-type property
+  # is set after connecting.
+  if (exists("DATABRICKS_GUID", envir = .GlobalEnv)) {
+    rm("DATABRICKS_GUID", envir = .GlobalEnv)
+  }
+
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  captured <- NULL
+  prop <- NULL
+  with_mocked_bindings(
+    spark_connect_method = function(x, method, master, ...) {
+      captured <<- list(master = master, method = method)
+      structure(
+        list(
+          master = master,
+          method = method,
+          state = list(open = FALSE),
+          extensions = list()
+        ),
+        class = c("test_connection", "spark_connection")
+      )
+    },
+    initialize_connection = function(scon) scon,
+    initialize_method = function(method, scon) scon,
+    register_mapping_tables = function() invisible(NULL),
+    spark_web = function(scon, ...) NULL,
+    spark_ide_connection_open = function(...) invisible(NULL),
+    spark_connections_add = function(sc) invisible(NULL),
+    spark_context = function(scon) "ctx",
+    invoke = function(jobj, method, ...) {
+      prop <<- method
+      NULL
+    },
+    .package = "sparklyr",
+    spark_connect(method = "databricks", config = list())
+  )
+  expect_equal(captured$method, "databricks-connect")
+  expect_equal(captured$master, "local")
+  expect_equal(prop, "setLocalProperty")
+})
+
+test_that("spark_connect() clears the apply bundle and runs initializers", {
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  bundle <- withr::local_tempdir()
+  ran <- FALSE
+  scon_obj <- structure(
+    list(
+      master = "local",
+      method = "shell",
+      state = list(open = FALSE),
+      extensions = list(initializers = list(function(scon) ran <<- TRUE))
+    ),
+    class = c("test_connection", "spark_connection")
+  )
+
+  with_mocked_bindings(
+    spark_apply_bundle_path = function() bundle,
+    spark_connect_method = function(...) scon_obj,
+    initialize_connection = function(scon) scon,
+    initialize_method = function(method, scon) scon,
+    register_mapping_tables = function() invisible(NULL),
+    spark_web = function(scon, ...) NULL,
+    spark_ide_connection_open = function(...) invisible(NULL),
+    spark_connections_add = function(sc) invisible(NULL),
+    .package = "sparklyr",
+    spark_connect(master = "local", method = "test", config = list())
+  )
+
+  expect_false(dir.exists(bundle)) # pre-existing bundle was unlinked
+  expect_true(ran) # extension initializer was invoked
+})
+
+test_that("spark_connect() re-uses an open connection with matching params", {
+  old <- sparkConnectionsEnv$instances
+  withr::defer(sparkConnectionsEnv$instances <- old)
+  sparkConnectionsEnv$instances <- list()
+
+  existing <- fake_scon(
+    master = "local",
+    app_name = "sparklyr",
+    method = "shell"
+  )
+  spark_connections_add(existing)
+
+  expect_message(
+    reused <- spark_connect(
+      master = "local",
+      app_name = "sparklyr",
+      method = "shell",
+      config = list()
+    ),
+    "Re-using existing"
+  )
+  expect_identical(reused, existing)
+})
+
+test_that("spark_connect_method.default() routes each method to its constructor", {
+  fake <- structure(
+    list(state = list(), extensions = list()),
+    class = c("test_connection", "spark_connection")
+  )
+  base_args <- list(
+    master = "local",
+    spark_home = "",
+    config = list(),
+    app_name = "sparklyr",
+    version = NULL,
+    extensions = list(),
+    scala_version = NULL
+  )
+
+  with_mocked_bindings(
+    spark_config_shell_args = function(config, master) list(),
+    shell_connection = function(...) fake,
+    livy_connection = function(...) "livy",
+    databricks_connection = function(...) "dbx",
+    synapse_connection = function(...) "syn",
+    .package = "sparklyr",
+    {
+      # qubole goes through shell_connection and is tagged with its method
+      q <- do.call(
+        spark_connect_method,
+        c(list(x = as_spark_method("qubole"), method = "qubole"), base_args)
+      )
+      expect_equal(q$method, "qubole")
+
+      expect_equal(
+        do.call(
+          spark_connect_method,
+          c(list(x = as_spark_method("livy"), method = "livy"), base_args)
+        ),
+        "livy"
+      )
+      expect_equal(
+        do.call(
+          spark_connect_method,
+          c(
+            list(x = as_spark_method("databricks"), method = "databricks"),
+            base_args
+          )
+        ),
+        "dbx"
+      )
+      expect_equal(
+        do.call(
+          spark_connect_method,
+          c(list(x = as_spark_method("synapse"), method = "synapse"), base_args)
+        ),
+        "syn"
+      )
+    }
+  )
+})
+
+test_that("spark_inspect() returns the jobj when the connection is closed", {
+  fake_jobj <- structure(list(), class = "spark_jobj")
+  with_mocked_bindings(
+    print = function(x, ...) invisible(x),
+    .package = "base",
+    {
+      result <- with_mocked_bindings(
+        spark_connection = function(x, ...) fake_scon(open = FALSE),
+        .package = "sparklyr",
+        spark_inspect(fake_jobj)
+      )
+      expect_identical(result, fake_jobj)
+    }
+  )
+})
+
 skip_connection("connection")
 skip_on_livy()
 skip_on_arrow_devel()
@@ -304,6 +592,13 @@ sc <- testthat_spark_connection()
 call_sparkr <- function(method, ...) {
   get(method, envir = asNamespace("SparkR"))(...)
 }
+
+test_that("sparklyr_get_backend_port() returns the live backend port", {
+  port <- sparklyr_get_backend_port(sc)
+  expect_true(is.numeric(port))
+  expect_length(port, 1)
+  expect_gt(port, 0)
+})
 
 test_that("gateway connection fails with invalid session", {
   expect_error(

--- a/tests/testthat/test-connection_databricks.R
+++ b/tests/testthat/test-connection_databricks.R
@@ -2,6 +2,83 @@ skip_connection("connection_databricks")
 skip_on_livy()
 skip_on_arrow_devel()
 
+# ---- Connection-free tests --------------------------------------------------
+# These exercise the parts of the Databricks/Synapse connectors that do not
+# require a live Databricks notebook, Synapse session, or SparkR. They must sit
+# *above* skip_unless_databricks_connect(), which otherwise aborts the file.
+
+test_that("databricks_expand_jars copies missing compatibility jars", {
+  # the sparklyr-2.2/2.1 compatibility jars are not shipped, so the copy branch
+  # runs for both; only file.copy is mocked (mocking file.exists globally breaks
+  # package/namespace lookup, which relies on it)
+  copied <- character(0)
+  with_mocked_bindings(
+    spark_default_app_jar = function(version, ...) {
+      paste0("/jars/app-", version, ".jar")
+    },
+    .package = "sparklyr",
+    with_mocked_bindings(
+      file.copy = function(from, to, ...) {
+        copied <<- c(copied, to)
+        TRUE
+      },
+      .package = "base",
+      databricks_expand_jars()
+    )
+  )
+  # one copy for each missing version (2.2, 2.1)
+  expect_length(copied, 2)
+})
+
+test_that("databricks_connection errors when the SparkR backend is unavailable", {
+  with_mocked_bindings(
+    databricks_expand_jars = function() invisible(NULL),
+    .package = "sparklyr",
+    expect_error(
+      databricks_connection(config = list(), extensions = NULL),
+      "Failed to start sparklyr backend"
+    )
+  )
+})
+
+test_that("synapse_connection errors when the SparkR backend is unavailable", {
+  home <- withr::local_tempdir()
+  with_mocked_bindings(
+    spark_default_app_jar = function(...) "/jars/x.jar",
+    .package = "sparklyr",
+    expect_error(
+      synapse_connection(
+        spark_home = home,
+        spark_version = "3.5.0",
+        scala_version = "2.12",
+        config = list(),
+        extensions = NULL
+      ),
+      "\\[Synapse\\] Failed to start sparklyr backend"
+    )
+  )
+})
+
+test_that("spark_version methods return the cached version", {
+  sc_db <- structure(
+    list(state = list(spark_version = numeric_version("3.5.0"))),
+    class = c("databricks_connection", "spark_connection")
+  )
+  expect_equal(
+    spark_version.databricks_connection(sc_db),
+    numeric_version("3.5.0")
+  )
+
+  sc_syn <- structure(
+    list(state = list(spark_version = numeric_version("3.4.1"))),
+    class = c("synapse_connection", "spark_connection")
+  )
+  expect_equal(
+    spark_version.synapse_connection(sc_syn),
+    numeric_version("3.4.1")
+  )
+})
+
 skip_unless_databricks_connect()
 
 test_that("spark connection method is configured correctly", {

--- a/tests/testthat/test-connection_kubernetes.R
+++ b/tests/testthat/test-connection_kubernetes.R
@@ -1,3 +1,173 @@
+# ---- Connection-free tests --------------------------------------------------
+# These exercise the parts of the Kubernetes connector that do not require a
+# live k8s cluster, kubectl, or spark-submit. They are placed *above* the
+# skip_connection() gate, which otherwise aborts the file when no Spark
+# connection is available.
+#
+# Note: the rstudioapi-based helpers (spark_config_kubernetes_terminal_id,
+# spark_config_kubernetes_forward_init_terminal, and the Windows branch of
+# spark_config_kubernetes_forward_cleanup) call rstudioapi with explicit
+# `::` qualification, which with_mocked_bindings cannot intercept, so they
+# are intentionally left uncovered here.
+
+test_that("spark_config_kubernetes_forward_init runs kubectl port-forward", {
+  slept <- NULL
+  forwarded <- NULL
+  with_mocked_bindings(
+    Sys.sleep = function(time) {
+      slept <<- time
+      invisible(NULL)
+    },
+    system2 = function(command, args, ...) {
+      forwarded <<- list(command = command, args = args, dots = list(...))
+      invisible(0)
+    },
+    .package = "base",
+    spark_config_kubernetes_forward_init(
+      driver = "spark-driver",
+      timeout = 0,
+      ports = c("8880:8880", "4040:4040")
+    )
+  )
+
+  expect_equal(slept, 0)
+  expect_equal(forwarded$command, "kubectl")
+  expect_equal(
+    forwarded$args,
+    c("port-forward", "spark-driver", "8880:8880", "4040:4040")
+  )
+  # system2 is invoked with wait = FALSE so the forward runs in the background
+  expect_false(forwarded$dots$wait)
+})
+
+test_that("spark_config_kubernetes_forward_init_message prints kubectl command", {
+  msgs <- testthat::capture_messages(
+    spark_config_kubernetes_forward_init_message(
+      driver = "spark-driver",
+      timeout = 0,
+      ports = c("8880:8880", "4040:4040")
+    )
+  )
+  expect_match(msgs, "Please enable port forwarding", all = FALSE)
+  expect_match(
+    msgs,
+    "kubectl port-forward spark-driver 8880:8880 4040:4040",
+    all = FALSE,
+    fixed = TRUE
+  )
+})
+
+test_that("spark_config_kubernetes_forward_cleanup pkills kubectl on non-Windows", {
+  skip_on_os("windows")
+  killed <- NULL
+  with_mocked_bindings(
+    system2 = function(command, args, ...) {
+      killed <<- list(command = command, args = args)
+      invisible(0)
+    },
+    .package = "base",
+    spark_config_kubernetes_forward_cleanup(driver = "spark-driver")
+  )
+
+  expect_equal(killed$command, "pkill")
+  expect_equal(killed$args, "kubectl")
+})
+
+test_that("spark_config_kubernetes builds forward submit/disconnect functions", {
+  skip_on_os("windows")
+  config <- spark_config_kubernetes(
+    master = "k8s://https://192.168.99.100:8443",
+    version = "3.0",
+    driver = "spark-driver",
+    forward = TRUE,
+    fix_config = FALSE
+  )
+
+  # forward = TRUE wires up both lifecycle callbacks
+  expect_type(config$sparklyr.connect.aftersubmit, "closure")
+  expect_type(config$sparklyr.connect.ondisconnect, "closure")
+
+  # the submit callback forwards the doubled-up ports through kubectl
+  forwarded <- NULL
+  with_mocked_bindings(
+    Sys.sleep = function(time) invisible(NULL),
+    system2 = function(command, args, ...) {
+      forwarded <<- args
+      invisible(0)
+    },
+    .package = "base",
+    config$sparklyr.connect.aftersubmit()
+  )
+  expect_equal(
+    forwarded,
+    c("port-forward", "spark-driver", "8880:8880", "8881:8881", "4040:4040")
+  )
+
+  # the disconnect callback cleans up the forward
+  killed <- NULL
+  with_mocked_bindings(
+    system2 = function(command, args, ...) {
+      killed <<- command
+      invisible(0)
+    },
+    .package = "base",
+    config$sparklyr.connect.ondisconnect()
+  )
+  expect_equal(killed, "pkill")
+})
+
+test_that("spark_config_kubernetes adds executor and conf entries", {
+  config <- spark_config_kubernetes(
+    master = "k8s://https://192.168.99.100:8443",
+    version = "3.0",
+    driver = "spark-driver",
+    forward = FALSE,
+    fix_config = FALSE,
+    executors = 4,
+    conf = list("spark.kubernetes.namespace" = "sparklyr-ns")
+  )
+
+  expect_true(
+    "spark.executor.instances=4" %in% config$sparklyr.shell.conf
+  )
+  expect_true(
+    "spark.kubernetes.namespace=sparklyr-ns" %in% config$sparklyr.shell.conf
+  )
+})
+
+test_that("spark_config_kubernetes fixes spark-defaults.conf when fix_config = TRUE", {
+  conf_dir <- withr::local_tempdir()
+  defaults <- file.path(conf_dir, "spark-defaults.conf")
+  writeLines(
+    c(
+      "spark.local.dir /tmp/spark",
+      "spark.sql.warehouse.dir /tmp/warehouse",
+      "spark.executor.memory 2g"
+    ),
+    defaults
+  )
+
+  with_mocked_bindings(
+    spark_install_find = function(...) list(sparkConfDir = conf_dir),
+    .package = "sparklyr",
+    spark_config_kubernetes(
+      master = "k8s://https://192.168.99.100:8443",
+      version = "3.0",
+      driver = "spark-driver",
+      forward = FALSE,
+      fix_config = TRUE
+    )
+  )
+
+  fixed <- readLines(defaults)
+  # the local.dir and warehouse.dir lines get commented out; others untouched
+  expect_true("# spark.local.dir /tmp/spark" %in% fixed)
+  expect_true("# spark.sql.warehouse.dir /tmp/warehouse" %in% fixed)
+  expect_true("spark.executor.memory 2g" %in% fixed)
+})
+
+# ---- Connection-gated tests -------------------------------------------------
+
 skip_connection("connection_kubernetes")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-connection_livy.R
+++ b/tests/testthat/test-connection_livy.R
@@ -37,7 +37,10 @@ test_that("livy_config() sets proxy, default headers, and rejects bad params", {
   expect_equal(config$sparklyr.livy.proxy, httr::use_proxy("localhost", 9999))
 
   # default custom header
-  expect_equal(config$sparklyr.livy.headers, list("X-Requested-By" = "sparklyr"))
+  expect_equal(
+    config$sparklyr.livy.headers,
+    list("X-Requested-By" = "sparklyr")
+  )
 
   expect_error(
     livy_config(not_a_real_param = 1),
@@ -50,7 +53,10 @@ test_that("livy_get_httr_config() merges headers, proxy, and curl opts", {
     proxy = httr::use_proxy("localhost", 9999),
     curl_opts = list(verbose = 1)
   )
-  httr_config <- livy_get_httr_config(config, list("Content-Type" = "application/json"))
+  httr_config <- livy_get_httr_config(
+    config,
+    list("Content-Type" = "application/json")
+  )
   expect_true(!is.null(httr_config$options))
 })
 
@@ -62,7 +68,23 @@ test_that("livy_config_get() filters spark.* but not spark.sql.*", {
 })
 
 test_that("livy_config_get_prefix() returns NULL when nothing matches", {
-  expect_null(livy_config_get_prefix("local", list(), "spark.", c("spark.sql.")))
+  expect_null(livy_config_get_prefix(
+    "local",
+    list(),
+    "spark.",
+    c("spark.sql.")
+  ))
+})
+
+test_that("livy_config_get_prefix() unboxes scalars but keeps vectors", {
+  out <- livy_config_get_prefix(
+    "local",
+    list("spark.scalar" = "x", "spark.vector" = c("a", "b")),
+    "spark.",
+    c("spark.sql.")
+  )
+  expect_s3_class(out[["spark.scalar"]], "scalar")
+  expect_equal(as.character(out[["spark.vector"]]), c("a", "b"))
 })
 
 test_that("livy_available_jars() returns version strings", {
@@ -72,7 +94,10 @@ test_that("livy_available_jars() returns version strings", {
 })
 
 test_that("livy_serialized_chunks() splits a string into n-sized chunks", {
-  expect_equal(livy_serialized_chunks("abcdefghij", 3), c("abc", "def", "ghi", "j"))
+  expect_equal(
+    livy_serialized_chunks("abcdefghij", 3),
+    c("abc", "def", "ghi", "j")
+  )
   expect_equal(livy_serialized_chunks("abc", 10), "abc")
 })
 
@@ -188,7 +213,10 @@ test_that("livy_get_json() issues a GET and returns parsed content", {
     http_error = function(...) FALSE,
     content = function(...) list(foo = "bar"),
     .package = "sparklyr",
-    expect_equal(livy_get_json("http://host/sessions", list()), list(foo = "bar"))
+    expect_equal(
+      livy_get_json("http://host/sessions", list()),
+      list(foo = "bar")
+    )
   )
 })
 
@@ -266,7 +294,9 @@ test_that("livy_post_statement() polls until a statement is available", {
 test_that("livy_invoke_statement() converts supported data types", {
   sc <- list()
   with_mocked_bindings(
-    livy_post_statement = function(sc, code) list("application/json" = list(a = 1)),
+    livy_post_statement = function(sc, code) {
+      list("application/json" = list(a = 1))
+    },
     .package = "sparklyr",
     expect_equal(livy_invoke_statement(sc, list(code = "x"))$a, 1)
   )
@@ -308,6 +338,253 @@ test_that("livy_validate_master() succeeds when sessions are reachable", {
     .package = "sparklyr",
     expect_null(livy_validate_master("http://host", list()))
   )
+})
+
+test_that("livy_validate_master() stops after exhausting retries", {
+  with_mocked_bindings(
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      livy_get_sessions = function(...) stop("no service"),
+      .package = "sparklyr",
+      expect_error(
+        livy_validate_master("http://host", list()),
+        "Failed to connect to Livy service"
+      )
+    )
+  )
+})
+
+test_that("create_hive_context.livy_connection() builds a HiveContext", {
+  with_mocked_bindings(
+    invoke_new = function(sc, class, ...) list(class = class),
+    spark_context = function(sc) "ctx",
+    .package = "sparklyr",
+    expect_equal(
+      create_hive_context.livy_connection("sc")$class,
+      "org.apache.spark.sql.hive.HiveContext"
+    )
+  )
+})
+
+test_that("livy_create_session() appends session params when present", {
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) list(id = 1, state = "idle", kind = "spark"),
+    .package = "sparklyr",
+    {
+      session <- livy_create_session("http://host", list("livy.foo" = "bar"))
+      expect_equal(session$state, "idle")
+    }
+  )
+})
+
+test_that("livy_post_statement() polls, then surfaces bad states and errors", {
+  sc <- list(
+    master = "http://host",
+    sessionId = 1,
+    config = list(),
+    log = tempfile(fileext = ".log")
+  )
+
+  # poll: running -> available
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) list(id = 1, state = "running"),
+    livy_get_statement = function(...) {
+      list(
+        id = 1,
+        state = "available",
+        output = list(
+          status = "ok",
+          data = list("application/json" = list(x = 1))
+        )
+      )
+    },
+    .package = "sparklyr",
+    {
+      data <- livy_post_statement(sc, "1 + 1")
+      expect_equal(data[["application/json"]]$x, 1)
+    }
+  )
+
+  # non-available terminal state
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) list(id = 1, state = "dead"),
+    .package = "sparklyr",
+    expect_error(livy_post_statement(sc, "x"), "state dead")
+  )
+
+  # output error with an evalue
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) {
+      list(
+        id = 1,
+        state = "available",
+        output = list(
+          status = "error",
+          evalue = "kaboom",
+          traceback = list("at X")
+        )
+      )
+    },
+    .package = "sparklyr",
+    expect_error(livy_post_statement(sc, "x"), "kaboom")
+  )
+
+  # output error without an evalue (falls back to the JSON dump)
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) {
+      list(
+        id = 1,
+        state = "available",
+        output = list(status = "error", evalue = NULL, traceback = list())
+      )
+    },
+    .package = "sparklyr",
+    expect_error(
+      livy_post_statement(sc, "x"),
+      "Failed to execute Livy statement"
+    )
+  )
+})
+
+test_that("livy_invoke_statement_fetch() returns, retries on truncation, and validates type", {
+  sc <- list(code = new.env())
+  lobj <- structure(list(varName = "v"), class = c("spark_jobj", "livy_jobj"))
+
+  # normal path
+  with_mocked_bindings(
+    livy_statement_compose = function(...) list(code = "c", lobj = lobj),
+    livy_invoke_statement = function(...) "result",
+    livy_invoke_deserialize = function(sc, res) res,
+    .package = "sparklyr",
+    expect_equal(
+      livy_invoke_statement_fetch(sc, TRUE, "Class", "m", FALSE),
+      "result"
+    )
+  )
+
+  # non-character result -> error
+  with_mocked_bindings(
+    livy_statement_compose = function(...) list(code = "c", lobj = lobj),
+    livy_invoke_statement = function(...) list(),
+    .package = "sparklyr",
+    expect_error(
+      livy_invoke_statement_fetch(sc, TRUE, "Class", "m", FALSE),
+      "character result expected"
+    )
+  )
+
+  # truncated result -> retried with magic
+  n <- 0
+  with_mocked_bindings(
+    livy_statement_compose = function(...) list(code = "c", lobj = lobj),
+    livy_invoke_statement = function(...) {
+      n <<- n + 1
+      if (n == 1) "truncated..." else "full"
+    },
+    livy_invoke_deserialize = function(sc, res) res,
+    .package = "sparklyr",
+    expect_equal(
+      livy_invoke_statement_fetch(sc, TRUE, "Class", "m", FALSE),
+      "full"
+    )
+  )
+})
+
+test_that("livy invoke dispatch methods delegate to the fetch helper", {
+  jobj <- structure(list(), class = c("spark_jobj", "livy_jobj"))
+  with_mocked_bindings(
+    livy_invoke_statement_fetch = function(sc, static, jobj, method, ref, ...) {
+      list(static = static, ref = ref)
+    },
+    spark_connection = function(x) "sc",
+    .package = "sparklyr",
+    {
+      expect_false(invoke.livy_jobj(jobj, "m")$static)
+      expect_true(j_invoke.livy_jobj(jobj, "m")$ref)
+      expect_true(invoke_static.livy_connection("sc", "Class", "m")$static)
+      expect_true(j_invoke_static.livy_connection("sc", "Class", "m")$ref)
+      expect_true(invoke_new.livy_connection("sc", "Class")$static)
+      expect_true(j_invoke_new.livy_connection("sc", "Class")$ref)
+    }
+  )
+
+  with_mocked_bindings(
+    livy_post_statement = function(sc, code) code,
+    .package = "sparklyr",
+    expect_equal(invoke_raw("sc", "code"), "code")
+  )
+})
+
+test_that("livy_try_get_session() swallows errors", {
+  with_mocked_bindings(
+    livy_get_session = function(sc) list(state = "idle"),
+    .package = "sparklyr",
+    expect_equal(livy_try_get_session("sc")$state, "idle")
+  )
+  with_mocked_bindings(
+    livy_get_session = function(sc) stop("boom"),
+    .package = "sparklyr",
+    expect_null(livy_try_get_session("sc"))
+  )
+})
+
+test_that("connection_is_open.livy_connection() reflects session state", {
+  with_mocked_bindings(
+    livy_try_get_session = function(sc) NULL,
+    .package = "sparklyr",
+    expect_false(connection_is_open.livy_connection("sc"))
+  )
+  with_mocked_bindings(
+    livy_try_get_session = function(sc) list(state = "idle"),
+    .package = "sparklyr",
+    expect_true(connection_is_open.livy_connection("sc"))
+  )
+})
+
+test_that("spark_disconnect.livy_connection() destroys unless terminate is FALSE", {
+  destroyed <- FALSE
+  with_mocked_bindings(
+    livy_destroy_session = function(sc) {
+      destroyed <<- TRUE
+      NULL
+    },
+    .package = "sparklyr",
+    {
+      spark_disconnect.livy_connection("sc")
+      expect_true(destroyed)
+
+      destroyed <- FALSE
+      spark_disconnect.livy_connection("sc", terminate = FALSE)
+      expect_false(destroyed)
+    }
+  )
+})
+
+test_that("livy_connection_jars() honors a scala version", {
+  jars <- livy_connection_jars(list(), "3.4", "2.12")
+  expect_match(jars, "github.com/sparklyr")
+})
+
+test_that("livy_connection() requires an explicit Spark version", {
+  expect_error(
+    livy_connection("local", list(), "app", NULL, NULL, list()),
+    "require the Spark version"
+  )
+})
+
+test_that("assert_that() aborts on a false condition", {
+  expect_error(assert_that(1 == 2))
 })
 
 # ---------------------------------------------------------------------------

--- a/tests/testthat/test-connection_livy.R
+++ b/tests/testthat/test-connection_livy.R
@@ -1,7 +1,322 @@
+# ---------------------------------------------------------------------------
+# Local, Livy-free tests. These exercise the pure helpers and (via mocked httr)
+# the request/response layer without ever contacting a live Livy server. The
+# genuinely live integration test is gated below by skip_unless_livy().
+# ---------------------------------------------------------------------------
+
+test_that("livy_config() works with extended parameters", {
+  config <- livy_config(num_executors = 1)
+  expect_equal(as.integer(config$livy.numExecutors), 1)
+})
+
+test_that("livy_config() works with authentication", {
+  config_basic <- livy_config(username = "foo", password = "bar")
+  expect_equal(
+    config_basic$sparklyr.livy.auth,
+    httr::authenticate("foo", "bar", type = "basic")
+  )
+
+  config_negotiate <- livy_config(negotiate = TRUE)
+  expect_equal(
+    config_negotiate$sparklyr.livy.auth,
+    httr::authenticate("", "", type = "gssnegotiate")
+  )
+})
+
+test_that("livy_config() works with additional_curl_opts", {
+  config <- livy_config()
+  expect_null(config$sparklyr.livy.curl_opts)
+
+  curl_opts <- list(accepttimeout_ms = 5000, verbose = 1)
+  config <- livy_config(curl_opts = curl_opts)
+  expect_equal(config$sparklyr.livy.curl_opts, curl_opts)
+})
+
+test_that("livy_config() sets proxy, default headers, and rejects bad params", {
+  config <- livy_config(proxy = httr::use_proxy("localhost", 9999))
+  expect_equal(config$sparklyr.livy.proxy, httr::use_proxy("localhost", 9999))
+
+  # default custom header
+  expect_equal(config$sparklyr.livy.headers, list("X-Requested-By" = "sparklyr"))
+
+  expect_error(
+    livy_config(not_a_real_param = 1),
+    "are not valid session parameters"
+  )
+})
+
+test_that("livy_get_httr_config() merges headers, proxy, and curl opts", {
+  config <- livy_config(
+    proxy = httr::use_proxy("localhost", 9999),
+    curl_opts = list(verbose = 1)
+  )
+  httr_config <- livy_get_httr_config(config, list("Content-Type" = "application/json"))
+  expect_true(!is.null(httr_config$options))
+})
+
+test_that("livy_config_get() filters spark.* but not spark.sql.*", {
+  config <- list("spark.foo" = "bar", "spark.sql.shuffle" = "200")
+  out <- livy_config_get("local", config)
+  expect_true("spark.foo" %in% names(out))
+  expect_false("spark.sql.shuffle" %in% names(out))
+})
+
+test_that("livy_config_get_prefix() returns NULL when nothing matches", {
+  expect_null(livy_config_get_prefix("local", list(), "spark.", c("spark.sql.")))
+})
+
+test_that("livy_available_jars() returns version strings", {
+  jars <- livy_available_jars()
+  expect_type(jars, "character")
+  expect_true(length(jars) > 0)
+})
+
+test_that("livy_serialized_chunks() splits a string into n-sized chunks", {
+  expect_equal(livy_serialized_chunks("abcdefghij", 3), c("abc", "def", "ghi", "j"))
+  expect_equal(livy_serialized_chunks("abc", 10), "abc")
+})
+
+test_that("livy_statement_new() and livy_jobj_create() build expected structures", {
+  st <- livy_statement_new("code", list(varName = "x"))
+  expect_equal(st$code, "code")
+
+  jobj <- livy_jobj_create(sc = "sc", varName = "v")
+  expect_s3_class(jobj, "livy_jobj")
+  expect_equal(jobj$varName, "v")
+})
+
+test_that("livy_code_new_return_var() names and increments return vars", {
+  sc <- list(code = new.env())
+  sc$code$totalReturnVars <- 0
+  expect_equal(livy_code_new_return_var(sc), "sparklyrRetVar_0")
+  expect_equal(livy_code_new_return_var(sc), "sparklyrRetVar_1")
+  expect_equal(sc$code$totalReturnVars, 2)
+})
+
+test_that("livy_statement_compose_magic() builds a magic statement", {
+  st <- livy_statement_compose_magic(list(varName = "v"), "json")
+  expect_equal(st$code, "%json v")
+  expect_null(st$lobj)
+})
+
+test_that("livy_invoke_statement_command() renders each call form", {
+  expect_equal(
+    livy_invoke_statement_command(NULL, TRUE, "MyClass", "<init>", FALSE),
+    "// invoke_new(sc, 'MyClass', ...)"
+  )
+  expect_equal(
+    livy_invoke_statement_command(NULL, TRUE, "MyClass", "doThing", TRUE),
+    "// j_invoke_static(sc, 'MyClass', 'doThing', ...)"
+  )
+  expect_equal(
+    livy_invoke_statement_command(NULL, FALSE, list(), "doThing", FALSE),
+    "// invoke(sc, <jobj>, 'doThing', ...)"
+  )
+})
+
+test_that("livy_inspect() returns NULL", {
+  expect_null(livy_inspect(list()))
+})
+
+test_that("livy_log_operation() appends truncated text to the log file", {
+  sc <- list(log = tempfile(fileext = ".log"))
+  livy_log_operation(sc, "hello world")
+  expect_equal(readLines(sc$log), "hello world")
+})
+
+test_that("livy_connection_not_used_warn() warns only on non-default values", {
+  expect_warning(livy_connection_not_used_warn("custom", "default", "thing"))
+  expect_silent(livy_connection_not_used_warn("default", "default", "thing"))
+})
+
+test_that("livy_states_info() reports connected status per state", {
+  states <- livy_states_info()
+  expect_false(states$dead$connected)
+  expect_true(states$idle$connected)
+})
+
+test_that("livy_connection_jars() picks a jar url or honors an explicit jar", {
+  jars <- livy_connection_jars(list(), "3.4", NULL)
+  expect_match(jars, "github.com/sparklyr")
+
+  explicit <- livy_connection_jars(
+    list(sparklyr.livy.jar = "my.jar"),
+    "3.4",
+    NULL
+  )
+  expect_equal(explicit, list("my.jar"))
+})
+
+test_that("spark_log/spark_web are unsupported for livy connections", {
+  expect_error(spark_log.livy_connection(NULL), "Unsupported operation")
+  expect_error(spark_web.livy_connection(NULL), "Unsupported operation")
+})
+
+test_that("livy_validate_http_response() handles success, 401, and other errors", {
+  # success: no error -> returns invisibly without stopping
+  with_mocked_bindings(
+    http_error = function(...) FALSE,
+    .package = "sparklyr",
+    expect_silent(livy_validate_http_response("msg", "req"))
+  )
+
+  # 401 -> unauthorized message
+  with_mocked_bindings(
+    http_error = function(...) TRUE,
+    status_code = function(...) 401L,
+    .package = "sparklyr",
+    expect_error(livy_validate_http_response("msg", "req"), "unauthorized")
+  )
+
+  # other error -> message + status + content
+  with_mocked_bindings(
+    http_error = function(...) TRUE,
+    status_code = function(...) 500L,
+    http_status = function(...) list(message = "Server Error"),
+    content = function(...) "boom",
+    .package = "sparklyr",
+    expect_error(
+      livy_validate_http_response("Failed", "req"),
+      "Failed.*Server Error.*boom"
+    )
+  )
+})
+
+test_that("livy_get_json() issues a GET and returns parsed content", {
+  with_mocked_bindings(
+    GET = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) list(foo = "bar"),
+    .package = "sparklyr",
+    expect_equal(livy_get_json("http://host/sessions", list()), list(foo = "bar"))
+  )
+})
+
+test_that("livy_get_sessions/get_session/get_statement validate their payloads", {
+  with_mocked_bindings(
+    livy_get_json = function(...) list(sessions = list(), total = 0),
+    .package = "sparklyr",
+    expect_equal(livy_get_sessions("http://host", list())$total, 0)
+  )
+
+  sc <- list(master = "http://host", sessionId = 7, config = list())
+  with_mocked_bindings(
+    livy_get_json = function(...) list(id = 7, state = "idle"),
+    .package = "sparklyr",
+    expect_equal(livy_get_session(sc)$state, "idle")
+  )
+
+  with_mocked_bindings(
+    livy_get_json = function(...) list(id = 3, state = "available"),
+    .package = "sparklyr",
+    expect_equal(livy_get_statement(sc, 3)$state, "available")
+  )
+})
+
+test_that("livy_create_session() posts and validates the session payload", {
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) list(id = 1, state = "idle", kind = "spark"),
+    .package = "sparklyr",
+    {
+      session <- livy_create_session("http://host", list())
+      expect_equal(session$id, 1)
+      expect_equal(session$kind, "spark")
+    }
+  )
+})
+
+test_that("livy_destroy_session() deletes and confirms the session", {
+  sc <- list(master = "http://host", sessionId = 1, config = list())
+  with_mocked_bindings(
+    DELETE = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) list(msg = "deleted"),
+    .package = "sparklyr",
+    expect_null(livy_destroy_session(sc))
+  )
+})
+
+test_that("livy_post_statement() polls until a statement is available", {
+  sc <- list(
+    master = "http://host",
+    sessionId = 1,
+    config = list(),
+    log = tempfile(fileext = ".log")
+  )
+  with_mocked_bindings(
+    POST = function(...) "req",
+    http_error = function(...) FALSE,
+    content = function(...) {
+      list(
+        id = 1,
+        state = "available",
+        output = list(status = "ok", data = list("text/plain" = "result"))
+      )
+    },
+    .package = "sparklyr",
+    {
+      data <- livy_post_statement(sc, "1 + 1")
+      expect_equal(data[["text/plain"]], "result")
+    }
+  )
+})
+
+test_that("livy_invoke_statement() converts supported data types", {
+  sc <- list()
+  with_mocked_bindings(
+    livy_post_statement = function(sc, code) list("application/json" = list(a = 1)),
+    .package = "sparklyr",
+    expect_equal(livy_invoke_statement(sc, list(code = "x"))$a, 1)
+  )
+
+  with_mocked_bindings(
+    livy_post_statement = function(sc, code) list("unsupported/type" = "x"),
+    .package = "sparklyr",
+    expect_error(livy_invoke_statement(sc, list(code = "x")), "unsupported")
+  )
+})
+
+test_that("livy_statement_compose() composes single- and multi-chunk statements", {
+  sc <- list(code = new.env())
+  sc$code$totalReturnVars <- 0
+
+  with_mocked_bindings(
+    livy_invoke_serialize = function(...) "short",
+    .package = "sparklyr",
+    {
+      st <- livy_statement_compose(sc, TRUE, "MyClass", "doThing")
+      expect_match(st$code, "invokeFromBase64")
+      expect_s3_class(st$lobj, "livy_jobj")
+    }
+  )
+
+  with_mocked_bindings(
+    livy_invoke_serialize = function(...) paste(rep("x", 25000), collapse = ""),
+    .package = "sparklyr",
+    {
+      st <- livy_statement_compose(sc, TRUE, "MyClass", "doThing")
+      expect_match(st$code, "StringBuilder")
+    }
+  )
+})
+
+test_that("livy_validate_master() succeeds when sessions are reachable", {
+  with_mocked_bindings(
+    livy_get_sessions = function(...) list(sessions = list(), total = 0),
+    .package = "sparklyr",
+    expect_null(livy_validate_master("http://host", list()))
+  )
+})
+
+# ---------------------------------------------------------------------------
+# Live Livy integration. Skipped unless a Livy server is available. We are not
+# investing further in live Livy coverage (legacy technology).
+# ---------------------------------------------------------------------------
 skip_connection("connection_livy")
 skip_unless_livy()
 skip_on_arrow_devel()
-
 
 num_open_fds <- function(port) {
   n <- system2(
@@ -12,37 +327,6 @@ num_open_fds <- function(port) {
 
   as.integer(n)
 }
-
-test_that("'livy_config()' works with extended parameters", {
-  config <- livy_config(num_executors = 1)
-
-  expect_equal(as.integer(config$livy.numExecutors), 1)
-})
-
-test_that("'livy_config()' works with authentication", {
-  config_basic <- livy_config(username = "foo", password = "bar")
-
-  expect_equal(
-    config_basic$sparklyr.livy.auth,
-    httr::authenticate("foo", "bar", type = "basic")
-  )
-
-  config_negotiate <- livy_config(negotiate = TRUE)
-
-  expect_equal(
-    config_negotiate$sparklyr.livy.auth,
-    httr::authenticate("", "", type = "gssnegotiate")
-  )
-})
-
-test_that("'livy_config()' works with additional_curl_opts", {
-  config <- livy_config()
-  expect_null(config$sparklyr.livy.curl_opts)
-
-  curl_opts <- list(accepttimeout_ms = 5000, verbose = 1)
-  config <- livy_config(curl_opts = curl_opts)
-  expect_equal(config$sparklyr.livy.curl_opts, curl_opts)
-})
 
 test_that("Livy connection works with HTTP proxy", {
   sc <- testthat_spark_connection()

--- a/tests/testthat/test-connection_livy.R
+++ b/tests/testthat/test-connection_livy.R
@@ -593,14 +593,20 @@ test_that("assert_that() aborts on a false condition", {
 # create-session retry loop, the wait-for-start loop, and the session-state
 # guards) without a live Livy server -- only the HTTP boundary is mocked.
 
-livy_connect_mocked <- function(create,
-                                get = function(sc) list(id = "s1", state = "idle"),
-                                config = list(),
-                                master = "local") {
+livy_connect_mocked <- function(
+  create,
+  get = function(sc) list(id = "s1", state = "idle"),
+  config = list(),
+  master = "local"
+) {
   with_mocked_bindings(
     livy_validate_master = function(...) invisible(TRUE),
     spark_dependencies_from_extensions = function(...) {
-      list(catalog_jars = character(), packages = "org.x:y:1", repositories = "https://r")
+      list(
+        catalog_jars = character(),
+        packages = "org.x:y:1",
+        repositories = "https://r"
+      )
     },
     livy_create_session = create,
     livy_get_session = get,
@@ -609,8 +615,12 @@ livy_connect_mocked <- function(create,
       Sys.sleep = function(...) invisible(NULL),
       .package = "base",
       suppressWarnings(livy_connection(
-        master = master, config = config, app_name = "sparklyr",
-        version = "3.5.0", hadoop_version = NULL, extensions = list(),
+        master = master,
+        config = config,
+        app_name = "sparklyr",
+        version = "3.5.0",
+        hadoop_version = NULL,
+        extensions = list(),
         scala_version = NULL
       ))
     )
@@ -618,7 +628,9 @@ livy_connect_mocked <- function(create,
 }
 
 test_that("livy_connection() assembles config and connects to an idle session", {
-  sc <- livy_connect_mocked(create = function(...) list(id = "s1", state = "idle"))
+  sc <- livy_connect_mocked(create = function(...) {
+    list(id = "s1", state = "idle")
+  })
   expect_s3_class(sc, "livy_connection")
   expect_equal(sc$master, "http://localhost:8998") # local -> http normalized
   expect_match(sc$config[["spark.jars.packages"]], "org.x:y:1")

--- a/tests/testthat/test-connection_livy.R
+++ b/tests/testthat/test-connection_livy.R
@@ -587,6 +587,94 @@ test_that("assert_that() aborts on a false condition", {
   expect_error(assert_that(1 == 2))
 })
 
+# ---- livy_connection() orchestration, Livy HTTP layer mocked ----------------
+# The version-NULL guard is covered above. These drive the rest of the body
+# (master normalization, jars/packages/repositories config assembly, the
+# create-session retry loop, the wait-for-start loop, and the session-state
+# guards) without a live Livy server -- only the HTTP boundary is mocked.
+
+livy_connect_mocked <- function(create,
+                                get = function(sc) list(id = "s1", state = "idle"),
+                                config = list(),
+                                master = "local") {
+  with_mocked_bindings(
+    livy_validate_master = function(...) invisible(TRUE),
+    spark_dependencies_from_extensions = function(...) {
+      list(catalog_jars = character(), packages = "org.x:y:1", repositories = "https://r")
+    },
+    livy_create_session = create,
+    livy_get_session = get,
+    .package = "sparklyr",
+    with_mocked_bindings(
+      Sys.sleep = function(...) invisible(NULL),
+      .package = "base",
+      suppressWarnings(livy_connection(
+        master = master, config = config, app_name = "sparklyr",
+        version = "3.5.0", hadoop_version = NULL, extensions = list(),
+        scala_version = NULL
+      ))
+    )
+  )
+}
+
+test_that("livy_connection() assembles config and connects to an idle session", {
+  sc <- livy_connect_mocked(create = function(...) list(id = "s1", state = "idle"))
+  expect_s3_class(sc, "livy_connection")
+  expect_equal(sc$master, "http://localhost:8998") # local -> http normalized
+  expect_match(sc$config[["spark.jars.packages"]], "org.x:y:1")
+  expect_match(sc$config[["spark.jars.repositories"]], "https://r")
+  expect_true(length(sc$config[["livy.jars"]]) > 0)
+})
+
+test_that("livy_connection() trims a trailing slash from the master URL", {
+  sc <- livy_connect_mocked(
+    create = function(...) list(id = "s1", state = "idle"),
+    master = "http://example.com:8998/"
+  )
+  expect_equal(sc$master, "http://example.com:8998")
+})
+
+test_that("livy_connection() waits for a starting session to become idle", {
+  sc <- livy_connect_mocked(
+    create = function(...) list(id = "s1", state = "starting"),
+    get = function(sc) list(id = "s1", state = "idle")
+  )
+  expect_s3_class(sc, "livy_connection")
+})
+
+test_that("livy_connection() errors when the session never leaves starting", {
+  expect_error(
+    livy_connect_mocked(
+      create = function(...) list(id = "s1", state = "starting"),
+      get = function(sc) list(id = "s1", state = "starting"),
+      config = list(sparklyr.connect.timeout = 0)
+    ),
+    "still starting"
+  )
+})
+
+test_that("livy_connection() errors on a non-idle session state", {
+  expect_error(
+    livy_connect_mocked(create = function(...) list(id = "s1", state = "dead")),
+    "session status is dead"
+  )
+})
+
+test_that("livy_connection() retries session creation before failing", {
+  attempts <- 0L
+  expect_error(
+    livy_connect_mocked(
+      create = function(...) {
+        attempts <<- attempts + 1L
+        stop("boom")
+      },
+      config = list(sparklyr.livy_create_session.retries = 1L)
+    ),
+    "boom"
+  )
+  expect_equal(attempts, 2L) # initial attempt + one retry
+})
+
 # ---------------------------------------------------------------------------
 # Live Livy integration. Skipped unless a Livy server is available. We are not
 # investing further in live Livy coverage (legacy technology).

--- a/tests/testthat/test-connection_shell.R
+++ b/tests/testthat/test-connection_shell.R
@@ -163,4 +163,112 @@ test_that("Misc tests", {
   )
 })
 
+test_that("shell_connection_validate_config warns on the deprecated jars config", {
+  expect_warning(
+    cfg <- shell_connection_validate_config(list(spark.jars.default = "x.jar")),
+    "deprecated"
+  )
+  expect_equal(cfg[["sparklyr.jars.default"]], "x.jar")
+  expect_silent(shell_connection_validate_config(list()))
+})
+
+test_that("abort_shell surfaces log/error file contents and parameters", {
+  out <- tempfile()
+  writeLines(c("out line 1", "out line 2"), out)
+  err <- tempfile()
+  writeLines("err line 1", err)
+
+  with_mocked_bindings(
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    expect_error(
+      abort_shell(
+        message = "boom",
+        spark_submit_path = "/bin/spark-submit",
+        shell_args = c("--a", "--b"),
+        output_file = out,
+        error_file = err
+      ),
+      "out line 2"
+    )
+  )
+})
+
+test_that("spark_log handles a filter and an unavailable log", {
+  f <- tempfile()
+  writeLines(c("INFO ok", "ERROR boom"), f)
+  sc_fake <- structure(
+    list(output_file = f),
+    class = c("spark_shell_connection", "spark_connection")
+  )
+
+  filtered <- spark_log.spark_shell_connection(sc_fake, filter = "ERROR")
+  expect_s3_class(filtered, "spark_log")
+  expect_true(all(grepl("ERROR", filtered)))
+
+  with_mocked_bindings(
+    file = function(...) stop("no log"),
+    .package = "base",
+    expect_equal(
+      as.character(spark_log.spark_shell_connection(sc_fake)),
+      "Spark log is not available."
+    )
+  )
+})
+
+test_that("print_jobj reports a detached jobj when the connection is closed", {
+  sc_fake <- structure(
+    list(),
+    class = c("spark_shell_connection", "spark_connection")
+  )
+  with_mocked_bindings(
+    connection_is_open = function(sc) FALSE,
+    .package = "sparklyr",
+    {
+      out <- capture.output(
+        print_jobj.spark_shell_connection(sc_fake, list(id = "7"))
+      )
+      expect_match(paste(out, collapse = " "), "detached")
+    }
+  )
+})
+
+test_that("shell j_invoke dispatch delegates to the core invoke helpers", {
+  sc_fake <- structure(
+    list(),
+    class = c("spark_shell_connection", "spark_connection")
+  )
+
+  # j_invoke_method passes jObject = TRUE through to core_invoke_method
+  with_mocked_bindings(
+    core_invoke_method = function(sc, static, object, method, jObject, ...) {
+      list(static = static, jObject = jObject, method = method)
+    },
+    .package = "sparklyr",
+    {
+      r <- j_invoke_method.spark_shell_connection(sc_fake, TRUE, "C", "m")
+      expect_true(r$jObject)
+    }
+  )
+
+  with_mocked_bindings(
+    j_invoke_method = function(sc, static, object, method, ...) {
+      list(static = static, method = method)
+    },
+    spark_connection = function(x) "sc",
+    .package = "sparklyr",
+    {
+      expect_false(j_invoke.shell_jobj(list(), "m")$static)
+      expect_equal(
+        j_invoke_static.spark_shell_connection("sc", "C", "m")$method,
+        "m"
+      )
+      expect_equal(
+        j_invoke_new.spark_shell_connection("sc", "C")$method,
+        "<init>"
+      )
+    }
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-connection_shell.R
+++ b/tests/testthat/test-connection_shell.R
@@ -291,7 +291,11 @@ test_that("start_shell assembles --jars/--packages/--repositories args", {
       f
     },
     spark_dependencies_from_extensions = function(...) {
-      list(jars = character(), packages = "org.example:lib:1.0", repositories = "https://repo")
+      list(
+        jars = character(),
+        packages = "org.example:lib:1.0",
+        repositories = "https://repo"
+      )
     },
     .package = "sparklyr",
     with_mocked_bindings(
@@ -324,16 +328,23 @@ test_that("start_shell assembles --jars/--packages/--repositories args", {
 })
 
 test_that("start_shell errors on bad spark_home / missing spark-submit / version", {
-  run <- function(spark_home, config = list(sparklyr.connect.app.jar = "x.jar"),
-                  app_jar_mock = function(...) "irrelevant.jar") {
+  run <- function(
+    spark_home,
+    config = list(sparklyr.connect.app.jar = "x.jar"),
+    app_jar_mock = function(...) "irrelevant.jar"
+  ) {
     with_mocked_bindings(
       spark_connect_gateway = function(...) NULL,
       spark_version_from_home = function(...) "3.5.0",
       spark_default_app_jar = app_jar_mock,
       .package = "sparklyr",
       start_shell(
-        master = "local", spark_home = spark_home, spark_version = "3.5.0",
-        app_name = "t", config = config, extensions = list(),
+        master = "local",
+        spark_home = spark_home,
+        spark_version = "3.5.0",
+        app_name = "t",
+        config = config,
+        extensions = list(),
         environment = new.env()
       )
     )
@@ -361,10 +372,18 @@ test_that("shell_connection errors when SPARK_HOME is not set", {
     .package = "sparklyr",
     expect_error(
       shell_connection(
-        master = "spark://host:7077", spark_home = "", method = "",
-        app_name = "t", version = NULL, hadoop_version = NULL,
-        shell_args = NULL, config = list(), service = FALSE,
-        remote = FALSE, extensions = list(), batch = NULL
+        master = "spark://host:7077",
+        spark_home = "",
+        method = "",
+        app_name = "t",
+        version = NULL,
+        hadoop_version = NULL,
+        shell_args = NULL,
+        config = list(),
+        service = FALSE,
+        remote = FALSE,
+        extensions = list(),
+        batch = NULL
       ),
       "SPARK_HOME is not set"
     )
@@ -389,7 +408,11 @@ test_that("start_shell aborts after exhausting gateway connect attempts", {
       f
     },
     spark_dependencies_from_extensions = function(...) {
-      list(jars = character(), packages = character(), repositories = character())
+      list(
+        jars = character(),
+        packages = character(),
+        repositories = character()
+      )
     },
     .package = "sparklyr",
     with_mocked_bindings(
@@ -398,9 +421,14 @@ test_that("start_shell aborts after exhausting gateway connect attempts", {
       .package = "base",
       expect_error(
         start_shell(
-          master = "local", spark_home = home, spark_version = "3.5.0",
-          app_name = "t", config = list(), extensions = list(),
-          environment = new.env(), gateway_connect_attempts = 1
+          master = "local",
+          spark_home = home,
+          spark_version = "3.5.0",
+          app_name = "t",
+          config = list(),
+          extensions = list(),
+          environment = new.env(),
+          gateway_connect_attempts = 1
         ),
         "Failed while connecting to sparklyr"
       )
@@ -425,8 +453,12 @@ test_that("start_shell aborts when the backend socket cannot be opened", {
       .package = "base",
       expect_error(
         start_shell(
-          master = "local", spark_home = "/x", spark_version = "3.5.0",
-          app_name = "t", config = list(), extensions = list(),
+          master = "local",
+          spark_home = "/x",
+          spark_version = "3.5.0",
+          app_name = "t",
+          config = list(),
+          extensions = list(),
           environment = new.env()
         ),
         "Failed to open connection to backend"
@@ -437,8 +469,13 @@ test_that("start_shell aborts when the backend socket cannot be opened", {
 
 test_that("initialize_connection aborts when backend setup fails", {
   sc <- structure(
-    list(state = new.env(), output_file = tempfile(), app_name = "t",
-         master = "local", config = list()),
+    list(
+      state = new.env(),
+      output_file = tempfile(),
+      app_name = "t",
+      master = "local",
+      config = list()
+    ),
     class = c("spark_shell_connection", "spark_connection")
   )
   with_mocked_bindings(

--- a/tests/testthat/test-connection_shell.R
+++ b/tests/testthat/test-connection_shell.R
@@ -271,4 +271,184 @@ test_that("shell j_invoke dispatch delegates to the core invoke helpers", {
   )
 })
 
+test_that("start_shell assembles --jars/--packages/--repositories args", {
+  # batch = TRUE makes start_shell build the args + call spark-submit, then
+  # return early (no gateway/socket). Mock spark_connect_gateway to NULL so it
+  # takes the launch path, and capture the spark-submit args from system2.
+  captured <- NULL
+  home <- withr::local_tempdir()
+  dir.create(file.path(home, "bin"))
+  invisible(file.create(file.path(home, "bin", "spark-submit")))
+  jar1 <- withr::local_tempfile(fileext = ".jar")
+  invisible(file.create(jar1))
+
+  with_mocked_bindings(
+    spark_connect_gateway = function(...) NULL,
+    spark_version_from_home = function(...) "3.5.0",
+    spark_default_app_jar = function(...) {
+      f <- tempfile(fileext = ".jar")
+      file.create(f)
+      f
+    },
+    spark_dependencies_from_extensions = function(...) {
+      list(jars = character(), packages = "org.example:lib:1.0", repositories = "https://repo")
+    },
+    .package = "sparklyr",
+    with_mocked_bindings(
+      system2 = function(command, args, ...) {
+        captured <<- args
+        0L
+      },
+      .package = "base",
+      expect_null(start_shell(
+        master = "local",
+        spark_home = home,
+        spark_version = "3.5.0",
+        app_name = "t",
+        config = list(),
+        extensions = list(),
+        jars = jar1,
+        packages = "com.example:foo:2.0",
+        environment = new.env(),
+        batch = TRUE
+      ))
+    )
+  )
+
+  joined <- paste(captured, collapse = " ")
+  expect_match(joined, "--jars")
+  expect_match(joined, basename(jar1), fixed = TRUE)
+  expect_match(joined, "--packages")
+  expect_match(joined, "com.example:foo:2.0", fixed = TRUE)
+  expect_match(joined, "--repositories")
+})
+
+test_that("start_shell errors on bad spark_home / missing spark-submit / version", {
+  run <- function(spark_home, config = list(sparklyr.connect.app.jar = "x.jar"),
+                  app_jar_mock = function(...) "irrelevant.jar") {
+    with_mocked_bindings(
+      spark_connect_gateway = function(...) NULL,
+      spark_version_from_home = function(...) "3.5.0",
+      spark_default_app_jar = app_jar_mock,
+      .package = "sparklyr",
+      start_shell(
+        master = "local", spark_home = spark_home, spark_version = "3.5.0",
+        app_name = "t", config = config, extensions = list(),
+        environment = new.env()
+      )
+    )
+  }
+
+  # empty spark_home (app jar supplied via config so we reach the nzchar guard)
+  expect_error(run(""), "No spark_home")
+  # spark_home points at a missing directory
+  expect_error(run("/no/such/dir"), "not found")
+  # real directory but no bin/spark-submit
+  empty_home <- withr::local_tempdir()
+  expect_error(run(empty_home), "Failed to find")
+  # unsupported Spark version: spark_default_app_jar returns ""
+  expect_error(
+    run("/whatever", config = list(), app_jar_mock = function(...) ""),
+    "does not support"
+  )
+})
+
+test_that("shell_connection errors when SPARK_HOME is not set", {
+  # non-local master skips the install-find/windows-prep branches, so we land on
+  # the nzchar(spark_home) guard.
+  with_mocked_bindings(
+    validate_java_version = function(...) invisible(TRUE),
+    .package = "sparklyr",
+    expect_error(
+      shell_connection(
+        master = "spark://host:7077", spark_home = "", method = "",
+        app_name = "t", version = NULL, hadoop_version = NULL,
+        shell_args = NULL, config = list(), service = FALSE,
+        remote = FALSE, extensions = list(), batch = NULL
+      ),
+      "SPARK_HOME is not set"
+    )
+  )
+})
+
+test_that("start_shell aborts after exhausting gateway connect attempts", {
+  # routing gateway returns NULL (enter launch path); the retry-loop gateway
+  # always errors, so after the attempts run out start_shell calls abort_shell.
+  home <- withr::local_tempdir()
+  dir.create(file.path(home, "bin"))
+  invisible(file.create(file.path(home, "bin", "spark-submit")))
+
+  with_mocked_bindings(
+    spark_connect_gateway = function(..., isStarting = FALSE) {
+      if (isStarting) stop("connection refused") else NULL
+    },
+    spark_version_from_home = function(...) "3.5.0",
+    spark_default_app_jar = function(...) {
+      f <- tempfile(fileext = ".jar")
+      file.create(f)
+      f
+    },
+    spark_dependencies_from_extensions = function(...) {
+      list(jars = character(), packages = character(), repositories = character())
+    },
+    .package = "sparklyr",
+    with_mocked_bindings(
+      system2 = function(...) 0L,
+      Sys.sleep = function(...) invisible(NULL),
+      .package = "base",
+      expect_error(
+        start_shell(
+          master = "local", spark_home = home, spark_version = "3.5.0",
+          app_name = "t", config = list(), extensions = list(),
+          environment = new.env(), gateway_connect_attempts = 1
+        ),
+        "Failed while connecting to sparklyr"
+      )
+    )
+  )
+})
+
+test_that("start_shell aborts when the backend socket cannot be opened", {
+  # routing gateway returns a live-looking gatewayInfo, so we skip the launch
+  # block and go straight to the socket setup, which we force to fail.
+  gw <- list(backendPort = 9999, gateway = textConnection("x"))
+  with_mocked_bindings(
+    spark_connect_gateway = function(...) gw,
+    .package = "sparklyr",
+    with_mocked_bindings(
+      socketConnection = function(...) stop("refused"),
+      Sys.sleep = function(...) invisible(NULL),
+      .package = "base",
+      expect_error(
+        start_shell(
+          master = "local", spark_home = "/x", spark_version = "3.5.0",
+          app_name = "t", config = list(), extensions = list(),
+          environment = new.env()
+        ),
+        "Failed to open connection to backend"
+      )
+    )
+  )
+})
+
+test_that("initialize_connection aborts when backend setup fails", {
+  sc <- structure(
+    list(state = new.env(), output_file = tempfile(), app_name = "t",
+         master = "local", config = list()),
+    class = c("spark_shell_connection", "spark_connection")
+  )
+  with_mocked_bindings(
+    invoke_static = function(...) stop("no backend"),
+    .package = "sparklyr",
+    with_mocked_bindings(
+      Sys.sleep = function(...) invisible(NULL),
+      .package = "base",
+      expect_error(
+        initialize_connection.spark_shell_connection(sc),
+        "Failed during initialize_connection"
+      )
+    )
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-connection_shell.R
+++ b/tests/testthat/test-connection_shell.R
@@ -411,7 +411,11 @@ test_that("start_shell aborts after exhausting gateway connect attempts", {
 test_that("start_shell aborts when the backend socket cannot be opened", {
   # routing gateway returns a live-looking gatewayInfo, so we skip the launch
   # block and go straight to the socket setup, which we force to fail.
-  gw <- list(backendPort = 9999, gateway = textConnection("x"))
+  gw_con <- textConnection("x")
+  # start_shell's error handler closes the gateway; defer a guarded close so the
+  # fixture is cleaned up regardless (tryCatch swallows the already-closed case).
+  withr::defer(tryCatch(close(gw_con), error = function(e) NULL))
+  gw <- list(backendPort = 9999, gateway = gw_con)
   with_mocked_bindings(
     spark_connect_gateway = function(...) gw,
     .package = "sparklyr",

--- a/tests/testthat/test-connection_spark.R
+++ b/tests/testthat/test-connection_spark.R
@@ -15,4 +15,51 @@ test_that("pre-command hooks are successfully executed", {
   expect_equal(lines[1], "Running pre-command hooks")
 })
 
+test_that("spark API accessors return the connection's context objects", {
+  expect_false(is.null(java_context(sc)))
+  expect_false(is.null(spark_session(sc)))
+  expect_false(is.null(hive_context(sc)))
+  expect_identical(spark_connection(sc), sc)
+  expect_null(spark_connection(42)) # default -> invisible NULL
+})
+
+test_that("spark_log default errors; print.spark_log prints", {
+  expect_error(spark_log(42), "Invalid class")
+  expect_equal(
+    length(capture.output(print(structure(c("a", "b"), class = "spark_log")))),
+    2
+  )
+})
+
+test_that("spark_web resolves from config and from the live SparkContext", {
+  sc_cfg <- sc
+  sc_cfg$state <- NULL
+  sc_cfg$config[["sparklyr.sparkui.url"]] <- "http://example:4040"
+  expect_match(as.character(spark_web(sc_cfg)), "/jobs/")
+  expect_match(as.character(spark_web(sc)), "jobs")
+})
+
+test_that("print.spark_web_url browses the url", {
+  with_mocked_bindings(
+    browse_url = function(x) invisible(x),
+    .package = "sparklyr",
+    expect_error(
+      print(structure("http://x/jobs/", class = "spark_web_url")),
+      NA
+    )
+  )
+})
+
+test_that("get_spark_sql_catalog_implementation reads the catalog property", {
+  expect_type(get_spark_sql_catalog_implementation(sc), "character")
+})
+
+test_that("connection constructors build the expected classes", {
+  expect_s3_class(
+    new_spark_gateway_connection(list(master = "m")),
+    "spark_gateway_connection"
+  )
+  expect_s3_class(new_livy_connection(list(master = "m")), "livy_connection")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-connection_test.R
+++ b/tests/testthat/test-connection_test.R
@@ -9,4 +9,22 @@ test_that("test connection does not fail", {
   expect_true(!is.null(sc))
 })
 
+test_that("test_connection invoke / sdf / hive methods round-trip", {
+  sc_test <- spark_connect(master = "test", method = "test")
+
+  jobj <- sc_test$state$spark_context
+  expect_equal(invoke(jobj, "version"), "1.0.0")
+  expect_s3_class(invoke(jobj, "anythingElse"), "test_jobj")
+
+  expect_s3_class(invoke_static(sc_test, "some.Class", "method"), "test_jobj")
+  expect_s3_class(invoke_new(sc_test, "some.Class"), "test_jobj")
+  expect_s3_class(create_hive_context(sc_test), "test_jobj")
+
+  df <- data.frame(a = 1:3)
+  expect_identical(sdf_copy_to(sc_test, df), df)
+  # sdf_import dispatches on its first argument, so the test_connection method
+  # is reached by passing the connection there (it simply returns it)
+  expect_identical(sdf_import(sc_test, sc_test), sc_test)
+})
+
 test_clear_cache()

--- a/tests/testthat/test-connection_yarn.R
+++ b/tests/testthat/test-connection_yarn.R
@@ -1,75 +1,371 @@
+# ---------------------------------------------------------------------------
+# Local, connection-free tests for YARN cluster helpers. These read the
+# `data/yarn-site.xml` fixture for the conf-property logic and mock httr / the
+# internal helpers for everything that would otherwise hit a live YARN resource
+# manager. The live UI test is gated below by skip_connection().
+# ---------------------------------------------------------------------------
+
+yarn_conf_dir <- function() test_path("data")
+
+test_that("spark_yarn_get_conf_property() requires a conf dir and yarn-site.xml", {
+  withr::local_envvar(c(YARN_CONF_DIR = NA, HADOOP_CONF_DIR = NA))
+  expect_error(
+    spark_yarn_get_conf_property("anything"),
+    "YARN_CONF_DIR or HADOOP_CONF_DIR"
+  )
+  expect_null(spark_yarn_get_conf_property("anything", fails = FALSE))
+
+  # conf dir set, but no yarn-site.xml inside it
+  empty <- withr::local_tempdir()
+  withr::local_envvar(c(YARN_CONF_DIR = empty))
+  expect_error(spark_yarn_get_conf_property("anything"), "yarn-site.xml")
+  expect_null(spark_yarn_get_conf_property("anything", fails = FALSE))
+})
+
+test_that("spark_yarn_get_conf_property() reads values and expands variables", {
+  withr::local_envvar(c(YARN_CONF_DIR = yarn_conf_dir()))
+
+  expect_equal(
+    spark_yarn_get_conf_property("yarn.resourcemanager.nonexistent"),
+    character()
+  )
+  expect_equal(spark_yarn_get_conf_property("yarn.resourcemanager.empty"), "")
+  expect_equal(
+    spark_yarn_get_conf_property("yarn.resourcemanager.port"),
+    "8032"
+  )
+  expect_equal(
+    spark_yarn_get_conf_property("yarn.resourcemanager.host"),
+    "invalidhost123.com"
+  )
+  # single variable substitution
+  expect_equal(
+    spark_yarn_get_conf_property("yarn.resourcemanager.hostname"),
+    "invalidhost123.com"
+  )
+  # nested variable substitution
+  expect_equal(
+    spark_yarn_get_conf_property("yarn.resourcemanager.address"),
+    "invalidhost123.com:8032"
+  )
+})
+
+test_that("spark_yarn_get_conf_property() falls back to HADOOP_CONF_DIR", {
+  withr::local_envvar(c(
+    YARN_CONF_DIR = NA,
+    HADOOP_CONF_DIR = yarn_conf_dir()
+  ))
+  expect_equal(
+    spark_yarn_get_conf_property("yarn.resourcemanager.port"),
+    "8032"
+  )
+})
+
+test_that("spark_yarn_cluster_get_protocol() picks https only when configured", {
+  with_mocked_bindings(
+    spark_yarn_cluster_get_conf_property = function(...) "HTTPS_ONLY",
+    .package = "sparklyr",
+    expect_equal(spark_yarn_cluster_get_protocol(), "https")
+  )
+  with_mocked_bindings(
+    spark_yarn_cluster_get_conf_property = function(...) character(),
+    .package = "sparklyr",
+    expect_equal(spark_yarn_cluster_get_protocol(), "http")
+  )
+})
+
+test_that("spark_yarn_cluster_resource_manager_is_online() maps responses to TRUE/FALSE", {
+  with_mocked_bindings(
+    spark_yarn_cluster_get_protocol = function() "http",
+    .package = "sparklyr",
+    {
+      # reachable, no http error -> TRUE
+      with_mocked_bindings(
+        GET = function(...) "resp",
+        http_error = function(...) FALSE,
+        .package = "httr",
+        expect_true(spark_yarn_cluster_resource_manager_is_online("host:8088"))
+      )
+
+      # http error -> warns, FALSE
+      with_mocked_bindings(
+        GET = function(...) "resp",
+        http_error = function(...) TRUE,
+        status_code = function(...) 500L,
+        .package = "httr",
+        expect_warning(
+          expect_false(
+            spark_yarn_cluster_resource_manager_is_online("host:8088")
+          ),
+          "Failed to open"
+        )
+      )
+
+      # GET throws -> warns, FALSE
+      with_mocked_bindings(
+        GET = function(...) stop("boom"),
+        .package = "httr",
+        expect_warning(
+          expect_false(
+            spark_yarn_cluster_resource_manager_is_online("host:8088")
+          ),
+          "Failed to open"
+        )
+      )
+    }
+  )
+})
+
+test_that("spark_yarn_cluster_get_resource_manager_webapp() resolves an HA webapp", {
+  withr::local_envvar(c(YARN_CONF_DIR = yarn_conf_dir()))
+
+  # an online RM candidate is selected
+  with_mocked_bindings(
+    spark_yarn_cluster_resource_manager_is_online = function(...) TRUE,
+    .package = "sparklyr",
+    expect_match(
+      spark_yarn_cluster_get_resource_manager_webapp(),
+      "invalidhost123.com"
+    )
+  )
+
+  # no RM online under HA -> error
+  with_mocked_bindings(
+    spark_yarn_cluster_resource_manager_is_online = function(...) FALSE,
+    .package = "sparklyr",
+    expect_error(
+      spark_yarn_cluster_get_resource_manager_webapp(),
+      "Failed to find online resource manager"
+    )
+  )
+})
+
+test_that("spark_yarn_cluster_get_resource_manager_webapp() handles non-HA fallback", {
+  lookup <- function(values) {
+    function(property) values[[property]] %||% character()
+  }
+
+  # non-HA: webapp.address absent -> fall back to resourcemanager.address:8088
+  with_mocked_bindings(
+    spark_yarn_cluster_get_conf_property = lookup(list(
+      "yarn.resourcemanager.ha.enabled" = "false",
+      "yarn.resourcemanager.webapp.address" = character(),
+      "yarn.resourcemanager.address" = "rmhost:8032"
+    )),
+    .package = "sparklyr",
+    expect_equal(
+      spark_yarn_cluster_get_resource_manager_webapp(),
+      "rmhost:8088"
+    )
+  )
+
+  # non-HA: neither webapp.address nor resourcemanager.address -> error
+  with_mocked_bindings(
+    spark_yarn_cluster_get_conf_property = lookup(list(
+      "yarn.resourcemanager.ha.enabled" = "false"
+    )),
+    .package = "sparklyr",
+    expect_error(
+      spark_yarn_cluster_get_resource_manager_webapp(),
+      "Failed to retrieve"
+    )
+  )
+})
+
+test_that("spark_yarn_cluster_get_app_property() returns values and reports gaps", {
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(app = list(state = "RUNNING")),
+    .package = "httr",
+    expect_equal(
+      spark_yarn_cluster_get_app_property("host", "app_1", "state"),
+      "RUNNING"
+    )
+  )
+
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(app = list(state = "RUNNING")),
+    .package = "httr",
+    expect_error(
+      spark_yarn_cluster_get_app_property("host", "app_1", "missing"),
+      "Failed to retrieve"
+    )
+  )
+})
+
+test_that("spark_yarn_cluster_while_app() polls until the condition is false", {
+  calls <- 0
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(app = list(state = "RUNNING")),
+    .package = "httr",
+    {
+      spark_yarn_cluster_while_app("host", "app_1", 30, function(app) {
+        calls <<- calls + 1
+        FALSE # stop immediately
+      })
+    }
+  )
+  expect_equal(calls, 1)
+})
+
+test_that("spark_yarn_cluster_get_app_id() finds, rejects duplicates, and times out", {
+  app <- function(name = "sparklyr-app", id = "app_1", user = "tester") {
+    list(list(name = name, id = id, user = user))
+  }
+
+  # found by prefix (byname disabled)
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(apps = list(app())),
+    .package = "httr",
+    expect_equal(
+      spark_yarn_cluster_get_app_id(
+        list(sparklyr.yarn.cluster.lookup.byname = FALSE),
+        0,
+        "host"
+      ),
+      "app_1"
+    )
+  )
+
+  # found by user (the default by-name lookup, using the USER env var)
+  me <- Sys.getenv("USER")
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(apps = list(app(user = me))),
+    .package = "httr",
+    expect_equal(
+      spark_yarn_cluster_get_app_id(
+        list(sparklyr.yarn.cluster.lookup.byname = TRUE),
+        0,
+        "host"
+      ),
+      "app_1"
+    )
+  )
+
+  # multiple matches -> error
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(apps = list(app(), app(id = "app_2"))),
+    .package = "httr",
+    expect_error(
+      spark_yarn_cluster_get_app_id(
+        list(sparklyr.yarn.cluster.lookup.byname = FALSE),
+        0,
+        "host"
+      ),
+      "Multiple sparklyr apps"
+    )
+  )
+
+  # nothing found before the (zero) timeout -> error
+  with_mocked_bindings(
+    GET = function(...) "resp",
+    content = function(...) list(apps = list()),
+    .package = "httr",
+    expect_error(
+      spark_yarn_cluster_get_app_id(
+        list(
+          sparklyr.yarn.cluster.lookup.byname = FALSE,
+          sparklyr.yarn.cluster.start.timeout = 0
+        ),
+        0,
+        "host"
+      ),
+      "Failed to retrieve new sparklyr"
+    )
+  )
+})
+
+test_that("spark_yarn_cluster_get_gateway() walks the accepted-state flow", {
+  base_mocks <- function(state, body) {
+    with_mocked_bindings(
+      spark_yarn_cluster_get_resource_manager_webapp = function() "rmhost:8088",
+      spark_yarn_cluster_get_protocol = function() "http",
+      spark_yarn_cluster_get_app_id = function(...) "app_1",
+      spark_yarn_cluster_while_app = function(rm, appId, wait, condition) {
+        # exercise the inline state/host-address condition closures
+        condition(list(state = "ACCEPTED", amHostHttpAddress = "amhost:8042"))
+        invisible(NULL)
+      },
+      spark_yarn_cluster_get_app_property = function(rm, appId, property, ...) {
+        if (property == "state") state else "amhost:8042"
+      },
+      .package = "sparklyr",
+      body
+    )
+  }
+
+  # accepted -> returns the host portion of amHostHttpAddress
+  base_mocks(
+    "ACCEPTED",
+    expect_equal(spark_yarn_cluster_get_gateway(list(), 0), "amhost")
+  )
+
+  # still in a pre-accepted state -> error
+  base_mocks(
+    "SUBMITTED",
+    expect_error(spark_yarn_cluster_get_gateway(list(), 0), "was not accepted")
+  )
+
+  # unexpected state -> error
+  base_mocks(
+    "RUNNING",
+    expect_error(spark_yarn_cluster_get_gateway(list(), 0), "while 'ACCEPTED'")
+  )
+
+  # no resource manager webapp available -> error before any polling
+  with_mocked_bindings(
+    spark_yarn_cluster_get_resource_manager_webapp = function() character(),
+    .package = "sparklyr",
+    expect_error(
+      spark_yarn_cluster_get_gateway(list(), 0),
+      "not present in yarn-site.xml"
+    )
+  )
+})
+
+test_that("spark_connection_yarn_ui() builds a URL from config or yarn-site", {
+  # explicit override wins
+  sc <- list(config = list(sparklyr.web.yarn = "http://my-yarn:8088"))
+  expect_equal(spark_connection_yarn_ui(sc), "http://my-yarn:8088")
+
+  # derived from spark_web + resourcemanager.address
+  sc <- list(config = list())
+  with_mocked_bindings(
+    spark_web = function(sc) "http://driver-host:4040/jobs",
+    spark_yarn_get_conf_property = function(property, fails = TRUE) {
+      if (property == "yarn.resourcemanager.address") {
+        "rmhost:8032"
+      } else {
+        character()
+      }
+    },
+    .package = "sparklyr",
+    expect_equal(spark_connection_yarn_ui(sc), "http://rmhost:8088")
+  )
+
+  # derived using resourcemanager.hostname
+  with_mocked_bindings(
+    spark_web = function(sc) "http://driver-host:4040/jobs",
+    spark_yarn_get_conf_property = function(property, fails = TRUE) {
+      if (property == "yarn.resourcemanager.hostname") "rmhost" else character()
+    },
+    .package = "sparklyr",
+    expect_match(spark_connection_yarn_ui(sc), "rmhost")
+  )
+})
+
+# ---------------------------------------------------------------------------
+# Live integration. Skipped unless a real connection is available.
+# ---------------------------------------------------------------------------
 skip_connection("connection_yarn")
 skip_on_livy()
 skip_on_arrow_devel()
 skip_databricks_connect()
-
-test_that("'spark_yarn_cluster_get_resource_manager_webapp' fails under HA configuration", {
-  Sys.setenv(
-    YARN_CONF_DIR = dirname(dir(
-      getwd(),
-      recursive = TRUE,
-      pattern = "yarn-site.xml",
-      full.names = TRUE
-    ))
-  )
-
-  expect_error(
-    expect_warning(
-      spark_yarn_cluster_get_resource_manager_webapp()
-    )
-  )
-
-  Sys.unsetenv("YARN_CONF_DIR")
-})
-
-test_that("'spark_yarn_cluster_get_conf_property' does variable expansion for conf property value strings", {
-  Sys.setenv(
-    YARN_CONF_DIR = dirname(dir(
-      getwd(),
-      recursive = TRUE,
-      pattern = "yarn-site.xml",
-      full.names = TRUE
-    ))
-  )
-
-  expect_equal(
-    spark_yarn_cluster_get_conf_property("yarn.resourcemanager.nonexistent"),
-    character(),
-    info = "nonexistent property name"
-  )
-
-  expect_equal(
-    spark_yarn_cluster_get_conf_property("yarn.resourcemanager.empty"),
-    "",
-    info = "empty property value string"
-  )
-
-  expect_equal(
-    spark_yarn_cluster_get_conf_property("yarn.resourcemanager.port"),
-    "8032",
-    info = "numeric property value string"
-  )
-
-  expect_equal(
-    spark_yarn_cluster_get_conf_property("yarn.resourcemanager.host"),
-    "invalidhost123.com",
-    info = "character property value string"
-  )
-
-  expect_equal(
-    spark_yarn_cluster_get_conf_property("yarn.resourcemanager.hostname"),
-    "invalidhost123.com",
-    info = "variable property value string"
-  )
-
-  expect_equal(
-    spark_yarn_cluster_get_conf_property("yarn.resourcemanager.address"),
-    "invalidhost123.com:8032",
-    info = "nested variable property value string"
-  )
-
-  Sys.unsetenv("YARN_CONF_DIR")
-})
 
 test_that("'spark_connection_yarn_ui()' can build a default URL", {
   expect_true(

--- a/tests/testthat/test-core_gateway.R
+++ b/tests/testthat/test-core_gateway.R
@@ -67,6 +67,198 @@ test_that("spark_gateway_connection aborts when the backend socket fails", {
   )
 })
 
+test_that("query_gateway_for_port returns ports when the gateway responds", {
+  # readInt feeds: backendSessionId, redirectGatewayPort, backendPort
+  reads <- c(1L, 8880L, 9001L)
+  i <- 0L
+  with_mocked_bindings(
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      writeInt = function(...) invisible(NULL),
+      readInt = function(...) {
+        i <<- i + 1L
+        reads[[i]]
+      },
+      .package = "sparklyr",
+      {
+        res <- query_gateway_for_port(
+          gateway = NULL,
+          sessionId = 1,
+          config = list(),
+          isStarting = TRUE
+        )
+        expect_equal(res$redirectGatewayPort, 8880L)
+        expect_equal(res$backendPort, 9001L)
+      }
+    )
+  )
+})
+
+test_that("query_gateway_for_port returns NULL when not starting and silent", {
+  with_mocked_bindings(
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      writeInt = function(...) invisible(NULL),
+      readInt = function(...) integer(0),
+      .package = "sparklyr",
+      expect_null(
+        query_gateway_for_port(
+          gateway = NULL,
+          sessionId = 1,
+          config = list(sparklyr.gateway.timeout = 0.05),
+          isStarting = FALSE
+        )
+      )
+    )
+  )
+})
+
+test_that("query_gateway_for_port aborts when starting and silent", {
+  with_mocked_bindings(
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      writeInt = function(...) invisible(NULL),
+      readInt = function(...) integer(0),
+      .package = "sparklyr",
+      expect_error(
+        query_gateway_for_port(
+          gateway = NULL,
+          sessionId = 1,
+          config = list(sparklyr.connect.timeout = 0.05),
+          isStarting = TRUE
+        ),
+        "did not respond while retrieving ports"
+      )
+    )
+  )
+})
+
+test_that("spark_connect_gateway returns the backend when the port matches", {
+  with_mocked_bindings(
+    wait_connect_gateway = function(...) "gw",
+    query_gateway_for_port = function(...) {
+      list(gateway = "gw", backendPort = 9001L, redirectGatewayPort = 8880L)
+    },
+    .package = "sparklyr",
+    {
+      res <- spark_connect_gateway("h", 8880L, 1, list(), isStarting = FALSE)
+      expect_equal(res$backendPort, 9001L)
+    }
+  )
+})
+
+test_that("spark_connect_gateway follows a redirect to a new gateway port", {
+  i <- 0L
+  with_mocked_bindings(
+    close = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      wait_connect_gateway = function(...) "gw",
+      query_gateway_for_port = function(...) {
+        i <<- i + 1L
+        # first response redirects away from 8880, second response matches 9999
+        list(gateway = "gw", backendPort = 9001L, redirectGatewayPort = 9999L)
+      },
+      .package = "sparklyr",
+      {
+        res <- spark_connect_gateway("h", 8880L, 1, list(), isStarting = FALSE)
+        expect_equal(res$backendPort, 9001L)
+      }
+    )
+  )
+  expect_equal(i, 2L)
+})
+
+test_that("spark_connect_gateway handles an unregistered session", {
+  with_mocked_bindings(
+    close = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      wait_connect_gateway = function(...) "gw",
+      query_gateway_for_port = function(...) {
+        list(gateway = "gw", backendPort = 0L, redirectGatewayPort = 0L)
+      },
+      .package = "sparklyr",
+      {
+        expect_null(
+          spark_connect_gateway("h", 8880L, 1, list(), isStarting = FALSE)
+        )
+        expect_error(
+          spark_connect_gateway("h", 8880L, 1, list(), isStarting = TRUE),
+          "does not have the requested session registered"
+        )
+      }
+    )
+  )
+})
+
+test_that("spark_connect_gateway surfaces a failing port query", {
+  attempts <- 0L
+  with_mocked_bindings(
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      wait_connect_gateway = function(...) "gw",
+      query_gateway_for_port = function(...) {
+        attempts <<- attempts + 1L
+        stop("ports query boom")
+      },
+      .package = "sparklyr",
+      expect_error(
+        spark_connect_gateway(
+          "h",
+          8880L,
+          1,
+          list(
+            sparklyr.gateway.port.query.attempts = 2L,
+            sparklyr.gateway.port.query.retry.interval.seconds = 0L
+          ),
+          isStarting = FALSE
+        ),
+        "ports query boom"
+      )
+    )
+  )
+  expect_equal(attempts, 1L)
+})
+
+test_that("gateway_connection parses the master and aborts when connect fails", {
+  with_mocked_bindings(
+    spark_connect_gateway = function(gatewayAddress,
+                                     gatewayPort,
+                                     sessionId,
+                                     config,
+                                     ...) {
+      # the master URL is split into address / port / session id
+      expect_equal(gatewayAddress, "10.0.0.5")
+      expect_equal(gatewayPort, 8880L)
+      expect_equal(sessionId, 7L)
+      NULL
+    },
+    .package = "sparklyr",
+    expect_error(
+      gateway_connection("sparklyr://10.0.0.5:8880/7", list()),
+      "Failed to connect to gateway"
+    )
+  )
+})
+
+test_that("gateway_connection builds a connection on success", {
+  fake_sc <- structure(list(), class = "spark_gateway_connection")
+  with_mocked_bindings(
+    spark_connect_gateway = function(...) list(gateway = "gw", backendPort = 9001L),
+    spark_gateway_connection = function(...) fake_sc,
+    .package = "sparklyr",
+    expect_identical(
+      gateway_connection("sparklyr://h:8880", list()),
+      fake_sc
+    )
+  )
+})
+
 test_that("spark_log / spark_web are unavailable over a gateway connection", {
   sc <- structure(
     list(),

--- a/tests/testthat/test-core_gateway.R
+++ b/tests/testthat/test-core_gateway.R
@@ -1,0 +1,79 @@
+skip_connection("core_gateway")
+skip_on_livy()
+skip_on_arrow_devel()
+
+test_that("master_is_gateway recognizes gateway master URLs", {
+  expect_true(master_is_gateway("sparklyr://10.0.0.1:8880"))
+  expect_true(master_is_gateway("10.0.0.1:8880/3"))
+  expect_false(master_is_gateway("local"))
+  expect_false(master_is_gateway("yarn"))
+})
+
+test_that("spark_gateway_commands exposes the protocol command codes", {
+  cmds <- spark_gateway_commands()
+  expect_equal(cmds[["GetPorts"]], 0)
+  expect_equal(cmds[["RegisterInstance"]], 1)
+})
+
+test_that("gateway_connection rejects a non-gateway master", {
+  expect_error(
+    gateway_connection("local", list()),
+    "expected to be formatted as sparklyr://"
+  )
+})
+
+test_that("wait_connect_gateway returns NULL when the socket never connects", {
+  with_mocked_bindings(
+    socketConnection = function(...) stop("connection refused"),
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    expect_null(
+      wait_connect_gateway(
+        "localhost", 9999,
+        list(sparklyr.gateway.timeout = 0.05),
+        isStarting = FALSE
+      )
+    )
+  )
+})
+
+test_that("spark_connect_gateway returns NULL or aborts when the gateway is down", {
+  with_mocked_bindings(
+    wait_connect_gateway = function(...) NULL,
+    .package = "sparklyr",
+    {
+      expect_null(
+        spark_connect_gateway("localhost", 9999, 1, list(), isStarting = FALSE)
+      )
+      expect_error(
+        spark_connect_gateway("localhost", 9999, 1, list(), isStarting = TRUE),
+        "did not respond"
+      )
+    }
+  )
+})
+
+test_that("spark_gateway_connection aborts when the backend socket fails", {
+  gw <- list(gateway = textConnection("x"), backendPort = 9999)
+  # the error handler closes gw$gateway; guard the fixture cleanup either way
+  withr::defer(tryCatch(close(gw$gateway), error = function(e) NULL))
+  with_mocked_bindings(
+    socketConnection = function(...) stop("refused"),
+    .package = "base",
+    expect_error(
+      spark_gateway_connection("sparklyr://h:8880", list(), gw, "h"),
+      "Failed to open connection to backend"
+    )
+  )
+})
+
+test_that("spark_log / spark_web are unavailable over a gateway connection", {
+  sc <- structure(
+    list(),
+    class = c("spark_gateway_connection", "spark_connection")
+  )
+  expect_error(spark_log(sc), "not available")
+  expect_error(spark_web(sc), "not available")
+})
+
+test_clear_cache()

--- a/tests/testthat/test-core_gateway.R
+++ b/tests/testthat/test-core_gateway.R
@@ -29,7 +29,8 @@ test_that("wait_connect_gateway returns NULL when the socket never connects", {
     .package = "base",
     expect_null(
       wait_connect_gateway(
-        "localhost", 9999,
+        "localhost",
+        9999,
         list(sparklyr.gateway.timeout = 0.05),
         isStarting = FALSE
       )
@@ -227,11 +228,13 @@ test_that("spark_connect_gateway surfaces a failing port query", {
 
 test_that("gateway_connection parses the master and aborts when connect fails", {
   with_mocked_bindings(
-    spark_connect_gateway = function(gatewayAddress,
-                                     gatewayPort,
-                                     sessionId,
-                                     config,
-                                     ...) {
+    spark_connect_gateway = function(
+      gatewayAddress,
+      gatewayPort,
+      sessionId,
+      config,
+      ...
+    ) {
       # the master URL is split into address / port / session id
       expect_equal(gatewayAddress, "10.0.0.5")
       expect_equal(gatewayPort, 8880L)
@@ -249,7 +252,9 @@ test_that("gateway_connection parses the master and aborts when connect fails", 
 test_that("gateway_connection builds a connection on success", {
   fake_sc <- structure(list(), class = "spark_gateway_connection")
   with_mocked_bindings(
-    spark_connect_gateway = function(...) list(gateway = "gw", backendPort = 9001L),
+    spark_connect_gateway = function(...) {
+      list(gateway = "gw", backendPort = 9001L)
+    },
     spark_gateway_connection = function(...) fake_sc,
     .package = "sparklyr",
     expect_identical(

--- a/tests/testthat/test-core_invoke.R
+++ b/tests/testthat/test-core_invoke.R
@@ -143,4 +143,193 @@ test_that("NaN is handled correctly", {
   expect_equal(invoke_static(sc, "sparklyr.Test", "readFloat", jflt), NaN)
 })
 
+test_that("j_invoke variants return JVM object references", {
+  # j_invoke_* force the return value to be retrieved as a JVM object reference
+  obj <- j_invoke_new(sc, "java.lang.Object")
+  expect_true(inherits(obj, "spark_jobj"))
+
+  str_ref <- j_invoke(obj, "toString")
+  expect_true(inherits(str_ref, "spark_jobj"))
+
+  props <- j_invoke_static(sc, "java.lang.System", "getProperties")
+  expect_true(inherits(props, "spark_jobj"))
+})
+
+# ---- Socket / dispatch helpers (no live backend needed) -------------------
+
+test_that("core_invoke_socket picks backend or monitoring by state", {
+  sc_b <- list(
+    state = list(use_monitoring = FALSE),
+    backend = "B",
+    monitoring = "M"
+  )
+  expect_equal(core_invoke_socket(sc_b), "B")
+  expect_equal(core_invoke_socket_name(sc_b), "backend")
+
+  sc_m <- list(
+    state = list(use_monitoring = TRUE),
+    backend = "B",
+    monitoring = "M"
+  )
+  expect_equal(core_invoke_socket(sc_m), "M")
+  expect_equal(core_invoke_socket_name(sc_m), "monitoring")
+})
+
+test_that("jobj_subclass methods all resolve to shell_jobj", {
+  expect_equal(jobj_subclass.shell_backend(NULL), "shell_jobj")
+  expect_equal(jobj_subclass.spark_connection(NULL), "shell_jobj")
+  expect_equal(jobj_subclass.spark_worker_connection(NULL), "shell_jobj")
+})
+
+test_that("invoke entry points reject a NULL connection", {
+  expect_error(core_invoke_synced(NULL), "no longer valid")
+  expect_error(
+    core_invoke_method_impl(NULL, TRUE, FALSE, "obj", "m", FALSE),
+    "no longer valid"
+  )
+})
+
+# ---- Job cancellation -----------------------------------------------------
+
+test_that("core_invoke_cancel_running short-circuits on guard conditions", {
+  # no spark context
+  expect_null(core_invoke_cancel_running(list(state = list())))
+  # monitoring connection
+  expect_null(core_invoke_cancel_running(
+    list(state = list(spark_context = "x", use_monitoring = TRUE))
+  ))
+  # already cancelling
+  expect_null(core_invoke_cancel_running(
+    list(state = list(spark_context = "x", cancelling_all_jobs = TRUE))
+  ))
+})
+
+test_that("core_invoke_cancel_running cancels jobs on the active context", {
+  cancelled <- FALSE
+  with_mocked_bindings(
+    invoke = function(jobj, method, ...) {
+      cancelled <<- identical(method, "cancelAllJobs")
+      NULL
+    },
+    .package = "sparklyr",
+    {
+      sc_fake <- list(
+        state = list(spark_context = "ctx"),
+        config = list(sparklyr.progress = FALSE)
+      )
+      core_invoke_cancel_running(sc_fake)
+    }
+  )
+  expect_true(cancelled)
+})
+
+# ---- Error handling + reporting -------------------------------------------
+
+test_that("core_handle_known_errors warns on the tachyon/localhost failure", {
+  expect_warning(
+    core_handle_known_errors(
+      list(master = "local"),
+      "java.util.ServiceConfigurationError: tachyon could not be loaded"
+    ),
+    "validate that the hostname"
+  )
+})
+
+test_that("core_handle_known_errors aborts on local worker failures", {
+  sc_fake <- list(
+    master = "local",
+    output_file = tempfile(),
+    error_file = tempfile()
+  )
+  with_mocked_bindings(
+    abort_shell = function(...) stop("aborted by mock"),
+    .package = "sparklyr",
+    expect_error(
+      core_handle_known_errors(sc_fake, "please check worker logs for details"),
+      "aborted by mock"
+    )
+  )
+})
+
+test_that("core_read_spark_log_error reads logs or falls back to a default", {
+  log <- tempfile()
+  writeLines(c("2024-01-01 INFO starting", "2024-01-01 ERROR boom"), log)
+  msg <- core_read_spark_log_error(list(output_file = log))
+  expect_match(msg, "failed to invoke spark command")
+  expect_match(msg, "ERROR boom")
+
+  # a missing log file falls back to the unknown-reason message (readLines
+  # warns before erroring; the try() only silences the error)
+  expect_equal(
+    suppressWarnings(core_read_spark_log_error(list(output_file = tempfile()))),
+    "failed to invoke spark command (unknown reason)"
+  )
+})
+
+test_that("spark_error honors the simple-errors option", {
+  withr::local_options(sparklyr.simple.errors = TRUE)
+  expect_error(spark_error("simple boom"), "simple boom")
+})
+
+test_that("spark_error formats a rich, hyperlinked message", {
+  withr::local_options(sparklyr.simple.errors = NULL)
+
+  # color terminal -> builds the OSC 8 hyperlink (x-r-run scheme, not RStudio)
+  withr::local_envvar(TERM = "xterm-256color")
+  expect_error(
+    spark_error("boom\n\tat some.scala.Frame"),
+    "see the full Spark error"
+  )
+
+  # non-color terminal -> plain backticked function reference
+  withr::local_envvar(TERM = "dumb")
+  expect_error(
+    spark_error("boom\n\tat some.scala.Frame"),
+    "see the full Spark error"
+  )
+})
+
+test_that("spark_last_error reports the stored error or its absence", {
+  orig <- genv_get_last_error()
+  withr::defer(genv_set_last_error(orig))
+
+  genv_set_last_error("previous failure")
+  expect_message(spark_last_error(), "previous failure")
+
+  genv_set_last_error(NULL)
+  expect_message(spark_last_error(), "No error found")
+})
+
+# ---- invoke_trace ---------------------------------------------------------
+
+test_that("invoke_trace honors the sparklyr.log.invoke setting", {
+  expect_output(
+    invoke_trace(
+      list(config = list(sparklyr.log.invoke = "cat")),
+      "Invoking",
+      "m"
+    ),
+    "Invoking m"
+  )
+  expect_message(
+    invoke_trace(
+      list(config = list(sparklyr.log.invoke = TRUE)),
+      "Invoking",
+      "m"
+    ),
+    "Invoking m"
+  )
+  expect_message(
+    invoke_trace(
+      list(config = list(sparklyr.log.invoke = "callstack")),
+      "Invoking",
+      "m"
+    )
+  )
+  # default (FALSE) emits nothing
+  expect_silent(
+    invoke_trace(list(config = list()), "Invoking", "m")
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-core_jobj.R
+++ b/tests/testthat/test-core_jobj.R
@@ -38,4 +38,26 @@ test_that("print supports spark context", {
   )
 })
 
+test_that("spark_jobj helpers: id accessor, default error, passthrough", {
+  expect_equal(spark_jobj_id(list(id = "7")), "7")
+  expect_error(spark_jobj(42), "Unable to retrieve")
+  fake <- structure(list(id = "x"), class = "spark_jobj")
+  expect_identical(spark_jobj(fake), fake)
+})
+
+test_that("jobj_create rejects non-character ids; jobj_info rejects non-jobj", {
+  expect_error(jobj_create(sc, 42), "must be a character")
+  expect_error(jobj_info(42), "non-jobj")
+})
+
+test_that("attach_connection recurses into environments", {
+  out <- attach_connection(as.environment(list(a = 1, b = 2)), sc)
+  expect_true(is.list(out))
+})
+
+test_that("jobj_inspect prints fields and methods of a live jobj", {
+  out <- capture.output(suppressWarnings(jobj_inspect(spark_context(sc))))
+  expect_true(any(grepl("Fields:|Methods:", out)))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-core_serialize.R
+++ b/tests/testthat/test-core_serialize.R
@@ -1,3 +1,267 @@
+# ---------------------------------------------------------------------------
+# Connection-free serializer tests. The write*/read* functions operate on a
+# binary connection, so we exercise them through an in-memory rawConnection
+# (read_bin dispatches to read_bin.default for a rawConnection) with no Spark.
+# The live round-trip tests below cover the happy path against real Spark; these
+# add the edge branches the fast local path never hits.
+# ---------------------------------------------------------------------------
+
+# Run a writer `fn` into a raw connection, then read it back with readObject().
+serde_read_back <- function(fn) {
+  wc <- rawConnection(raw(0), "wb")
+  fn(wc)
+  bytes <- rawConnectionValue(wc)
+  close(wc)
+  rc <- rawConnection(bytes, "rb")
+  on.exit(close(rc))
+  readObject(rc)
+}
+serde_roundtrip <- function(x) {
+  serde_read_back(function(con) writeObject(con, x))
+}
+
+test_that("serializer round-trips scalar types", {
+  expect_equal(serde_roundtrip(5L), 5L)
+  expect_equal(serde_roundtrip(3.14), 3.14)
+  expect_true(serde_roundtrip(TRUE))
+  expect_equal(serde_roundtrip("hello"), "hello")
+  expect_equal(serde_roundtrip(as.raw(c(1, 2, 3))), as.raw(c(1, 2, 3)))
+  expect_equal(serde_roundtrip(as.Date("2021-03-04")), as.Date("2021-03-04"))
+  expect_equal(serde_roundtrip(factor("b")), "b")
+
+  t <- as.POSIXct("2021-03-04 05:06:07", tz = "UTC")
+  expect_equal(as.double(serde_roundtrip(t)), as.double(t), tolerance = 1e-3)
+})
+
+test_that("serializer round-trips arrays and lists", {
+  expect_equal(serde_roundtrip(list(1L, 2L, 3L)), c(1L, 2L, 3L)) # same-type -> array
+  expect_equal(serde_roundtrip(list("a", "b")), list("a", "b")) # array of strings
+  expect_equal(serde_roundtrip(list()), list()) # empty array
+  expect_equal(serde_roundtrip(list(1L, "a")), list(1L, "a")) # mixed -> list
+  # an empty raw round-trips to raw()
+  expect_equal(serde_roundtrip(raw(0)), raw(0))
+})
+
+test_that("serializer maps NA scalars to NULL and NULLs back to NA", {
+  expect_null(serde_roundtrip(NA_integer_))
+  # a same-typed list containing NA serializes as a list; NULLs read back as NA
+  expect_equal(serde_roundtrip(list(1L, NA_integer_, 3L)), list(1L, NA, 3L))
+})
+
+test_that("serializer round-trips a data.frame as a column list", {
+  # writeObject() iterates a data.frame's columns and serializes each scalar, so
+  # use a single-row frame (the column writer assumes scalar values).
+  back <- serde_roundtrip(
+    data.frame(a = 1L, b = "x", stringsAsFactors = FALSE)
+  )
+  expect_length(back, 2)
+  expect_equal(back[[1]], 1L)
+  expect_equal(back[[2]], "x")
+})
+
+test_that("writeObject() handles struct / env / spark_apply_binary_result writes", {
+  wc <- rawConnection(raw(0), "wb")
+  on.exit(close(wc))
+  # struct path + listToStruct()
+  expect_silent(writeObject(wc, listToStruct(list(a = 1L))))
+  # environment -> map write path
+  expect_silent(writeObject(wc, as.environment(list(a = 1L, b = 2L))))
+  # spark_apply_binary_result -> writeList
+  expect_silent(
+    writeObject(
+      wc,
+      structure(list(raw(1)), class = "spark_apply_binary_result")
+    )
+  )
+})
+
+test_that("writeObject() errors on an unsupported type", {
+  wc <- rawConnection(raw(0), "wb")
+  on.exit(close(wc))
+  bad <- structure(1, class = "zzz_unsupported")
+  # writeType = FALSE reaches the switch's default stop
+  expect_error(writeObject(wc, bad, writeType = FALSE), "Unsupported type")
+  # writeType = TRUE reaches writeType()'s default stop
+  expect_error(writeObject(wc, bad), "Unsupported type")
+})
+
+test_that("writeJobj() errors on an invalid jobj", {
+  wc <- rawConnection(raw(0), "wb")
+  on.exit(close(wc))
+  with_mocked_bindings(
+    isValidJobj = function(x) FALSE,
+    .package = "sparklyr",
+    expect_error(writeJobj(wc, list(id = "bad")), "invalid jobj")
+  )
+})
+
+test_that("readStruct() reads a Spark struct into a named list", {
+  s <- serde_read_back(function(con) {
+    writeType(con, "struct")
+    writeObject(con, list("x", "y")) # field names
+    writeObject(con, list(1L, "a")) # field values (mixed -> stays a list)
+  })
+  expect_s3_class(s, "struct")
+  expect_equal(s$x, 1L)
+  expect_equal(s$y, "a")
+})
+
+test_that("readMap() reads a Spark map into a named list", {
+  m <- serde_read_back(function(con) {
+    writeType(con, "environment")
+    writeInt(con, 1L)
+    writeString(con, "foo")
+    writeObject(con, 5)
+  })
+  expect_equal(m, list(foo = 5))
+})
+
+test_that("readStringArray() reads an 'f'-typed string array", {
+  arr <- serde_read_back(function(con) {
+    writeBin(charToRaw("f"), con)
+    writeString(con, "ab<NA>")
+  })
+  expect_equal(arr, list("a", "b", NA_character_))
+})
+
+test_that("readObject() parses a 'J' JSON-typed value", {
+  res <- serde_read_back(function(con) {
+    writeBin(charToRaw("J"), con)
+    writeString(con, '{"a":1}')
+  })
+  expect_equal(res$a, 1L)
+})
+
+test_that("readObject() errors on an unknown deserialization type", {
+  rc <- rawConnection(charToRaw("Z"), "rb")
+  on.exit(close(rc))
+  expect_error(readObject(rc), "Unsupported type for deserialization")
+})
+
+test_that("readRaw() handles the NA (length -1) sentinel", {
+  na_raw <- serde_read_back(function(con) {
+    writeBin(charToRaw("r"), con)
+    writeInt(con, -1L)
+  })
+  expect_true(is.na(na_raw))
+})
+
+test_that("readString() warns and removes embedded nuls", {
+  wc <- rawConnection(raw(0), "wb")
+  writeInt(wc, 3L)
+  writeBin(as.raw(c(0x61, 0x00, 0x62)), wc, endian = "big")
+  bytes <- rawConnectionValue(wc)
+  close(wc)
+  rc <- rawConnection(bytes, "rb")
+  on.exit(close(rc))
+  expect_warning(s <- readString(rc), "embedded nuls")
+  expect_equal(s, "ab")
+})
+
+test_that("readDate()/readTime() honor sparklyr.collect.datechars", {
+  withr::local_options(sparklyr.collect.datechars = TRUE)
+  expect_equal(serde_roundtrip(as.Date("2021-01-02")), "2021-01-02")
+  expect_type(
+    serde_roundtrip(as.POSIXct("2021-01-02 03:04:05", tz = "UTC")),
+    "character"
+  )
+})
+
+test_that("typed readers return empty vectors for n = 0", {
+  rc <- rawConnection(raw(0), "rb")
+  on.exit(close(rc))
+  expect_identical(readInt(rc, 0), integer(0))
+  expect_identical(readDouble(rc, 0), double(0))
+  expect_identical(readBoolean(rc, 0), logical(0))
+  expect_identical(readTime(rc, 0), as.POSIXct(character(0)))
+  expect_identical(readDateArray(rc, 0), as.Date(NA))
+})
+
+test_that("read_bin.livy_backend reads from the wrapped connection", {
+  wc <- rawConnection(raw(0), "wb")
+  writeBin(7L, wc, endian = "big")
+  bytes <- rawConnectionValue(wc)
+  close(wc)
+  rc <- rawConnection(bytes, "rb")
+  on.exit(close(rc))
+  livy <- structure(list(rc = rc), class = "livy_backend")
+  expect_equal(read_bin(livy, integer(), 1, endian = "big"), 7L)
+})
+
+# read_bin.spark_connection isn't registered in NAMESPACE (no @export), so under
+# load_all it falls through to read_bin.default; read_bin.spark_worker_connection
+# IS registered and routes to the same read_bin_wait(), so test through that.
+test_that("read_bin_wait() returns data immediately when available", {
+  worker <- structure(
+    list(state = new.env(), config = list(), backend = "<be>"),
+    class = "spark_worker_connection"
+  )
+  with_mocked_bindings(
+    readBin = function(con, what, n, ...) 42L,
+    .package = "base",
+    expect_equal(read_bin(worker, integer(), 1, endian = "big"), 42L)
+  )
+})
+
+test_that("read_bin_wait() polls and reports progress until data arrives", {
+  fake_sc <- structure(
+    list(
+      state = new.env(),
+      config = list(sparklyr.progress.interval = 0),
+      backend = "<be>"
+    ),
+    class = "spark_worker_connection"
+  )
+  calls <- 0
+  progressed <- FALSE
+  with_mocked_bindings(
+    readBin = function(con, what, n, ...) {
+      calls <<- calls + 1
+      if (calls < 3) integer(0) else 42L
+    },
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    with_mocked_bindings(
+      connection_progress = function(sc) {
+        progressed <<- TRUE
+        invisible(NULL)
+      },
+      connection_progress_terminated = function(sc) invisible(NULL),
+      .package = "sparklyr",
+      {
+        expect_equal(read_bin(fake_sc, integer(), 1, endian = "big"), 42L)
+        # also drive the no-endian read path inside the poll loop
+        calls <- 0
+        expect_equal(read_bin(fake_sc, integer(), 1), 42L)
+      }
+    )
+  )
+  expect_true(progressed)
+})
+
+test_that("read_bin_wait() errors when it times out", {
+  fake_sc <- structure(
+    list(
+      state = new.env(),
+      config = list(
+        sparklyr.backend.timeout = 0,
+        sparklyr.progress.interval = 999
+      ),
+      backend = "<be>"
+    ),
+    class = "spark_worker_connection"
+  )
+  with_mocked_bindings(
+    readBin = function(con, what, n, ...) integer(0),
+    Sys.sleep = function(...) invisible(NULL),
+    .package = "base",
+    expect_error(
+      read_bin(fake_sc, integer(), 1, endian = "big"),
+      "timed out"
+    )
+  )
+})
+
 skip_connection("core_serialize")
 skip_on_livy()
 

--- a/tests/testthat/test-core_serialize.R
+++ b/tests/testthat/test-core_serialize.R
@@ -6,10 +6,29 @@
 # add the edge branches the fast local path never hits.
 # ---------------------------------------------------------------------------
 
+# The read* functions parse the Scala -> R wire format, where a string is a
+# byte-count length followed by the raw bytes (no terminating nul). R's
+# writeString() targets the opposite direction (the Scala *reader*): it writes
+# length + 1 and a nul terminator that the Scala side expects and drops. Feeding
+# writeString()'s output straight back into readString() would therefore trip
+# the (legitimate) embedded-nul guard, so when round-tripping we emit strings the
+# way the Scala backend does.
+scala_write_string <- function(con, value) {
+  bytes <- charToRaw(enc2utf8(as.character(value)))
+  writeInt(con, length(bytes))
+  if (length(bytes) > 0) {
+    writeBin(bytes, con, endian = "big")
+  }
+}
+
 # Run a writer `fn` into a raw connection, then read it back with readObject().
 serde_read_back <- function(fn) {
   wc <- rawConnection(raw(0), "wb")
-  fn(wc)
+  with_mocked_bindings(
+    writeString = scala_write_string,
+    .package = "sparklyr",
+    fn(wc)
+  )
   bytes <- rawConnectionValue(wc)
   close(wc)
   rc <- rawConnection(bytes, "rb")

--- a/tests/testthat/test-core_utils.R
+++ b/tests/testthat/test-core_utils.R
@@ -113,9 +113,14 @@ test_that("spark_get_java handles invalid and unset JAVA_HOME", {
   expect_error(spark_get_java(throws = TRUE), "does not point to a valid")
   expect_identical(spark_get_java(throws = FALSE), "")
 
-  # JAVA_HOME unset -> falls back to Sys.which("java")
+  # JAVA_HOME unset -> falls back to Sys.which("java"); mock Sys.which so this
+  # doesn't depend on the host PATH
   withr::local_envvar(JAVA_HOME = NA)
-  expect_match(spark_get_java(), "java")
+  with_mocked_bindings(
+    Sys.which = function(...) c(java = "/usr/bin/java"),
+    .package = "base",
+    expect_identical(spark_get_java(), c(java = "/usr/bin/java"))
+  )
 })
 
 test_that("java_is_x64 returns a logical (and FALSE when java is absent)", {

--- a/tests/testthat/test-core_utils.R
+++ b/tests/testthat/test-core_utils.R
@@ -85,4 +85,67 @@ test_that("'validate_java_version_line' works when date is present and version h
   succeed()
 })
 
+test_that("core_get_package_function resolves a function or returns NULL", {
+  expect_true(is.function(core_get_package_function("stats", "sd")))
+  expect_null(core_get_package_function("nosuchpkg123", "x"))
+  expect_null(core_get_package_function("stats", "nosuchfn123"))
+})
+
+test_that("arrow record-batch helpers round-trip a data frame", {
+  skip_if_not_installed("arrow")
+  # include a tz-less POSIXt column + a Spark < 3.0 version to hit the legacy
+  # IPC-format env var and the timezone-defaulting branch
+  df_in <- data.frame(
+    x = 1:3,
+    y = c("a", "b", "c"),
+    t = as.POSIXct(c("2020-01-01", "2020-01-02", "2020-01-03"))
+  )
+  attr(df_in$t, "tzone") <- NULL # so the timezone-defaulting branch runs
+  raw <- arrow_write_record_batch(df_in, spark_version_number = "2.4.0")
+  reader <- arrow_record_stream_reader(raw)
+  df <- arrow_as_tibble(arrow_read_record_batch(reader))
+  expect_equal(nrow(df), 3)
+  expect_equal(df$x, 1:3)
+})
+
+test_that("spark_get_java handles invalid and unset JAVA_HOME", {
+  withr::local_envvar(JAVA_HOME = "/invalid/java/home")
+  expect_error(spark_get_java(throws = TRUE), "does not point to a valid")
+  expect_identical(spark_get_java(throws = FALSE), "")
+
+  # JAVA_HOME unset -> falls back to Sys.which("java")
+  withr::local_envvar(JAVA_HOME = NA)
+  expect_match(spark_get_java(), "java")
+})
+
+test_that("java_is_x64 returns a logical (and FALSE when java is absent)", {
+  expect_type(java_is_x64(), "logical")
+  with_mocked_bindings(
+    spark_get_java = function(...) "",
+    .package = "sparklyr",
+    expect_false(java_is_x64())
+  )
+})
+
+test_that("validate_java_version short-circuits for remote masters and guards missing Java", {
+  # non-local master with SPARK_HOME set returns TRUE without probing Java
+  expect_true(validate_java_version("spark://host:7077", "/some/spark/home"))
+  with_mocked_bindings(
+    spark_get_java = function(...) "",
+    .package = "sparklyr",
+    expect_error(validate_java_version("local", ""), "Java is required")
+  )
+})
+
+test_that("validate_java_version_line errors on unparseable input", {
+  expect_error(
+    validate_java_version_line("local", character(0)),
+    "not detected"
+  )
+  expect_error(
+    validate_java_version_line("local", "garbage with no ver"),
+    "couldn't parse"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-data_copy.R
+++ b/tests/testthat/test-data_copy.R
@@ -119,4 +119,34 @@ test_that("sdf_copy_to preserves NA_real_ correctly", {
   )
 })
 
+test_that("sdf_copy_to coerces Date/POSIXt/factor/character columns", {
+  df <- data.frame(
+    d = as.Date("2020-01-01") + 0:2,
+    t = as.POSIXct("2020-01-01 00:00:00") + 0:2,
+    f = factor(c("a", "b", "a")),
+    s = c("x", "y", "z"),
+    stringsAsFactors = FALSE
+  )
+  out <- sdf_copy_to(sc, df, "dc_types", overwrite = TRUE) %>% collect()
+  expect_equal(nrow(out), 3)
+  expect_equal(out$s, c("x", "y", "z"))
+})
+
+test_that("sdf_copy_to rejects a non-integer repartition", {
+  expect_error(
+    sdf_copy_to(sc, data.frame(x = 1:3), "dc_rp", overwrite = TRUE, repartition = "bad"),
+    "must be an integer"
+  )
+})
+
+test_that("sdf_copy_to handles temporal (Date) array columns on Spark 3.0+", {
+  skip_if(spark_version(sc) < "3.0.0")
+  df <- dplyr::tibble(
+    id = 1:2,
+    darr = list(as.Date(c("2020-01-01", "2020-01-02")), as.Date("2020-02-01"))
+  )
+  out <- sdf_copy_to(sc, df, "dc_darr", overwrite = TRUE) %>% collect()
+  expect_equal(nrow(out), 2)
+})
+
 test_clear_cache()

--- a/tests/testthat/test-data_copy.R
+++ b/tests/testthat/test-data_copy.R
@@ -80,7 +80,8 @@ test_that("sdf_copy_to can preserve list columns", {
     c(sapply(sparklyr.nested::sdf_select(sdf, b.d) %>% sdf_collect(), c)),
     c("a", "b", "c")
   )
-  res <- sdf_collect(sdf)
+  # collecting a struct column disables arrow (with a warning) and falls back
+  expect_warning_on_arrow(res <- sdf_collect(sdf))
   expect_equivalent(df$a, res$a)
 })
 

--- a/tests/testthat/test-data_copy.R
+++ b/tests/testthat/test-data_copy.R
@@ -134,7 +134,13 @@ test_that("sdf_copy_to coerces Date/POSIXt/factor/character columns", {
 
 test_that("sdf_copy_to rejects a non-integer repartition", {
   expect_error(
-    sdf_copy_to(sc, data.frame(x = 1:3), "dc_rp", overwrite = TRUE, repartition = "bad"),
+    sdf_copy_to(
+      sc,
+      data.frame(x = 1:3),
+      "dc_rp",
+      overwrite = TRUE,
+      repartition = "bad"
+    ),
     "must be an integer"
   )
 })

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -321,6 +321,8 @@ test_that("spark_read() works as expected", {
 test_that("spark_read_avro() works as expected", {
   skip_on_livy()
   skip_connection("format-avro")
+  # Capped at Spark 4: avro works on 4.x, but the test harness only loads the
+  # avro package on Spark < 4.1 (helper-initialize.R). See plan "Issues to open".
   test_requires_version("2.4.0", max_version = "4")
   skip_databricks_connect()
 

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -728,4 +728,87 @@ test_that("avro_set_schema() attaches a character schema and passes through NULL
     "{\"type\":\"record\"}"
   )
 })
+
+test_that("spark_csv_options() emits boolean strings for header/inferSchema", {
+  # data_read.R:46-68 — TRUE branches map to "true", anything else to "false"
+  opts <- spark_csv_options(
+    header = TRUE,
+    inferSchema = TRUE,
+    delimiter = ",",
+    quote = "\"",
+    escape = "\\",
+    charset = "UTF-8",
+    nullValue = NULL,
+    options = list()
+  )
+
+  expect_equal(opts$header, "true")
+  expect_equal(opts$inferSchema, "true")
+  expect_equal(opts$delimiter, ",")
+  expect_equal(opts$quote, "\"")
+  expect_equal(opts$escape, "\\")
+  expect_equal(opts$charset, "UTF-8")
+  # toString(NULL) yields the empty string
+  expect_equal(opts$nullValue, "")
+})
+
+test_that("spark_csv_options() maps non-TRUE header/inferSchema to 'false'", {
+  # data_read.R:59-60 — the else branches of the header/inferSchema flags
+  opts <- spark_csv_options(
+    header = FALSE,
+    inferSchema = FALSE,
+    delimiter = ";",
+    quote = "'",
+    escape = "|",
+    charset = "latin1",
+    nullValue = "NA",
+    options = list()
+  )
+
+  expect_equal(opts$header, "false")
+  expect_equal(opts$inferSchema, "false")
+  expect_equal(opts$delimiter, ";")
+  expect_equal(opts$nullValue, "NA")
+})
+
+test_that("spark_csv_options() preserves caller-supplied options", {
+  # data_read.R:56-57 — user `options` are prepended and survive the merge
+  opts <- spark_csv_options(
+    header = TRUE,
+    inferSchema = FALSE,
+    delimiter = ",",
+    quote = "\"",
+    escape = "\\",
+    charset = "UTF-8",
+    nullValue = NULL,
+    options = list(maxColumns = "5", mode = "DROPMALFORMED")
+  )
+
+  expect_equal(opts$maxColumns, "5")
+  expect_equal(opts$mode, "DROPMALFORMED")
+  # built-in options are still present alongside the custom ones
+  expect_equal(opts$header, "true")
+  expect_equal(opts$inferSchema, "false")
+})
+
+test_that("spark_read_csv() errors when infer_schema=TRUE with typed columns", {
+  # data_read.R:158-162 — the mutually-exclusive guard between
+  # infer_schema and a typed `columns` specification.
+  skip_on_livy()
+  skip_connection("format-csv")
+
+  csvPath <- get_test_data_path(
+    "spark-read-csv-can-read-column-types.txt"
+  )
+  expect_error(
+    spark_read_csv(
+      sc,
+      name = "test_infer_schema_conflict",
+      path = csvPath,
+      columns = c(a = "byte", b = "integer", c = "double"),
+      infer_schema = TRUE
+    ),
+    "'infer_schema' must be set to FALSE when 'columns' specifies column types"
+  )
+})
 test_clear_cache()

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -811,4 +811,158 @@ test_that("spark_read_csv() errors when infer_schema=TRUE with typed columns", {
     "'infer_schema' must be set to FALSE when 'columns' specifies column types"
   )
 })
+
+test_that("spark_read_table() and spark_load_table() read a registered table", {
+  skip_on_livy()
+  skip_connection("format-table")
+  skip_databricks_connect()
+  test_requires("dplyr")
+
+  src <- random_string("rt_src_")
+  name <- random_string("rt_tbl_")
+  on.exit(dbRemoveTable(sc, name, fail_if_missing = FALSE), add = TRUE)
+  copy_to(sc, data.frame(id = 1:4), name = src, overwrite = TRUE)
+  spark_write_table(tbl(sc, src), name)
+
+  expect_equal(sdf_nrow(spark_read_table(sc, name)), 4)
+
+  # deprecated alias delegates to spark_read_table
+  expect_warning(
+    loaded <- spark_load_table(sc, name, path = "unused"),
+    "deprecated"
+  )
+  expect_equal(sdf_nrow(loaded), 4)
+})
+
+test_that("spark_read_delta() reads a delta table, including a prior version", {
+  skip_on_livy()
+  skip_connection("format-delta")
+  test_requires_version("3", max_version = "4")
+  skip_databricks_connect()
+
+  path <- tempfile("delta_read_")
+  spark_write_delta(
+    sdf_copy_to(sc, data.frame(id = 1:5), overwrite = TRUE),
+    path
+  )
+
+  expect_equal(sdf_nrow(spark_read_delta(sc, path)), 5)
+})
+
+test_that("version-gated readers error on older Spark", {
+  with_mocked_bindings(
+    spark_version = function(sc, ...) numeric_version("2.3.0"),
+    .package = "sparklyr",
+    {
+      expect_error(
+        spark_read_binary(sc, name = "x", dir = "/tmp"),
+        "Spark 3.0 or above"
+      )
+      expect_error(
+        spark_read_image(sc, name = "x", dir = "/tmp"),
+        "Spark 2.4 or above"
+      )
+    }
+  )
+})
+
+test_that("spark_read() requires named columns on Spark 4+", {
+  with_mocked_bindings(
+    spark_version = function(sc, ...) numeric_version("4.0.0"),
+    .package = "sparklyr",
+    expect_error(
+      spark_read(
+        sc,
+        list("p"),
+        reader = function(df, path) df,
+        columns = c("a", "b")
+      ),
+      "Spark 4"
+    )
+  )
+})
+
+test_that("spark_data_apply_mode handles null, character, list, and invalid modes", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  skip_databricks_connect()
+
+  writer <- invoke(spark_dataframe(testthat_tbl("iris")), "write")
+  expect_s3_class(spark_data_apply_mode(writer, NULL), "spark_jobj")
+  expect_s3_class(spark_data_apply_mode(writer, "overwrite"), "spark_jobj")
+  expect_s3_class(
+    spark_data_apply_mode(writer, list("overwrite")),
+    "spark_jobj"
+  )
+  expect_error(spark_data_apply_mode(writer, 42L), "Unsupported type")
+})
+
+test_that("spark_write_source() exercises the generic write path", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  skip_databricks_connect()
+
+  tbl <- sdf_copy_to(
+    sc,
+    data.frame(id = 1:6, grp = rep(c("a", "b", "c"), 2)),
+    overwrite = TRUE
+  )
+  path <- tempfile("gen_src_")
+  # options + partition_by + mode cover writeOptions/partitionBy/format-save in
+  # spark_data_write_generic (a write helper that lives in data_read.R)
+  spark_write_source(
+    tbl,
+    "parquet",
+    mode = "overwrite",
+    options = list(path = path),
+    partition_by = "grp"
+  )
+  expect_equal(sdf_nrow(spark_read_parquet(sc, random_string(), path)), 6)
+})
+
+test_that("spark_read_orc() accepts an explicit Spark schema", {
+  skip_on_livy()
+  skip_connection("format-orc")
+  skip_databricks_connect()
+
+  src <- tempfile("schema_src_")
+  spark_write_orc(
+    sdf_copy_to(sc, data.frame(id = 1:3), overwrite = TRUE),
+    src
+  )
+  schema <- spark_read_orc(sc, random_string(), src) %>%
+    spark_dataframe() %>%
+    invoke("schema")
+
+  out <- spark_read_orc(sc, random_string(), src, schema = schema)
+  expect_equal(sdf_nrow(out), 3)
+})
+
+test_that("jdbc write without a url errors (jdbc branch guard)", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  skip_databricks_connect()
+
+  # exercises the is_jdbc guard in spark_data_write_generic (lives in data_read.R)
+  expect_error(
+    spark_write_jdbc(
+      testthat_tbl("iris"),
+      name = random_string("j_"),
+      options = list()
+    ),
+    "url"
+  )
+})
+
+test_that("spark_read_csv() auto-names columns when header = FALSE", {
+  skip_on_livy()
+  skip_connection("format-csv")
+  skip_databricks_connect()
+
+  p <- tempfile(fileext = ".csv")
+  writeLines(c("1,a", "2,b"), p)
+  sdf <- spark_read_csv(sc, random_string(), p, header = FALSE)
+  expect_setequal(colnames(sdf), c("V1", "V2"))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-data_read.R
+++ b/tests/testthat/test-data_read.R
@@ -321,9 +321,7 @@ test_that("spark_read() works as expected", {
 test_that("spark_read_avro() works as expected", {
   skip_on_livy()
   skip_connection("format-avro")
-  # Capped at Spark 4: avro works on 4.x, but the test harness only loads the
-  # avro package on Spark < 4.1 (helper-initialize.R). See plan "Issues to open".
-  test_requires_version("2.4.0", max_version = "4")
+  test_requires_version("2.4.0")
   skip_databricks_connect()
 
   expected <- dplyr::tibble(

--- a/tests/testthat/test-data_write.R
+++ b/tests/testthat/test-data_write.R
@@ -370,4 +370,79 @@ test_that("spark_write_parquet() accepts a list of modes", {
   expect_equal(sdf_nrow(spark_read_parquet(sc, random_string(), path)), 3)
 })
 
+test_that("spark_write() validates its arguments", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    spark_write(iris_tbl, writer = function(df, path) df, paths = list()),
+    "'paths' must contain at least 1 path"
+  )
+
+  expect_error(
+    spark_write(iris_tbl, writer = "not a function", paths = "hdfs://iris")
+  )
+})
+
+test_that("spark_write_csv() partitions output by the given columns", {
+  skip_on_livy()
+  skip_connection("format-csv")
+  skip_databricks_connect()
+
+  iris_tbl <- testthat_tbl("iris")
+  path <- tempfile(pattern = "test_write_csv_partition_")
+
+  spark_write_csv(iris_tbl, path, partition_by = "Species")
+
+  # Each distinct Species becomes a partition directory of the form
+  # `Species=<value>` written by Spark's partitionBy().
+  partition_dirs <- list.files(path, pattern = "^Species=")
+  expect_gt(length(partition_dirs), 0)
+})
+
+test_that("spark_write_source() writes a generic source", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  skip_databricks_connect()
+
+  sdf <- sdf_copy_to(sc, data.frame(id = 1:3), overwrite = TRUE)
+  path <- tempfile(pattern = "test_write_source_")
+
+  spark_write_source(
+    sdf,
+    source = "parquet",
+    options = list(path = path)
+  )
+
+  expect_equal(
+    sdf_nrow(spark_read_parquet(sc, random_string(), path)),
+    3
+  )
+})
+
+test_that("spark_write_rds() errors when URI count does not match partitions", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  test_requires_version("3.0.0")
+  skip_on_arrow()
+  skip_databricks_connect()
+
+  sdf <- sdf_copy_to(
+    sc,
+    data.frame(id = 1:6),
+    overwrite = TRUE,
+    repartition = 3
+  )
+
+  expect_error(
+    spark_write_rds(
+      sdf,
+      dest_uri = c("file:///tmp/only_one.rds", "file:///tmp/only_two.rds")
+    ),
+    "Number of destination URI"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-data_write.R
+++ b/tests/testthat/test-data_write.R
@@ -16,6 +16,8 @@ test_avro_schema <- list(
 test_that("spark_write_delta() and spark_read_delta() work as expected", {
   skip_on_livy()
   skip_connection("format-delta")
+  # Capped at Spark 4.1+: no compatible delta-spark build exists yet — delta-spark
+  # 4.0.0 (the latest) throws NoSuchMethodError on Spark 4.1. Works on Spark 3.x/4.0.
   test_requires_version("3", max_version = "4")
   test_requires("nycflights13")
 
@@ -252,7 +254,7 @@ test_that("spark_write() works as expected", {
 test_that("spark_write_avro() works as expected", {
   skip_on_livy()
   skip_connection("format-avro")
-  test_requires_version("2.4.0", max_version = "4")
+  test_requires_version("2.4.0")
   skip_databricks_connect()
 
   df <- dplyr::tibble(
@@ -277,13 +279,15 @@ test_that("spark_write_avro() works as expected", {
 
 test_that("spark read/write methods avoid name collision on identical file names", {
   skip_on_livy()
-  skip_connection("format-avro")
-  test_requires_version("2.4.0", max_version = "4")
+  skip_connection("format-generalized")
 
+  # Package-free formats: these work on every supported Spark version, so they
+  # are intentionally NOT version-capped. (avro is exercised separately below,
+  # since it needs the avro package — see plan "Issues to open".)
   tbl_1 <- dplyr::tibble(name = c("foo_1", "bar_1"))
   tbl_2 <- dplyr::tibble(name = c("foo_2", "bar_2"))
-  sdf_1 <- copy_to(sc, tbl_1)
-  sdf_2 <- copy_to(sc, tbl_2)
+  sdf_1 <- copy_to(sc, tbl_1, overwrite = TRUE)
+  sdf_2 <- copy_to(sc, tbl_2, overwrite = TRUE)
 
   impls <- list(
     structure(c(read = spark_read_csv, write = spark_write_csv)),
@@ -293,12 +297,35 @@ test_that("spark read/write methods avoid name collision on identical file names
     structure(c(read = spark_read_orc, write = spark_write_orc))
   )
 
-  if (!is_testing_databricks_connect()) {
-    impls <- append(
-      impls,
-      list(structure(c(read = spark_read_avro, write = spark_write_avro)))
-    )
+  for (impl in impls) {
+    path1 <- tempfile()
+    path2 <- tempfile()
+
+    impl$write(sdf_1, path1)
+    impl$write(sdf_2, path2)
+
+    sdf_1 <- impl$read(sc, path1)
+    expect_equivalent(sdf_1 %>% collect(), tbl_1)
+    sdf_2 <- impl$read(sc, path2)
+    expect_equivalent(sdf_2 %>% collect(), tbl_2)
+    expect_equivalent(sdf_1 %>% collect(), tbl_1)
   }
+})
+
+test_that("avro read/write avoids name collision on identical file names", {
+  skip_on_livy()
+  skip_connection("format-avro")
+  skip_databricks_connect()
+  test_requires_version("2.4.0")
+
+  tbl_1 <- dplyr::tibble(name = c("foo_1", "bar_1"))
+  tbl_2 <- dplyr::tibble(name = c("foo_2", "bar_2"))
+  sdf_1 <- copy_to(sc, tbl_1, overwrite = TRUE)
+  sdf_2 <- copy_to(sc, tbl_2, overwrite = TRUE)
+
+  impls <- list(
+    structure(c(read = spark_read_avro, write = spark_write_avro))
+  )
 
   for (impl in impls) {
     path1 <- tempfile()
@@ -443,6 +470,84 @@ test_that("spark_write_rds() errors when URI count does not match partitions", {
     ),
     "Number of destination URI"
   )
+})
+
+test_that("spark_write_rds() writes one RDS file per partition", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  test_requires_version("3.0.0")
+  skip_on_arrow()
+  skip_databricks_connect()
+
+  sdf <- sdf_copy_to(
+    sc,
+    data.frame(id = 1:6),
+    overwrite = TRUE,
+    repartition = 2
+  )
+  out_dir <- withr::local_tempdir()
+  uri_template <- paste0(
+    "file://",
+    file.path(out_dir, "part_{partitionId}.rds")
+  )
+
+  res <- spark_write_rds(sdf, uri_template)
+
+  # returns a tibble of partition_id + uri, one row per partition
+  expect_s3_class(res, "tbl_df")
+  expect_equal(nrow(res), 2)
+  expect_setequal(res$partition_id, c(0, 1))
+
+  # the RDS files were actually written, one per partition
+  written <- list.files(out_dir, pattern = "part_.*\\.rds$")
+  expect_equal(length(written), 2)
+})
+
+test_that("spark_write_rds() requires Spark 3.0 or above", {
+  # reachable on the supported Spark 2.x line; exercise the guard with a mocked
+  # connection so it runs without an actual < 3.0 cluster
+  with_mocked_bindings(
+    spark_connection = function(x, ...) "fake_sc",
+    spark_version = function(sc, ...) numeric_version("2.4.0"),
+    .package = "sparklyr",
+    expect_error(
+      spark_write_rds("x", "file:///tmp/a.rds"),
+      "only supported in Spark 3.0 or above"
+    )
+  )
+})
+
+test_that("spark_write_table() dispatches on a spark_jobj", {
+  skip_on_livy()
+  skip_connection("format-table")
+  skip_databricks_connect()
+
+  df <- copy_to(
+    sc,
+    data.frame(id = 1:3),
+    name = random_string("jobj_tbl_"),
+    overwrite = TRUE
+  )
+  tbl_name <- random_string("written_jobj_")
+  on.exit(dbRemoveTable(sc, tbl_name, fail_if_missing = FALSE), add = TRUE)
+
+  spark_write_table(spark_dataframe(df), tbl_name)
+  expect_equal(sdf_nrow(tbl(sc, tbl_name)), 3)
+})
+
+test_that("spark_write.spark_jobj() accepts a Dataset jobj and dispatches", {
+  skip_on_livy()
+  skip_connection("format-generalized")
+  skip_databricks_connect()
+
+  iris_tbl <- testthat_tbl("iris")
+  jobj <- spark_dataframe(iris_tbl)
+  writer <- function(df, path) list(list(path = path))
+
+  expect_warning_on_arrow(
+    res <- spark_write(jobj, writer = writer, paths = "hdfs://iris_jobj")
+  )
+  expect_equal(lapply(res, function(e) e$path), list("hdfs://iris_jobj"))
 })
 
 test_clear_cache()

--- a/tests/testthat/test-dbi.R
+++ b/tests/testthat/test-dbi.R
@@ -111,6 +111,209 @@ test_that("dbIsValid detects when a connection is opened", {
   expect_true(dbIsValid(sc))
 })
 
+# ---- Connection-free helpers ----------------------------------------------
+
+test_that("get_data_type maps R vectors to SQL types", {
+  expect_equal(get_data_type(factor("a")), "TEXT")
+  expect_equal(get_data_type(1L), "INTEGER")
+  expect_equal(get_data_type(1.5), "REAL")
+  expect_equal(get_data_type("x"), "STRING")
+  expect_equal(get_data_type(TRUE), "INTEGER")
+  expect_equal(get_data_type(list(1)), "BLOB")
+  expect_error(get_data_type(1 + 2i), "Unsupported type")
+})
+
+test_that("dbi_ensure_no_backtick rejects back ticks", {
+  expect_silent(dbi_ensure_no_backtick("good_name"))
+  expect_error(dbi_ensure_no_backtick("bad`name"), "back tick")
+})
+
+# ---- Quoting / type methods -----------------------------------------------
+
+test_that("dbQuoteString and dbQuoteLiteral return quoted SQL", {
+  quoted <- dbQuoteString(sc, c("a", "b"))
+  expect_s4_class(quoted, "SQL")
+  expect_match(as.character(quoted)[[1]], '"a"')
+
+  expect_s4_class(dbQuoteLiteral(sc, "x"), "SQL")
+})
+
+test_that("dbQuoteIdentifier backticks plain names and passes through the rest", {
+  expect_match(as.character(dbQuoteIdentifier(sc, "col")), "`col`")
+
+  # an SQL object is returned untouched
+  already <- SQL("`x`")
+  expect_identical(dbQuoteIdentifier(sc, already), already)
+
+  # a zero-length vector takes the pass-through branch
+  expect_identical(dbQuoteIdentifier(sc, character(0)), character(0))
+
+  # an already-backticked, schema-qualified name is passed through
+  expect_identical(dbQuoteIdentifier(sc, "`a`.`b`"), "`a`.`b`")
+
+  # a plain name containing a back tick errors
+  expect_error(dbQuoteIdentifier(sc, "a`b"), "back tick")
+})
+
+test_that("dbDataType dispatches to get_data_type", {
+  expect_equal(dbDataType(sc, 1L), "INTEGER")
+  expect_equal(dbDataType(sc, "x"), "STRING")
+})
+
+test_that("sqlInterpolate delegates to the DBIConnection method", {
+  out <- DBI::sqlInterpolate(
+    sc,
+    "SELECT * FROM t WHERE x = ?val",
+    val = "a"
+  )
+  expect_match(as.character(out), "a")
+})
+
+# ---- Connection-level methods ---------------------------------------------
+
+test_that("dbGetInfo, show and dbplyr_edition report connection details", {
+  expect_identical(dbGetInfo(sc), sc)
+  expect_output(show(sc), "<spark_connection>")
+  expect_type(dbplyr_edition(sc), "integer")
+})
+
+test_that("transaction methods are no-ops returning TRUE", {
+  expect_true(dbBegin(sc))
+  expect_true(dbCommit(sc))
+  expect_true(dbRollback(sc))
+})
+
+test_that("dbSetProperty issues a SET statement", {
+  expect_error(
+    dbSetProperty(sc, "spark.sql.shuffle.partitions", "10"),
+    NA
+  )
+})
+
+# ---- Result + fetch methods -----------------------------------------------
+
+test_that("result metadata methods report on a query", {
+  res <- dbSendQuery(sc, "SELECT * FROM iris")
+  on.exit(dbClearResult(res))
+
+  expect_equal(dbGetStatement(res), "SELECT * FROM iris")
+  expect_true(dbIsValid(res))
+  expect_equal(dbGetRowCount(res), 150)
+  expect_equal(dbGetRowsAffected(res), 150)
+  expect_true(dbHasCompleted(res))
+  expect_true(dbBind(res, list()))
+})
+
+test_that("dbFetch pages through results using the stored offset", {
+  res <- dbSendQuery(sc, "SELECT * FROM iris")
+  on.exit(dbClearResult(res))
+
+  first <- dbFetch(res, n = 10)
+  expect_equal(nrow(first), 10)
+
+  # a second fetch advances past the previously returned rows
+  second <- dbFetch(res, n = 5)
+  expect_equal(nrow(second), 5)
+})
+
+test_that("dbExecute and dbSendStatement run a statement", {
+  expect_equal(dbExecute(sc, "SELECT * FROM iris"), 150)
+
+  rs <- dbSendStatement(sc, "SELECT * FROM iris")
+  expect_s4_class(rs, "DBISparkResult")
+  dbClearResult(rs)
+})
+
+# ---- Table read / write / remove ------------------------------------------
+
+test_that("dbWriteTable round-trips a temporary table and honors flags", {
+  tbl_name <- random_table_name("dbi_tmp_")
+  other_name <- random_table_name("dbi_tmp_")
+  on.exit({
+    dbRemoveTable(sc, tbl_name, fail_if_missing = FALSE)
+    dbRemoveTable(sc, other_name, fail_if_missing = FALSE)
+  })
+
+  dbWriteTable(sc, tbl_name, dbi_df, temporary = TRUE)
+  expect_true(dbExistsTable(sc, tbl_name))
+  expect_setequal(dbReadTable(sc, tbl_name)$b, letters[1:3])
+
+  # writing again without overwrite is rejected
+  expect_error(
+    dbWriteTable(sc, tbl_name, dbi_df, temporary = TRUE),
+    "already exists"
+  )
+
+  # overwrite replaces the contents
+  dbWriteTable(
+    sc,
+    tbl_name,
+    dbi_df[c("a")],
+    temporary = TRUE,
+    overwrite = TRUE
+  )
+  expect_equal(colnames(dbReadTable(sc, tbl_name)), "a")
+
+  # append to a fresh table exercises the append mode branch
+  dbWriteTable(sc, other_name, dbi_df, temporary = TRUE, append = TRUE)
+  expect_true(dbExistsTable(sc, other_name))
+
+  # append and overwrite are mutually exclusive
+  expect_error(
+    dbWriteTable(
+      sc,
+      other_name,
+      dbi_df,
+      temporary = TRUE,
+      append = TRUE,
+      overwrite = TRUE
+    ),
+    "cannot both be"
+  )
+})
+
+test_that("dbWriteTable can persist a managed table", {
+  name <- random_table_name("dbi_persist_")
+  on.exit(dbRemoveTable(sc, name, fail_if_missing = FALSE))
+
+  # temporary = FALSE (the default) exercises the spark_write_table branch
+  dbWriteTable(sc, name, dbi_df)
+  expect_true(dbExistsTable(sc, name))
+  expect_equal(nrow(dbReadTable(sc, name)), 3)
+
+  # dropping an existing table uses the fail-if-missing (no IF EXISTS) path
+  dbRemoveTable(sc, name)
+  expect_false(dbExistsTable(sc, name))
+})
+
+test_that("dbListTables filters temporary helper tables and sorts", {
+  name <- random_table_name("dbi_list_")
+  on.exit(dbRemoveTable(sc, name, fail_if_missing = FALSE))
+
+  dbWriteTable(sc, name, dbi_df, temporary = TRUE)
+  tables <- dbListTables(sc)
+  expect_true(name %in% tables)
+  expect_false(any(grepl("^sparklyr_tmp_", tables)))
+})
+
+test_that("dbListTables can target a specific database", {
+  db <- random_table_name("dbi_db_")
+  on.exit(dbExecute(sc, paste0("DROP DATABASE IF EXISTS ", db, " CASCADE")))
+  dbExecute(sc, paste0("CREATE DATABASE IF NOT EXISTS ", db))
+
+  # exercises the `database` argument ("SHOW TABLES FROM <db>")
+  expect_type(dbListTables(sc, database = db), "character")
+})
+
+test_that("dbRemoveTable validates names and tolerates missing tables", {
+  expect_error(dbRemoveTable(sc, "bad`name"), "back tick")
+
+  # fail_if_missing = FALSE adds IF EXISTS and is a no-op when absent
+  expect_true(
+    dbRemoveTable(sc, random_table_name("absent_"), fail_if_missing = FALSE)
+  )
+})
+
 teardown({
   # These tables are only created by tests that are skipped on newer Spark
   # versions, so tolerate them being absent during cleanup.

--- a/tests/testthat/test-dplyr_spark.R
+++ b/tests/testthat/test-dplyr_spark.R
@@ -195,7 +195,10 @@ test_that("src_spark connection/describe/same_src/tbl helpers work", {
 
 test_that("connection glue methods (explain / tbl_vars / src_tbls) are wired up", {
   skip_databricks_connect()
-  expect_type(dbplyr::sql_query_explain(sc, dbplyr::sql("SELECT 1")), "character")
+  expect_type(
+    dbplyr::sql_query_explain(sc, dbplyr::sql("SELECT 1")),
+    "character"
+  )
   # call the .spark_jobj method directly (the dplyr generic post-processes with
   # group_vars, which isn't defined for a bare jobj)
   expect_equal(length(tbl_vars.spark_jobj(spark_dataframe(iris_tbl))), 5)
@@ -209,8 +212,11 @@ test_that("process_tbl_name rejects names with more than 3 components", {
 test_that("spark_partition_register_df registers a table; remove_if_exists drops it", {
   skip_databricks_connect()
   spark_partition_register_df(
-    sc, spark_dataframe(iris_tbl), "reg_part_tbl",
-    repartition = 2L, memory = TRUE
+    sc,
+    spark_dataframe(iris_tbl),
+    "reg_part_tbl",
+    repartition = 2L,
+    memory = TRUE
   )
   expect_true("reg_part_tbl" %in% src_tbls(sc))
   spark_remove_table_if_exists(sc, "reg_part_tbl")

--- a/tests/testthat/test-dplyr_spark.R
+++ b/tests/testthat/test-dplyr_spark.R
@@ -181,4 +181,63 @@ test_that("Connection functions work", {
   #
 })
 
+# ---- additional coverage for dplyr/dbplyr glue + helpers --------------------
+
+test_that("src_spark connection/describe/same_src/tbl helpers work", {
+  skip_databricks_connect()
+  src <- structure(list(con = sc), class = c("src_spark", "src_sql", "src"))
+  expect_true(inherits(spark_connection(src), "spark_connection"))
+  expect_type(dbplyr::db_connection_describe(src), "character")
+  expect_true(dplyr::same_src(src, src))
+  expect_false(dplyr::same_src(src, 42))
+  expect_true(inherits(dplyr::tbl(src, "iris"), "tbl_spark"))
+})
+
+test_that("connection glue methods (explain / tbl_vars / src_tbls) are wired up", {
+  skip_databricks_connect()
+  expect_type(dbplyr::sql_query_explain(sc, dbplyr::sql("SELECT 1")), "character")
+  # call the .spark_jobj method directly (the dplyr generic post-processes with
+  # group_vars, which isn't defined for a bare jobj)
+  expect_equal(length(tbl_vars.spark_jobj(spark_dataframe(iris_tbl))), 5)
+  expect_type(src_tbls(sc, database = "default"), "character")
+})
+
+test_that("process_tbl_name rejects names with more than 3 components", {
+  expect_error(process_tbl_name("a.b.c.d"), "expected input to be")
+})
+
+test_that("spark_partition_register_df registers a table; remove_if_exists drops it", {
+  skip_databricks_connect()
+  spark_partition_register_df(
+    sc, spark_dataframe(iris_tbl), "reg_part_tbl",
+    repartition = 2L, memory = TRUE
+  )
+  expect_true("reg_part_tbl" %in% src_tbls(sc))
+  spark_remove_table_if_exists(sc, "reg_part_tbl")
+  expect_false("reg_part_tbl" %in% src_tbls(sc))
+})
+
+test_that("spark_sqlresult_from_dplyr renders and runs a Spark SQL query", {
+  skip_databricks_connect()
+  res <- spark_sqlresult_from_dplyr(iris_tbl %>% filter(Petal_Width > 1))
+  expect_true(inherits(res, "spark_jobj"))
+})
+
+test_that("sample_n / sample_frac draw rows", {
+  skip_databricks_connect()
+  expect_equal(nrow(collect(sample_n(iris_tbl, 10))), 10)
+  expect_gt(nrow(collect(sample_frac(iris_tbl, 0.1))), 0)
+})
+
+test_that("sdf_remote_name.default is NULL; slice_ is unsupported; tbl_ptype simulates", {
+  expect_null(sdf_remote_name(42))
+  expect_error(slice_.tbl_spark(iris_tbl), "Slice is not supported")
+  expect_s3_class(dplyr::tbl_ptype(iris_tbl), "data.frame")
+})
+
+test_that("gen_prng_seed returns an integer when a PRNG seed exists", {
+  set.seed(1)
+  expect_type(gen_prng_seed(), "integer")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-dplyr_verbs.R
+++ b/tests/testthat/test-dplyr_verbs.R
@@ -1689,4 +1689,187 @@ test_that("doSpark works with 'qs' serializer", {
   )
 })
 
+# na.replace / replace_na -----------------------------------------------------
+
+test_that("na.replace.tbl_spark fills NA with a single value (unkeyed)", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3), y = c(NA, 2, 3))
+  sdf <- copy_to(sc, df, name = random_string("na_replace_"), overwrite = TRUE)
+
+  res <- sdf %>%
+    na.replace(0) %>%
+    collect()
+
+  expect_equivalent(res, dplyr::tibble(x = c(1, 0, 3), y = c(0, 2, 3)))
+})
+
+test_that("na.replace.tbl_spark fills NA by named column (keyed)", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3), y = c(NA, 2, 3))
+  sdf <- copy_to(sc, df, name = random_string("na_replace_"), overwrite = TRUE)
+
+  res <- sdf %>%
+    na.replace(x = -1) %>%
+    collect()
+
+  # only column 'x' should be filled; 'y' keeps its NA
+  expect_equivalent(res$x, c(1, -1, 3))
+  expect_true(is.na(res$y[[1]]))
+})
+
+test_that("replace_na.tbl_spark works as expected", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3))
+  sdf <- copy_to(sc, df, name = random_string("replace_na_"), overwrite = TRUE)
+
+  res <- sdf %>%
+    tidyr::replace_na(list(x = 0)) %>%
+    collect()
+
+  expect_equivalent(res, dplyr::tibble(x = c(1, 0, 3)))
+})
+
+test_that("na.replace / replace_na work on a spark_jobj directly", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3))
+  sdf <- copy_to(
+    sc,
+    df,
+    name = random_string("na_replace_jobj_"),
+    overwrite = TRUE
+  )
+  jobj <- spark_dataframe(sdf)
+
+  res1 <- na.replace(jobj, 0) %>% collect()
+  expect_equivalent(res1, dplyr::tibble(x = c(1, 0, 3)))
+
+  res2 <- tidyr::replace_na(jobj, list(x = 0)) %>% collect()
+  expect_equivalent(res2, dplyr::tibble(x = c(1, 0, 3)))
+})
+
+# na.omit ----------------------------------------------------------------------
+
+test_that("na.omit.tbl_spark drops NA rows and reports a message", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3), y = c(1, 2, 3))
+  sdf <- copy_to(sc, df, name = random_string("na_omit_"), overwrite = TRUE)
+
+  expect_message(
+    res <- na.omit(sdf) %>% collect(),
+    "Dropped"
+  )
+  expect_equivalent(res, dplyr::tibble(x = c(1, 3), y = c(1, 3)))
+})
+
+test_that("na.omit.tbl_spark reports when no rows are dropped", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, 2, 3), y = c(1, 2, 3))
+  sdf <- copy_to(
+    sc,
+    df,
+    name = random_string("na_omit_none_"),
+    overwrite = TRUE
+  )
+
+  expect_message(
+    res <- na.omit(sdf) %>% collect(),
+    "No rows dropped"
+  )
+  expect_equivalent(res, df)
+})
+
+# na.fail ----------------------------------------------------------------------
+
+test_that("na.fail.tbl_spark returns the object unchanged when no NA present", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, 2, 3))
+  sdf <- copy_to(sc, df, name = random_string("na_fail_"), overwrite = TRUE)
+
+  res <- na.fail(sdf)
+  expect_true(inherits(res, "spark_jobj"))
+})
+
+test_that("na.fail.tbl_spark errors when NA present", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3))
+  sdf <- copy_to(sc, df, name = random_string("na_fail_err_"), overwrite = TRUE)
+
+  expect_error(
+    na.fail(sdf),
+    "missing values"
+  )
+})
+
+# apply_na_action --------------------------------------------------------------
+
+test_that("apply_na_action returns x unchanged when na.action is NULL", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3))
+  sdf <- copy_to(sc, df, name = random_string("apply_na_"), overwrite = TRUE)
+
+  expect_identical(apply_na_action(sdf, na.action = NULL), sdf)
+})
+
+test_that("apply_na_action resolves a function passed by name", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3), y = c(1, 2, 3))
+  sdf <- copy_to(
+    sc,
+    df,
+    name = random_string("apply_na_name_"),
+    overwrite = TRUE
+  )
+
+  res <- apply_na_action(sdf, na.action = "na.omit") %>% collect()
+  expect_equal(nrow(res), 2)
+})
+
+test_that("apply_na_action errors for an unknown function name", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3))
+  sdf <- copy_to(
+    sc,
+    df,
+    name = random_string("apply_na_bad_"),
+    overwrite = TRUE
+  )
+
+  expect_error(
+    apply_na_action(sdf, na.action = "no_such_na_function_xyz"),
+    "no function with name"
+  )
+})
+
+test_that("apply_na_action errors when na.action is not a function", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3))
+  sdf <- copy_to(
+    sc,
+    df,
+    name = random_string("apply_na_notfn_"),
+    overwrite = TRUE
+  )
+
+  expect_error(
+    apply_na_action(sdf, na.action = 42),
+    "'na.action' is not a function"
+  )
+})
+
+# names<- ----------------------------------------------------------------------
+
+# single-input early returns ---------------------------------------------------
+
+test_that("rbind.tbl_spark returns the single input unchanged", {
+  skip_on_livy()
+  df1a_tbl <- testthat_tbl("df1a")
+  expect_identical(rbind(df1a_tbl), df1a_tbl)
+})
+
+test_that("sdf_bind_rows returns the single input unchanged", {
+  skip_on_livy()
+  df1a_tbl <- testthat_tbl("df1a")
+  expect_identical(sdf_bind_rows(df1a_tbl), df1a_tbl)
+})
+
 test_clear_cache()

--- a/tests/testthat/test-dplyr_verbs.R
+++ b/tests/testthat/test-dplyr_verbs.R
@@ -1719,8 +1719,10 @@ test_that("filter.tbl_spark rejects .preserve = TRUE", {
 test_that("registerDoSpark warns on unnamed and unrecognized options", {
   skip_on_livy()
   test_requires("foreach")
+  # pass `parallelism` explicitly so the extra args land in `...` (the first
+  # positional arg would otherwise bind to `parallelism`)
   w <- capture_warnings(
-    registerDoSpark(sc, "an_unnamed_value", bogus_option = 1)
+    registerDoSpark(sc, parallelism = 1, "an_unnamed_value", bogus_option = 1)
   )
   expect_match(w, "unnamed argument", all = FALSE)
   expect_match(w, "unrecognized doSpark package option", all = FALSE)
@@ -1947,6 +1949,13 @@ test_that("names<-.tbl_spark renames the columns", {
   expect_setequal(colnames(sdf), c("x", "y"))
   # the renamed view is usable (regression: dbplyr table_path quoting #mutate_names)
   expect_equal(nrow(collect(sdf)), 3)
+
+  # a derived tbl has no remote_name(); mutate_names must fall back to a temp
+  # name rather than passing character(0) to createOrReplaceTempView
+  derived <- sdf %>% dplyr::select(x)
+  names(derived) <- "z"
+  expect_setequal(colnames(derived), "z")
+  expect_equal(nrow(collect(derived)), 3)
 })
 
 # sdf_na_omit ------------------------------------------------------------------

--- a/tests/testthat/test-dplyr_verbs.R
+++ b/tests/testthat/test-dplyr_verbs.R
@@ -1311,6 +1311,21 @@ test_that("'cbind' works as expected", {
   )
 })
 
+test_that("'cbind' returns the single input unchanged", {
+  skip_on_livy()
+  df1a_tbl <- testthat_tbl("df1a")
+  expect_identical(cbind(df1a_tbl), df1a_tbl)
+})
+
+test_that("'sdf_bind_cols' err for non-tbl_spark", {
+  skip_on_livy()
+  df1a_tbl <- testthat_tbl("df1a")
+  expect_error(
+    sdf_bind_cols(df1a_tbl, df1a),
+    "all inputs must be tbl_spark"
+  )
+})
+
 test_that("'sdf_bind_cols' agrees with 'cbind'", {
   skip_on_livy()
   df1a_tbl <- testthat_tbl("df1a")
@@ -1689,6 +1704,68 @@ test_that("doSpark works with 'qs' serializer", {
   )
 })
 
+# filter .preserve ------------------------------------------------------------
+
+test_that("filter.tbl_spark rejects .preserve = TRUE", {
+  skip_on_livy()
+  expect_error(
+    iris_tbl %>% dplyr::filter(Sepal_Length > 0, .preserve = TRUE),
+    "`.preserve` is not supported"
+  )
+})
+
+# registerDoSpark option handling ---------------------------------------------
+
+test_that("registerDoSpark warns on unnamed and unrecognized options", {
+  skip_on_livy()
+  test_requires("foreach")
+  w <- capture_warnings(
+    registerDoSpark(sc, "an_unnamed_value", bogus_option = 1)
+  )
+  expect_match(w, "unnamed argument", all = FALSE)
+  expect_match(w, "unrecognized doSpark package option", all = FALSE)
+})
+
+test_that("registerDoSpark backend reports its name and version", {
+  skip_on_livy()
+  test_requires("foreach")
+  register_test_spark_connection()
+  expect_equal(foreach::getDoParName(), "doSpark")
+  # `getDoParVersion()` runs the `.info()` version branch; there is no installed
+  # package literally named "doSpark", so the lookup yields NA.
+  expect_true(is.na(suppressWarnings(foreach::getDoParVersion())))
+})
+
+test_that("registerDoSpark falls back to 0 workers when parallelism is unknown", {
+  skip_on_livy()
+  test_requires("foreach")
+  # spark_context() throwing exercises the tryCatch that returns 0 workers
+  with_mocked_bindings(
+    spark_context = function(...) stop("no context"),
+    .package = "sparklyr",
+    {
+      registerDoSpark(sc)
+      expect_equal(foreach::getDoParWorkers(), 0L)
+    }
+  )
+  # restore a healthy backend for any later use
+  register_test_spark_connection()
+})
+
+test_that("doSpark honors nocompile = TRUE", {
+  skip_on_livy()
+  skip_on_arrow_devel()
+  test_requires("foreach")
+  test_requires("iterators")
+  test_requires_package_version("dbplyr", 2)
+  registerDoSpark(sc, nocompile = TRUE)
+  expect_warning_on_arrow(
+    rs <- foreach(x = 1:5) %dopar% (x * x)
+  )
+  expect_equal(unlist(rs), (1:5)^2)
+  register_test_spark_connection()
+})
+
 # na.replace / replace_na -----------------------------------------------------
 
 test_that("na.replace.tbl_spark fills NA with a single value (unkeyed)", {
@@ -1857,6 +1934,35 @@ test_that("apply_na_action errors when na.action is not a function", {
 })
 
 # names<- ----------------------------------------------------------------------
+
+test_that("names<-.tbl_spark renames the columns", {
+  skip_on_livy()
+  sdf <- copy_to(
+    sc,
+    data.frame(a = 1:3, b = 4:6),
+    name = random_string("rename_"),
+    overwrite = TRUE
+  )
+  names(sdf) <- c("x", "y")
+  expect_setequal(colnames(sdf), c("x", "y"))
+  # the renamed view is usable (regression: dbplyr table_path quoting #mutate_names)
+  expect_equal(nrow(collect(sdf)), 3)
+})
+
+# sdf_na_omit ------------------------------------------------------------------
+
+test_that("sdf_na_omit drops NA only in the named columns", {
+  skip_on_livy()
+  df <- dplyr::tibble(x = c(1, NA, 3), y = c(NA, 2, 3))
+  sdf <- copy_to(sc, df, name = random_string("na_cols_"), overwrite = TRUE)
+
+  # restricting to column 'x' keeps the row whose only NA is in 'y'
+  res <- sdf_na_omit(spark_dataframe(sdf), columns = "x") %>%
+    sdf_register() %>%
+    collect()
+  expect_equal(nrow(res), 2)
+  expect_equal(res$x, c(1, 3))
+})
 
 # single-input early returns ---------------------------------------------------
 

--- a/tests/testthat/test-install_spark.R
+++ b/tests/testthat/test-install_spark.R
@@ -1,146 +1,460 @@
-skip("Skips due to how long it takes")
-skip_connection("install_spark")
-skip_on_livy()
-skip_on_arrow_devel()
-
-test_that("Install commands work", {
-  expect_true(spark_can_install())
-
-  spark_version <- as.character(spark_version(sc))
-
-  expect_equal(
-    spark_install_version_expand(spark_version, TRUE),
-    spark_version
-  )
-
-  expect_equal(
-    spark_install_version_expand(spark_version, FALSE),
-    spark_version
-  )
-
-  expect_equal(
-    names(spark_default_version()),
-    c("spark", "hadoop")
-  )
-
-  spark_home <- Sys.getenv("SPARK_HOME")
-  if (spark_home == "") {
-    spark_home <- NULL
-  }
-  expect_equal(spark_home(), spark_home)
-})
-
-skip_databricks_connect()
-test_that("supported spark_versions can be downloaded", {
-  skip("")
-  test_requires("RCurl")
-
-  versions <- spark_versions(latest = FALSE)
-  versions <- versions[versions$download != "", ]
-  for (row in seq_len(nrow(versions))) {
-    version <- versions[row, ]
-    expect_true(
-      RCurl::url.exists(version$download),
-      label = paste(version$spark, version$hadoop),
-      info = version$download
+# Returns a download_file() mock that drops a minimal fake Spark tarball at
+# `destfile`, so spark_install() can run end-to-end (untar + config writers)
+# without a real network download. `log4j` selects which template ships:
+# "v2" (log4j2.properties.template), "v1" (log4j.properties.template), or
+# "none" (no template, to exercise the missing-template error path).
+make_fake_download <- function(log4j = "v2") {
+  function(url, destfile, ...) {
+    component <- sub("\\.tgz$", "", basename(destfile))
+    staging <- tempfile("sparkfix")
+    conf_dir <- file.path(staging, component, "conf")
+    dir.create(conf_dir, recursive = TRUE)
+    if (log4j == "v2") {
+      # "rootLogger.level=" (no spaces) so the property-replace (gsub) branch
+      # fires for it, while the other properties exercise the append branch.
+      writeLines(
+        c("rootLogger.level=info", "logger.jetty.level = warn"),
+        file.path(conf_dir, "log4j2.properties.template")
+      )
+    } else if (log4j == "v1") {
+      writeLines(
+        c("log4j.rootCategory=INFO, console", "log4j.appender.localfile=x"),
+        file.path(conf_dir, "log4j.properties.template")
+      )
+    }
+    # A pre-existing "spark.local.dir" line triggers the gsub branch in the
+    # spark-defaults writer (only reached when properties are non-empty, i.e.
+    # on Windows); other properties hit the append branch.
+    writeLines(
+      c(
+        "# Default system properties included when running spark-submit.",
+        "spark.local.dir              /tmp/old"
+      ),
+      file.path(conf_dir, "spark-defaults.conf.template")
     )
-  }
-})
-
-test_that("spark_versions downloads use https", {
-  skip("")
-
-  versions <- spark_versions(latest = FALSE)
-  versions <- versions[versions$download != "", ]
-  for (row in seq_len(nrow(versions))) {
-    version <- versions[row, ]
-    expect_true(
-      length(grep("^https", version$download)) == 1,
-      label = paste(version$spark, version$hadoop),
-      info = version$download
+    withr::with_dir(
+      staging,
+      utils::tar(
+        destfile,
+        files = component,
+        compression = "gzip",
+        tar = "internal"
+      )
     )
+    0L
   }
-})
+}
 
-test_that("Installation and uninstallation of Spark work", {
+fake_spark_download <- make_fake_download("v2")
+
+test_that("spark_install downloads, untars, and configures (mocked download)", {
   skip_on_windows()
-  skip_on_ci()
-  test_spark_version <- "4.0.1"
-  test_hadoop_version <- "3"
+  test_version <- "3.4.4"
+  test_hadoop <- "3"
+  component <- sprintf("spark-%s-bin-hadoop%s", test_version, test_hadoop)
 
   withr::with_options(
-    new = list("spark.install.dir" = tempdir()),
+    list("spark.install.dir" = tempfile("sparkinstall")),
     {
       install_dir <- spark_install_dir()
 
-      test_folder <- sprintf(
-        "spark-%s-bin-hadoop%s",
-        test_spark_version,
-        test_hadoop_version
+      with_mocked_bindings(
+        download_file = fake_spark_download,
+        .package = "sparklyr",
+        {
+          info <- spark_install(
+            version = test_version,
+            hadoop_version = test_hadoop,
+            verbose = FALSE
+          )
+        }
       )
 
-      install_msg <- sprintf(
-        "Installing Spark %s for Hadoop %s or later.",
-        test_spark_version,
-        test_hadoop_version
+      conf <- file.path(install_dir, component, "conf")
+      expect_true(dir.exists(file.path(install_dir, component)))
+      expect_true(file.exists(file.path(conf, "log4j2.properties")))
+      expect_true(file.exists(file.path(conf, "spark-defaults.conf")))
+      expect_true(file.exists(file.path(conf, "hive-site.xml")))
+      expect_equal(info$sparkVersion, test_version)
+    }
+  )
+})
+
+test_that("spark_default_version uses bundled default when nothing installed", {
+  with_mocked_bindings(
+    spark_installed_versions = function() data.frame(),
+    .package = "sparklyr",
+    {
+      default <- spark_default_version()
+    }
+  )
+
+  expect_equal(names(default), c("spark", "hadoop"))
+  expect_equal(default$spark, "2.4.3")
+  expect_equal(default$hadoop, "2.7")
+})
+
+test_that("spark_default_version uses installed version when one exists", {
+  with_mocked_bindings(
+    spark_installed_versions = function() {
+      data.frame(spark = "3.4.4", hadoop = "3", stringsAsFactors = FALSE)
+    },
+    spark_install_find = function(...) {
+      list(sparkVersion = "3.4.4", hadoopVersion = "3")
+    },
+    .package = "sparklyr",
+    {
+      default <- spark_default_version()
+    }
+  )
+
+  expect_equal(default$spark, "3.4.4")
+  expect_equal(default$hadoop, "3")
+})
+
+test_that("spark_resolve_envpath expands env vars on Windows", {
+  with_mocked_bindings(
+    os_is_windows = function() TRUE,
+    .package = "sparklyr",
+    {
+      # env var set -> first segment substituted
+      withr::with_envvar(
+        c("SPARKLYR_TEST_HOME" = file.path("C:", "Users", "test")),
+        resolved <- spark_resolve_envpath("%SPARKLYR_TEST_HOME%/spark")
+      )
+      expect_equal(resolved, file.path("C:", "Users", "test", "spark"))
+
+      # env var not set -> %VAR% kept as a literal segment
+      withr::with_envvar(
+        c("SPARKLYR_NOT_SET" = NA),
+        unresolved <- spark_resolve_envpath("%SPARKLYR_NOT_SET%/spark")
+      )
+      expect_equal(unresolved, file.path("%SPARKLYR_NOT_SET%", "spark"))
+    }
+  )
+})
+
+test_that("spark_can_install checks the install dir", {
+  # non-existent dir -> installable
+  withr::with_options(
+    list("spark.install.dir" = tempfile("noexist")),
+    expect_true(spark_can_install())
+  )
+  # existing writable dir -> installable
+  writable <- tempfile("installable")
+  dir.create(writable)
+  withr::with_options(
+    list("spark.install.dir" = writable),
+    expect_true(spark_can_install())
+  )
+})
+
+test_that("spark_home reflects the SPARK_HOME env var", {
+  withr::with_envvar(
+    c("SPARK_HOME" = file.path("opt", "spark")),
+    expect_equal(spark_home(), file.path("opt", "spark"))
+  )
+  withr::with_envvar(
+    c("SPARK_HOME" = NA),
+    expect_null(spark_home())
+  )
+})
+
+test_that("spark_install_version_expand resolves installed-only lookups", {
+  with_mocked_bindings(
+    spark_installed_versions = function() {
+      data.frame(spark = c("3.4.4", "3.5.1"), stringsAsFactors = FALSE)
+    },
+    .package = "sparklyr",
+    expect_equal(spark_install_version_expand("3.4", TRUE), "3.4.4")
+  )
+})
+
+test_that("spark_install_find warns and builds a fallback for unknown versions", {
+  expect_warning(
+    info <- spark_install_find(version = "1.1", hadoop_version = "2.7"),
+    "version specified may not be available"
+  )
+  expect_equal(info$componentName, "spark-1.1-bin-hadoop2.7")
+  expect_equal(info$packageName, "spark-1.1-bin-hadoop2.7.tgz")
+  expect_match(info$packageRemotePath, "archive.apache.org")
+
+  # the "master" path filters to installed versions; with an empty install dir
+  # nothing is installed, so it funnels through the fallback (and warns)
+  withr::with_options(
+    list("spark.install.dir" = tempfile("nomaster")),
+    expect_warning(spark_install_find(version = "master"))
+  )
+})
+
+test_that("spark_install_tar validates and extracts a tarball", {
+  expect_error(
+    spark_install_tar(tempfile("missing", fileext = ".tgz")),
+    "does not exist"
+  )
+
+  bad <- tempfile(fileext = ".tgz")
+  file.create(bad)
+  expect_error(spark_install_tar(bad), "does not conform")
+
+  component <- "spark-3.4.4-bin-hadoop3"
+  staging <- tempfile("tarfix")
+  dir.create(file.path(staging, component, "conf"), recursive = TRUE)
+  writeLines("x", file.path(staging, component, "conf", "marker"))
+  tarpath <- file.path(staging, paste0(component, ".tgz"))
+  withr::with_dir(
+    staging,
+    utils::tar(
+      tarpath,
+      files = component,
+      compression = "gzip",
+      tar = "internal"
+    )
+  )
+
+  withr::with_options(
+    list("spark.install.dir" = tempfile("tarinstall")),
+    {
+      install_dir <- spark_install_dir()
+      dir.create(install_dir, recursive = TRUE)
+      spark_install_tar(tarpath)
+      expect_true(dir.exists(file.path(install_dir, component)))
+    }
+  )
+})
+
+test_that("spark_uninstall removes an install and reports when absent", {
+  skip_on_windows()
+  test_version <- "3.4.4"
+  test_hadoop <- "3"
+  component <- sprintf("spark-%s-bin-hadoop%s", test_version, test_hadoop)
+
+  withr::with_options(
+    list("spark.install.dir" = tempfile("uninstall")),
+    {
+      install_dir <- spark_install_dir()
+
+      expect_message(
+        absent <- spark_uninstall(test_version, test_hadoop),
+        "not found"
+      )
+      expect_false(absent)
+
+      with_mocked_bindings(
+        download_file = fake_spark_download,
+        .package = "sparklyr",
+        spark_install(test_version, test_hadoop, verbose = FALSE)
       )
 
       expect_message(
-        spark_install(
-          version = test_spark_version,
-          hadoop_version = test_hadoop_version,
-          verbose = TRUE
-        ),
-        install_msg
+        removed <- spark_uninstall(test_version, test_hadoop),
+        "successfully uninstalled"
       )
+      expect_true(removed)
+      expect_false(dir.exists(file.path(install_dir, component)))
+    }
+  )
+})
 
-      expect_true(
-        file.exists(file.path(install_dir, test_folder))
-      )
-
-      error_msg <- sprintf(
-        "Spark %s for Hadoop %s or later already installed.",
-        test_spark_version,
-        test_hadoop_version
-      )
-
-      expect_message(
-        spark_install(
-          version = test_spark_version,
-          hadoop_version = test_hadoop_version,
-          verbose = TRUE
-        ),
-        error_msg
-      )
-
-      uninstall_msg <- sprintf(
-        "spark-%s-bin-hadoop%s successfully uninstalled.",
-        test_spark_version,
-        test_hadoop_version
-      )
-
-      expect_message(
-        spark_uninstall(
-          version = test_spark_version,
-          hadoop_version = test_hadoop_version
-        ),
-        uninstall_msg
-      )
-
-      expect_false(
-        file.exists(file.path(install_dir, test_folder))
+test_that("spark_install is verbose and detects an existing install", {
+  skip_on_windows()
+  withr::with_options(
+    list("spark.install.dir" = tempfile("verbose")),
+    {
+      with_mocked_bindings(
+        download_file = fake_spark_download,
+        .package = "sparklyr",
+        {
+          expect_message(
+            spark_install("3.4.4", "3", verbose = TRUE),
+            "Installing Spark"
+          )
+          expect_message(
+            spark_install("3.4.4", "3", verbose = TRUE),
+            "already installed"
+          )
+        }
       )
     }
   )
 })
 
+test_that("spark_install applies Windows-specific configuration", {
+  test_version <- "3.4.4"
+  test_hadoop <- "3"
+  component <- sprintf("spark-%s-bin-hadoop%s", test_version, test_hadoop)
 
-test_that("Finding invalid Spark version fails", {
-  skip_on_windows()
-  expect_warning(
-    spark_install_find(version = "1.1")
+  withr::with_options(
+    list("spark.install.dir" = tempfile("wininstall")),
+    {
+      install_dir <- spark_install_dir()
+      with_mocked_bindings(
+        os_is_windows = function() TRUE,
+        download_file = fake_spark_download,
+        .package = "sparklyr",
+        spark_install(test_version, test_hadoop, verbose = FALSE)
+      )
+
+      conf <- file.path(install_dir, component, "conf")
+      defaults <- readLines(file.path(conf, "spark-defaults.conf"))
+      expect_true(any(grepl("spark.local.dir", defaults)))
+      expect_true(any(grepl("spark.sql.warehouse.dir", defaults)))
+    }
   )
 })
 
+test_that("spark_install handles the log4j v1 template on Windows", {
+  withr::with_options(
+    list("spark.install.dir" = tempfile("v1install")),
+    {
+      install_dir <- spark_install_dir()
+      with_mocked_bindings(
+        os_is_windows = function() TRUE,
+        download_file = make_fake_download("v1"),
+        .package = "sparklyr",
+        spark_install("3.4.4", "3", verbose = FALSE)
+      )
+      conf <- file.path(install_dir, "spark-3.4.4-bin-hadoop3", "conf")
+      expect_true(file.exists(file.path(conf, "log4j.properties")))
+    }
+  )
+})
+
+test_that("spark_install retries from the archive when the primary fails", {
+  skip_on_windows()
+  component <- "spark-3.4.4-bin-hadoop3"
+  withr::with_options(
+    list("spark.install.dir" = tempfile("retry")),
+    {
+      install_dir <- spark_install_dir()
+      fake_info <- list(
+        sparkDir = install_dir,
+        packageLocalPath = file.path(install_dir, paste0(component, ".tgz")),
+        packageRemotePath = paste0(
+          "https://dlcdn.apache.org/spark/spark-3.4.4/",
+          component,
+          ".tgz"
+        ),
+        sparkVersionDir = file.path(install_dir, component),
+        sparkConfDir = file.path(install_dir, component, "conf"),
+        sparkVersion = "3.4.4",
+        hadoopVersion = "3",
+        installed = FALSE
+      )
+      attempts <- 0
+      retry_download <- function(url, destfile, ...) {
+        attempts <<- attempts + 1
+        if (grepl("dlcdn", url, fixed = TRUE)) {
+          return(1L) # primary mirror fails
+        }
+        fake_spark_download(url, destfile, ...) # archive succeeds
+      }
+
+      with_mocked_bindings(
+        spark_install_find = function(...) fake_info,
+        download_file = retry_download,
+        .package = "sparklyr",
+        expect_message(
+          spark_install("3.4.4", "3", verbose = TRUE),
+          "retrying from archive"
+        )
+      )
+      expect_equal(attempts, 2)
+      expect_true(dir.exists(file.path(install_dir, component)))
+    }
+  )
+})
+
+test_that("spark_install errors when the download cannot complete", {
+  component <- "spark-3.4.4-bin-hadoop3"
+  make_info <- function(install_dir) {
+    list(
+      sparkDir = install_dir,
+      packageLocalPath = file.path(install_dir, paste0(component, ".tgz")),
+      packageRemotePath = paste0(
+        "https://dlcdn.apache.org/spark/spark-3.4.4/",
+        component,
+        ".tgz"
+      ),
+      sparkVersionDir = file.path(install_dir, component),
+      sparkConfDir = file.path(install_dir, component, "conf"),
+      sparkVersion = "3.4.4",
+      hadoopVersion = "3",
+      installed = FALSE
+    )
+  }
+
+  withr::with_options(
+    list("spark.install.dir" = tempfile("dlerror")),
+    {
+      fake_info <- make_info(spark_install_dir())
+      # download_file throws -> stop(download_result$message)
+      with_mocked_bindings(
+        spark_install_find = function(...) fake_info,
+        download_file = function(...) stop("network is down"),
+        .package = "sparklyr",
+        expect_error(spark_install("3.4.4", "3"), "network is down")
+      )
+    }
+  )
+
+  withr::with_options(
+    list("spark.install.dir" = tempfile("dlstatus")),
+    {
+      fake_info <- make_info(spark_install_dir())
+      # download_file returns non-zero everywhere -> stopf() status message
+      with_mocked_bindings(
+        spark_install_find = function(...) fake_info,
+        download_file = function(...) 19L,
+        .package = "sparklyr",
+        expect_error(spark_install("3.4.4", "3"), "exited with status 19")
+      )
+    }
+  )
+})
+
+test_that("spark_install warns when configuration steps fail", {
+  skip_on_windows()
+  withr::with_options(
+    list("spark.install.dir" = tempfile("confwarn")),
+    {
+      warns <- with_mocked_bindings(
+        download_file = fake_spark_download,
+        spark_conf_log4j_set_value = function(...) stop("log4j"),
+        spark_hive_file_set_value = function(...) stop("hive"),
+        spark_conf_file_set_value = function(...) stop("defaults"),
+        .package = "sparklyr",
+        capture_warnings(spark_install("3.4.4", "3", verbose = FALSE))
+      )
+      expect_match(warns, "Failed to set logging settings", all = FALSE)
+      expect_match(warns, "Failed to apply custom hive", all = FALSE)
+      expect_match(warns, "Failed to set spark-defaults", all = FALSE)
+    }
+  )
+})
+
+test_that("spark_conf_log4j_set_value errors without a template and honors custom properties", {
+  conf <- tempfile("conf")
+  dir.create(conf)
+  info <- list(sparkConfDir = conf)
+
+  # no template present -> error
+  expect_error(
+    spark_conf_log4j_set_value(info),
+    "No log4j template file found"
+  )
+
+  # template present + explicit properties -> properties take precedence
+  writeLines(
+    "rootLogger.level=info",
+    file.path(conf, "log4j2.properties.template")
+  )
+  spark_conf_log4j_set_value(
+    info,
+    properties = list("custom.prop" = "custom.prop = value")
+  )
+  written <- readLines(file.path(conf, "log4j2.properties"))
+  expect_true(any(grepl("custom.prop = value", written)))
+})
 
 test_clear_cache()

--- a/tests/testthat/test-install_tools.R
+++ b/tests/testthat/test-install_tools.R
@@ -7,12 +7,17 @@ test_that("spark_install_sync copies the sparkinstall sources into place", {
   # separate destination working dir, so we never touch the real package files.
   proj <- withr::local_tempdir()
   sources <- c(
-    "R/install.R", "R/versions.R", "R/windows.R",
-    "inst/extdata/config.json", "inst/extdata/versions.json"
+    "R/install.R",
+    "R/versions.R",
+    "R/windows.R",
+    "inst/extdata/config.json",
+    "inst/extdata/versions.json"
   )
   dir.create(file.path(proj, "R"), recursive = TRUE)
   dir.create(file.path(proj, "inst", "extdata"), recursive = TRUE)
-  for (f in sources) writeLines("placeholder", file.path(proj, f))
+  for (f in sources) {
+    writeLines("placeholder", file.path(proj, f))
+  }
 
   dest <- withr::local_tempdir()
   withr::local_dir(dest)

--- a/tests/testthat/test-install_tools.R
+++ b/tests/testthat/test-install_tools.R
@@ -1,0 +1,30 @@
+skip_connection("install_tools")
+skip_on_livy()
+skip_on_arrow_devel()
+
+test_that("spark_install_sync copies the sparkinstall sources into place", {
+  # Build a fake spark-install project with the expected source files, and a
+  # separate destination working dir, so we never touch the real package files.
+  proj <- withr::local_tempdir()
+  sources <- c(
+    "R/install.R", "R/versions.R", "R/windows.R",
+    "inst/extdata/config.json", "inst/extdata/versions.json"
+  )
+  dir.create(file.path(proj, "R"), recursive = TRUE)
+  dir.create(file.path(proj, "inst", "extdata"), recursive = TRUE)
+  for (f in sources) writeLines("placeholder", file.path(proj, f))
+
+  dest <- withr::local_tempdir()
+  withr::local_dir(dest)
+  dir.create("R")
+  dir.create(file.path("inst", "extdata"), recursive = TRUE)
+
+  spark_install_sync(proj)
+
+  expect_true(file.exists(file.path(dest, "R", "install_spark.R")))
+  expect_true(file.exists(file.path(dest, "R", "install_spark_versions.R")))
+  expect_true(file.exists(file.path(dest, "R", "install_spark_windows.R")))
+  expect_true(file.exists(file.path(dest, "inst", "extdata", "versions.json")))
+})
+
+test_clear_cache()

--- a/tests/testthat/test-ml_evaluation.R
+++ b/tests/testthat/test-ml_evaluation.R
@@ -1,3 +1,20 @@
+# Connection-free: the clustering silhouette path errors on Spark < 2.3, which
+# CI can't exercise (Spark 3.5/4.1), so cover the guard by mocking the version.
+test_that("ml_evaluate(clustering) requires Spark 2.3+ for silhouette", {
+  fake_model <- structure(list(model = "<m>"), class = "ml_model_clustering")
+  with_mocked_bindings(
+    spark_connection = function(x, ...) {
+      structure(list(), class = "spark_connection")
+    },
+    spark_version = function(x) numeric_version("2.2.0"),
+    .package = "sparklyr",
+    expect_error(
+      ml_evaluate(fake_model, "<dataset>"),
+      "Silhouette is only available"
+    )
+  )
+})
+
 skip_connection("ml_evaluation")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-ml_feature_encoders.R
+++ b/tests/testthat/test-ml_feature_encoders.R
@@ -1,3 +1,300 @@
+# ---------------------------------------------------------------------------
+# Connection-free contract tests for the version-gated OneHotEncoder code.
+# These exercise branches CI can no longer run: the Spark < 3.0 single-column
+# OneHotEncoder path and the Spark 2.3-2.4 OneHotEncoderEstimator family. Rather
+# than a live cluster, we mock the JVM-facing layer (spark_pipeline_stage /
+# invoke / new_ml_*) and assert the exact sequence of calls the R code emits,
+# which pins the interop contract for this otherwise-frozen 2.x code. Each mock
+# force()s its piped input so the whole magrittr chain evaluates inner-to-outer.
+# ---------------------------------------------------------------------------
+capture_ml_calls <- function(expr, required = FALSE) {
+  calls <- list()
+  record <- function(entry) {
+    calls[[length(calls) + 1]] <<- entry
+    "<jobj>"
+  }
+  with_mocked_bindings(
+    spark_require_version = function(...) invisible(NULL),
+    is_required_spark = function(x, required_version) required,
+    spark_pipeline_stage = function(sc, class, ...) {
+      record(c(list(call = "spark_pipeline_stage", class = class), list(...)))
+    },
+    invoke = function(jobj, method, ...) {
+      force(jobj)
+      record(list(call = "invoke", method = method, args = list(...)))
+    },
+    new_ml_one_hot_encoder = function(jobj) {
+      force(jobj)
+      record(list(call = "new_ml_one_hot_encoder"))
+    },
+    new_ml_one_hot_encoder_estimator = function(jobj) {
+      force(jobj)
+      record(list(call = "new_ml_one_hot_encoder_estimator"))
+    },
+    .package = "sparklyr",
+    force(expr)
+  )
+  calls
+}
+
+ml_enc_fake_sc <- structure(list(), class = "spark_connection")
+
+test_that("ft_one_hot_encoder() (Spark < 3.0) builds a single-column OneHotEncoder", {
+  calls <- capture_ml_calls(
+    ft_one_hot_encoder(
+      ml_enc_fake_sc,
+      input_cols = "a",
+      output_cols = "x",
+      handle_invalid = "keep",
+      drop_last = FALSE,
+      uid = "ohe_1"
+    )
+  )
+  expect_equal(
+    calls,
+    list(
+      list(
+        call = "spark_pipeline_stage",
+        class = "org.apache.spark.ml.feature.OneHotEncoder",
+        input_col = "a",
+        output_col = "x",
+        uid = "ohe_1"
+      ),
+      list(call = "invoke", method = "setDropLast", args = list(FALSE)),
+      list(call = "new_ml_one_hot_encoder")
+    )
+  )
+})
+
+test_that("ft_one_hot_encoder() (Spark < 3.0) rejects multiple columns", {
+  expect_error(
+    capture_ml_calls(
+      ft_one_hot_encoder(
+        ml_enc_fake_sc,
+        input_cols = c("a", "b"),
+        output_cols = c("x", "y")
+      )
+    ),
+    "does not support encoding multiple columns"
+  )
+})
+
+test_that("ft_one_hot_encoder_estimator() builds an OneHotEncoderEstimator", {
+  calls <- capture_ml_calls(
+    ft_one_hot_encoder_estimator(
+      ml_enc_fake_sc,
+      input_cols = c("a", "b"),
+      output_cols = c("x", "y"),
+      handle_invalid = "keep",
+      drop_last = FALSE,
+      uid = "ohe_est_1"
+    )
+  )
+  expect_equal(
+    calls,
+    list(
+      list(
+        call = "spark_pipeline_stage",
+        class = "org.apache.spark.ml.feature.OneHotEncoderEstimator",
+        input_cols = list("a", "b"),
+        output_cols = list("x", "y"),
+        uid = "ohe_est_1"
+      ),
+      list(call = "invoke", method = "setHandleInvalid", args = list("keep")),
+      list(call = "invoke", method = "setDropLast", args = list(FALSE)),
+      list(call = "new_ml_one_hot_encoder_estimator")
+    )
+  )
+})
+
+test_that("new_ml_one_hot_encoder() wraps as a transformer on Spark < 3.0", {
+  with_mocked_bindings(
+    is_required_spark = function(x, required_version) FALSE,
+    new_ml_transformer = function(jobj, class) list(class = class),
+    .package = "sparklyr",
+    expect_equal(new_ml_one_hot_encoder("<jobj>")$class, "ml_one_hot_encoder")
+  )
+})
+
+test_that("new_ml_one_hot_encoder_estimator() wraps as an estimator", {
+  with_mocked_bindings(
+    new_ml_estimator = function(jobj, class) list(class = class),
+    .package = "sparklyr",
+    expect_equal(
+      new_ml_one_hot_encoder_estimator("<jobj>")$class,
+      "ml_one_hot_encoder_estimator"
+    )
+  )
+})
+
+test_that("new_ml_one_hot_encoder_estimator_model() reads category sizes", {
+  with_mocked_bindings(
+    invoke = function(jobj, method, ...) {
+      expect_equal(method, "categorySizes")
+      c(2L, 3L)
+    },
+    new_ml_transformer = function(jobj, category_sizes, class) {
+      list(category_sizes = category_sizes, class = class)
+    },
+    .package = "sparklyr",
+    {
+      res <- new_ml_one_hot_encoder_estimator_model("<jobj>")
+      expect_equal(res$category_sizes, c(2L, 3L))
+      expect_equal(res$class, "ml_one_hot_encoder_model")
+    }
+  )
+})
+
+# The .ml_pipeline / .tbl_spark methods are thin dispatchers that forward to the
+# .spark_connection method (called by name, so it is mockable) and then add the
+# stage / fit / transform. We capture the forwarded args to confirm the
+# Spark < 3.0 path drops `handle_invalid`, and that estimator vs transformer
+# stages route to fit-and-transform vs transform.
+ml_enc_fake_pipeline <- structure(list(), class = "ml_pipeline")
+ml_enc_fake_tbl <- structure(list(), class = "tbl_spark")
+
+test_that("ft_one_hot_encoder(ml_pipeline) (Spark < 3.0) drops handle_invalid", {
+  forwarded <- NULL
+  with_mocked_bindings(
+    spark_connection = function(x, ...) ml_enc_fake_sc,
+    is_required_spark = function(x, required_version) FALSE,
+    ft_one_hot_encoder.spark_connection = function(
+      x,
+      input_cols,
+      output_cols,
+      handle_invalid,
+      drop_last,
+      uid,
+      ...
+    ) {
+      forwarded <<- list(
+        input_cols = input_cols,
+        handle_invalid_missing = missing(handle_invalid)
+      )
+      "<stage>"
+    },
+    ml_add_stage = function(x, stage) list(stage = stage),
+    .package = "sparklyr",
+    {
+      res <- ft_one_hot_encoder(
+        ml_enc_fake_pipeline,
+        input_cols = "a",
+        output_cols = "x",
+        uid = "u"
+      )
+      expect_equal(res$stage, "<stage>")
+      expect_equal(forwarded$input_cols, "a")
+      expect_true(forwarded$handle_invalid_missing)
+    }
+  )
+})
+
+test_that("ft_one_hot_encoder(tbl_spark) (Spark < 3.0) transforms the data", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) ml_enc_fake_sc,
+    is_required_spark = function(x, required_version) FALSE,
+    ft_one_hot_encoder.spark_connection = function(x, ...) "<transformer>",
+    is_ml_transformer = function(x) TRUE,
+    ml_transform = function(stage, x) list(transformed = stage),
+    .package = "sparklyr",
+    {
+      res <- ft_one_hot_encoder(
+        ml_enc_fake_tbl,
+        input_cols = "a",
+        output_cols = "x"
+      )
+      expect_equal(res$transformed, "<transformer>")
+    }
+  )
+})
+
+test_that("ft_one_hot_encoder_estimator(ml_pipeline) adds the stage", {
+  forwarded <- NULL
+  with_mocked_bindings(
+    spark_connection = function(x, ...) ml_enc_fake_sc,
+    ft_one_hot_encoder_estimator.spark_connection = function(
+      x,
+      input_cols,
+      ...
+    ) {
+      forwarded <<- input_cols
+      "<stage>"
+    },
+    ml_add_stage = function(x, stage) list(stage = stage),
+    .package = "sparklyr",
+    {
+      res <- ft_one_hot_encoder_estimator(
+        ml_enc_fake_pipeline,
+        input_cols = "a",
+        output_cols = "x",
+        uid = "u"
+      )
+      expect_equal(res$stage, "<stage>")
+      expect_equal(forwarded, "a")
+    }
+  )
+})
+
+test_that("ft_one_hot_encoder_estimator(tbl_spark) fits and transforms", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) ml_enc_fake_sc,
+    ft_one_hot_encoder_estimator.spark_connection = function(x, ...) {
+      "<estimator>"
+    },
+    is_ml_transformer = function(x) FALSE,
+    ml_fit_and_transform = function(stage, x) list(fitted = stage),
+    .package = "sparklyr",
+    {
+      res <- ft_one_hot_encoder_estimator(
+        ml_enc_fake_tbl,
+        input_cols = "a",
+        output_cols = "x"
+      )
+      expect_equal(res$fitted, "<estimator>")
+    }
+  )
+})
+
+test_that("ft_one_hot_encoder_estimator(tbl_spark) transforms an already-fit stage", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) ml_enc_fake_sc,
+    ft_one_hot_encoder_estimator.spark_connection = function(x, ...) {
+      "<transformer>"
+    },
+    is_ml_transformer = function(x) TRUE,
+    ml_transform = function(stage, x) list(transformed = stage),
+    .package = "sparklyr",
+    {
+      res <- ft_one_hot_encoder_estimator(
+        ml_enc_fake_tbl,
+        input_cols = "a",
+        output_cols = "x"
+      )
+      expect_equal(res$transformed, "<transformer>")
+    }
+  )
+})
+
+test_that("new_ml_one_hot_encoder_model() reads category sizes (Spark 3.0+ model)", {
+  with_mocked_bindings(
+    spark_require_version = function(...) invisible(NULL),
+    spark_connection = function(x, ...) ml_enc_fake_sc,
+    invoke = function(jobj, method, ...) {
+      expect_equal(method, "categorySizes")
+      c(1L, 4L)
+    },
+    new_ml_transformer = function(jobj, category_sizes, class) {
+      list(category_sizes = category_sizes, class = class)
+    },
+    .package = "sparklyr",
+    {
+      res <- new_ml_one_hot_encoder_model("<jobj>")
+      expect_equal(res$category_sizes, c(1L, 4L))
+      expect_equal(res$class, "ml_one_hot_encoder_model")
+    }
+  )
+})
+
 skip_connection("ml_feature_encoders")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-ml_feature_lsh.R
+++ b/tests/testthat/test-ml_feature_lsh.R
@@ -181,4 +181,24 @@ test_that("ft_bucketed_random_projection_lsh() works properly", {
   )
 })
 
+test_that("ft_bucketed_random_projection_lsh() fits + transforms via tbl_spark", {
+  skip_databricks_connect()
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  hashed <- testthat_tbl("iris") %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features") %>%
+    ft_bucketed_random_projection_lsh("features", "hashes", bucket_length = 2)
+  expect_true("hashes" %in% colnames(hashed))
+})
+
+test_that("ft_minhash_lsh() fits + transforms via tbl_spark", {
+  skip_databricks_connect()
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  hashed <- testthat_tbl("iris") %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features") %>%
+    ft_minhash_lsh("features", "hashes", num_hash_tables = 1L)
+  expect_true("hashes" %in% colnames(hashed))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_feature_scalers.R
+++ b/tests/testthat/test-ml_feature_scalers.R
@@ -179,4 +179,48 @@ test_that("ft_standard_scaler() works properly", {
   )
 })
 
+test_that("ft_standard_scaler() works via the tbl_spark interface", {
+  skip_databricks_connect()
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  df <- data.frame(id = 0:2, V1 = c(1, 2, 4), V2 = c(0.1, 1, 10))
+  scaled <- sdf_copy_to(sc, df, overwrite = TRUE) %>%
+    ft_vector_assembler(c("V1", "V2"), "features") %>%
+    ft_standard_scaler("features", "scaled")
+  expect_true(inherits(scaled, "tbl_spark"))
+  expect_true("scaled" %in% colnames(scaled))
+})
+
+test_that("fitted scaler models carry their typed model classes", {
+  skip_databricks_connect()
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  df <- data.frame(id = 0:2, V1 = c(1, 2, 4), V2 = c(0.1, 1, 10))
+  tbl <- sdf_copy_to(sc, df, overwrite = TRUE) %>%
+    ft_vector_assembler(c("V1", "V2"), "features")
+
+  expect_s3_class(
+    ml_fit(ft_min_max_scaler(sc, "features", "s"), tbl),
+    "ml_min_max_scaler_model"
+  )
+  expect_s3_class(
+    ml_fit(ft_max_abs_scaler(sc, "features", "s"), tbl),
+    "ml_max_abs_scaler_model"
+  )
+  # RobustScaler was missing from class_mapping.json; this asserts the fix so a
+  # fitted robust model is typed (not a generic ml_transformer).
+  expect_s3_class(
+    ml_fit(ft_robust_scaler(sc, "features", "s"), tbl),
+    "ml_robust_scaler_model"
+  )
+})
+
+test_that("ft_robust_scaler() adds a stage to an ml_pipeline", {
+  skip_databricks_connect()
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  pipeline <- ml_pipeline(sc) %>% ft_robust_scaler("features", "scaled")
+  expect_true(inherits(pipeline, "ml_pipeline"))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_feature_selectors.R
+++ b/tests/testthat/test-ml_feature_selectors.R
@@ -1,3 +1,21 @@
+# Connection-free: the weighted-quantile-discretizer Spark < 3.0 guard can't run
+# live on CI (Spark 3.5/4.1), so cover it by mocking the version check.
+test_that("ft_quantile_discretizer() rejects weight_column on Spark < 3.0", {
+  with_mocked_bindings(
+    spark_version = function(x) numeric_version("2.4.0"),
+    .package = "sparklyr",
+    expect_error(
+      ft_quantile_discretizer.spark_connection(
+        structure(list(), class = "spark_connection"),
+        input_col = "x",
+        output_col = "y",
+        weight_column = "w"
+      ),
+      "only supported in Spark 3.0"
+    )
+  )
+})
+
 skip_connection("ml_feature_selectors")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-ml_feature_sql.R
+++ b/tests/testthat/test-ml_feature_sql.R
@@ -303,4 +303,43 @@ test_that("ft_sql_transformer() works", {
   )
 })
 
+test_that("ft_r_formula fits an RFormula model", {
+  skip_on_arrow_devel()
+  sc <- testthat_spark_connection()
+  iris_tbl <- testthat_tbl("iris")
+
+  est <- ft_r_formula(sc, "Sepal_Length ~ Petal_Width")
+  model <- ml_fit(est, iris_tbl)
+  expect_s3_class(model, "ml_r_formula_model")
+  expect_true(inherits(ml_transform(model, iris_tbl), "tbl_spark"))
+})
+
+test_that("ft_dplyr_transformer rejects non-Spark tables and supports pipelines", {
+  sc <- testthat_spark_connection()
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    ft_dplyr_transformer(sc, tbl = data.frame(a = 1)),
+    "'tbl' must be a Spark table"
+  )
+
+  transformed <- iris_tbl %>% dplyr::mutate(pw2 = Petal_Width * 2)
+  pipe <- ml_pipeline(sc) %>% ft_dplyr_transformer(transformed)
+  expect_s3_class(pipe, "ml_pipeline")
+})
+
+test_that("ft_dplyr_transformer handles nested dplyr queries", {
+  sc <- testthat_spark_connection()
+  iris_tbl <- testthat_tbl("iris")
+
+  # filtering on a freshly-computed column can't collapse into one SELECT, so
+  # dbplyr nests the query, exercising get_base_name()'s recursion
+  transformed <- iris_tbl %>%
+    dplyr::mutate(pw2 = Petal_Width * 2) %>%
+    dplyr::filter(pw2 > 1)
+
+  stmt <- ft_dplyr_transformer(sc, transformed) %>% ml_param("statement")
+  expect_true(grepl("__THIS__", stmt))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_feature_string_indexer.R
+++ b/tests/testthat/test-ml_feature_string_indexer.R
@@ -115,4 +115,16 @@ test_that("ft_string_indexer_model works", {
   )
 })
 
+test_that("ft_string_indexer_model(ml_pipeline) appends the stage", {
+  sc <- testthat_spark_connection()
+  pipeline <- ml_pipeline(sc) %>%
+    ft_string_indexer_model("string", "indexed", labels = c("foo", "bar"))
+
+  expect_true(inherits(pipeline, "ml_pipeline"))
+  expect_identical(
+    ml_stage(pipeline, 1) %>% ml_param("input_col"),
+    "string"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_fpm.R
+++ b/tests/testthat/test-ml_fpm.R
@@ -76,7 +76,9 @@ test_that("ml_prefixspan() works as expected", {
     max_pattern_length = 5,
     max_local_proj_db_size = 32000000
   )
-  res <- prefix_span_model$frequent_sequential_patterns(sdf) %>%
+  # go through the exported ml_freq_seq_patterns() accessor (returns the
+  # frequent_sequential_patterns closure) rather than reaching into the model
+  res <- ml_freq_seq_patterns(prefix_span_model)(sdf) %>%
     collect()
 
   expect_equal(nrow(res), 5)

--- a/tests/testthat/test-ml_gbt.R
+++ b/tests/testthat/test-ml_gbt.R
@@ -1,3 +1,35 @@
+# Connection-free: the Spark < 2.2 GBTClassifier stage build (which omits the
+# probability/raw-prediction columns) can't run on CI (Spark 3.5/4.1). Mock the
+# version check + the JVM layer and confirm the reduced stage is built.
+test_that("ml_gbt_classifier() builds the Spark < 2.2 stage without probability cols", {
+  captured <- NULL
+  with_mocked_bindings(
+    spark_version = function(x) numeric_version("2.1.0"),
+    spark_pipeline_stage = function(sc, class, uid, ...) {
+      captured <<- list(class = class, params = list(...))
+      "<stage>"
+    },
+    jobj_set_param_helper = function(...) NULL,
+    invoke = function(jobj, method, ...) "<jobj>",
+    new_ml_gbt_classifier = function(jobj) "<model>",
+    .package = "sparklyr",
+    {
+      res <- ml_gbt_classifier(
+        structure(list(), class = "spark_connection"),
+        uid = "gbt_1"
+      )
+      expect_equal(res, "<model>")
+    }
+  )
+  expect_equal(
+    captured$class,
+    "org.apache.spark.ml.classification.GBTClassifier"
+  )
+  # the < 2.2 branch omits probability_col / raw_prediction_col
+  expect_true("prediction_col" %in% names(captured$params))
+  expect_false("probability_col" %in% names(captured$params))
+})
+
 skip_connection("ml_gbt")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-ml_gbt.R
+++ b/tests/testthat/test-ml_gbt.R
@@ -290,4 +290,68 @@ test_that("ml_gradient_boosted_trees() supports response-features syntax", {
   )
 })
 
+test_that("ml_gbt_classifier() fits without a formula and exposes trees()", {
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  binlab <- testthat_tbl("iris") %>%
+    dplyr::mutate(label = ifelse(Species == "setosa", 1, 0)) %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  m <- ml_gbt_classifier(binlab, features_col = "features", label_col = "label")
+  expect_s3_class(m, "ml_gbt_classification_model")
+  expect_gt(length(m$trees()), 0)
+})
+
+test_that("ml_gbt_regressor() model exposes trees()", {
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  feat <- testthat_tbl("iris") %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  m <- ml_fit(
+    ml_gbt_regressor(sc, features_col = "features", label_col = "Sepal_Length"),
+    feat
+  )
+  expect_gt(length(m$trees()), 0)
+})
+
+test_that("ml_gradient_boosted_trees() auto-detects classification + validates loss_type", {
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  tbl <- testthat_tbl("iris") %>%
+    dplyr::mutate(lab = ifelse(Species == "setosa", "yes", "no"))
+  # a string response triggers the auto classification branch
+  m <- ml_gradient_boosted_trees(tbl, lab ~ Petal_Length + Petal_Width)
+  expect_s3_class(m, "ml_model_gbt_classification")
+
+  expect_error(
+    ml_gradient_boosted_trees(
+      tbl, Sepal_Length ~ Petal_Length,
+      type = "regression", loss_type = "logistic"
+    ),
+    "squared"
+  )
+  expect_error(
+    ml_gradient_boosted_trees(
+      tbl, lab ~ Petal_Length,
+      type = "classification", loss_type = "squared"
+    ),
+    "logistic"
+  )
+
+  # valid explicit loss_type passthroughs (not the "auto" default)
+  expect_s3_class(
+    ml_gradient_boosted_trees(
+      tbl, Sepal_Length ~ Petal_Length,
+      type = "regression", loss_type = "absolute"
+    ),
+    "ml_model_gbt_regression"
+  )
+  expect_s3_class(
+    ml_gradient_boosted_trees(
+      tbl, lab ~ Petal_Length,
+      type = "classification", loss_type = "logistic"
+    ),
+    "ml_model_gbt_classification"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_gbt.R
+++ b/tests/testthat/test-ml_gbt.R
@@ -329,15 +329,19 @@ test_that("ml_gradient_boosted_trees() auto-detects classification + validates l
 
   expect_error(
     ml_gradient_boosted_trees(
-      tbl, Sepal_Length ~ Petal_Length,
-      type = "regression", loss_type = "logistic"
+      tbl,
+      Sepal_Length ~ Petal_Length,
+      type = "regression",
+      loss_type = "logistic"
     ),
     "squared"
   )
   expect_error(
     ml_gradient_boosted_trees(
-      tbl, lab ~ Petal_Length,
-      type = "classification", loss_type = "squared"
+      tbl,
+      lab ~ Petal_Length,
+      type = "classification",
+      loss_type = "squared"
     ),
     "logistic"
   )
@@ -345,15 +349,19 @@ test_that("ml_gradient_boosted_trees() auto-detects classification + validates l
   # valid explicit loss_type passthroughs (not the "auto" default)
   expect_s3_class(
     ml_gradient_boosted_trees(
-      tbl, Sepal_Length ~ Petal_Length,
-      type = "regression", loss_type = "absolute"
+      tbl,
+      Sepal_Length ~ Petal_Length,
+      type = "regression",
+      loss_type = "absolute"
     ),
     "ml_model_gbt_regression"
   )
   expect_s3_class(
     ml_gradient_boosted_trees(
-      tbl, lab ~ Petal_Length,
-      type = "classification", loss_type = "logistic"
+      tbl,
+      lab ~ Petal_Length,
+      type = "classification",
+      loss_type = "logistic"
     ),
     "ml_model_gbt_classification"
   )

--- a/tests/testthat/test-ml_gbt.R
+++ b/tests/testthat/test-ml_gbt.R
@@ -297,6 +297,11 @@ test_that("ml_gbt_classifier() fits without a formula and exposes trees()", {
     dplyr::mutate(label = ifelse(Species == "setosa", 1, 0)) %>%
     ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
   m <- ml_gbt_classifier(binlab, features_col = "features", label_col = "label")
+  # NB: on the CI Spark matrix (>= 3.0) this exercises the `>= 2.2.0` branch of
+  # new_ml_gbt_classification_model(), which always had the correct class. The
+  # copy-paste fix was in the `< 2.2.0` branch, which cannot run here (Spark
+  # < 2.2 is not in the test matrix) -- so this guards the class label on the
+  # reachable branch only.
   expect_s3_class(m, "ml_gbt_classification_model")
   expect_gt(length(m$trees()), 0)
 })

--- a/tests/testthat/test-ml_kmeans.R
+++ b/tests/testthat/test-ml_kmeans.R
@@ -158,4 +158,25 @@ test_that("ml_compute_silhouette_measure() for kmeans", {
   )
 })
 
+test_that("ml_kmeans() fits without a formula (tbl_spark estimator path)", {
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  m <- testthat_tbl("iris") %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features") %>%
+    ml_kmeans(k = 2)
+  expect_s3_class(m, "ml_kmeans_model")
+})
+
+test_that("print.ml_model_kmeans prints the cluster summary", {
+  test_requires_version("3.0.0")
+  sc <- testthat_spark_connection()
+  m <- ml_kmeans(
+    testthat_tbl("iris"),
+    Species ~ Petal_Length + Petal_Width,
+    k = 2
+  )
+  out <- capture.output(print(m))
+  expect_true(any(grepl("K-means clustering", out)))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_linear_svc.R
+++ b/tests/testthat/test-ml_linear_svc.R
@@ -51,4 +51,49 @@ test_that("ml_linear_svc() runs", {
   )
 })
 
+test_that("ml_linear_svc() warns and ignores weight_col on Spark 3.0+", {
+  test_requires_version("3.0.0")
+  test_requires("dplyr")
+  sc <- testthat_spark_connection()
+  iris_tbl2 <- testthat_tbl("iris") %>%
+    mutate(is_versicolor = ifelse(Species == "versicolor", 1, 0)) %>%
+    select(-Species)
+
+  expect_warning(
+    ml_linear_svc(iris_tbl2, is_versicolor ~ ., weight_col = "Sepal_Length"),
+    "weight_col"
+  )
+})
+
+test_that("ml_linear_svc() fits a transformer when no formula is given", {
+  test_requires_version("2.2.0")
+  test_requires("dplyr")
+  sc <- testthat_spark_connection()
+  prepped <- testthat_tbl("iris") %>%
+    mutate(label = ifelse(Species == "versicolor", 1, 0)) %>%
+    ft_vector_assembler(
+      c("Sepal_Length", "Sepal_Width", "Petal_Length", "Petal_Width"),
+      "features"
+    )
+
+  # no formula -> the estimator is fit directly via ml_fit()
+  model <- ml_linear_svc(prepped)
+  expect_true(inherits(model, "ml_linear_svc_model"))
+})
+
+test_that("print.ml_model_linear_svc shows the formula and coefficients", {
+  test_requires_version("2.2.0")
+  test_requires("dplyr")
+  sc <- testthat_spark_connection()
+  iris_tbl2 <- testthat_tbl("iris") %>%
+    mutate(
+      is_versicolor = ifelse(Species == "versicolor", "versicolor", "other")
+    ) %>%
+    select(-Species)
+
+  model <- ml_linear_svc(iris_tbl2, is_versicolor ~ .)
+  expect_output(print(model), "Coefficients")
+  expect_output(print(model), "Formula")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_mapping_tables.R
+++ b/tests/testthat/test-ml_mapping_tables.R
@@ -1,0 +1,32 @@
+skip_connection("ml_mapping_tables")
+skip_on_livy()
+skip_on_arrow_devel()
+
+test_that("register_mapping_tables populates the genv class/param mappings", {
+  register_mapping_tables()
+
+  expect_true(is.environment(genv_get_param_mapping_r_to_s()))
+  expect_true(is.environment(genv_get_param_mapping_s_to_r()))
+  expect_true(is.environment(genv_get_ml_class_mapping()))
+  expect_true(is.environment(genv_get_ml_package_mapping()))
+
+  # base class_mapping.json entries are loaded and resolve sparklyr's package
+  class_mapping <- as.list(genv_get_ml_class_mapping())
+  expect_equal(
+    class_mapping[["org.apache.spark.ml.feature.StandardScaler"]],
+    "ml_standard_scaler"
+  )
+  pkg_mapping <- as.list(genv_get_ml_package_mapping())
+  expect_equal(
+    pkg_mapping[["org.apache.spark.ml.feature.StandardScaler"]],
+    "sparklyr"
+  )
+
+  # param_mapping round-trips R <-> Spark names
+  r_to_s <- as.list(genv_get_param_mapping_r_to_s())
+  s_to_r <- as.list(genv_get_param_mapping_s_to_r())
+  expect_true(length(r_to_s) > 0)
+  expect_true(length(s_to_r) > 0)
+})
+
+test_clear_cache()

--- a/tests/testthat/test-ml_model_constructors.R
+++ b/tests/testthat/test-ml_model_constructors.R
@@ -1,0 +1,50 @@
+skip_connection("ml_model_constructors")
+skip_on_livy()
+skip_on_arrow_devel()
+
+sc <- testthat_spark_connection()
+
+test_that("supervised regression model: construct, print, spark_jobj", {
+  test_requires_version("3.0.0")
+  m <- testthat_tbl("iris") %>%
+    ml_gbt_regressor(Sepal_Length ~ Petal_Length + Petal_Width)
+  expect_s3_class(m, "ml_model_regression")
+  expect_s3_class(spark_jobj(m), "spark_jobj")
+  expect_match(paste(capture.output(print(m)), collapse = " "), "Formula")
+})
+
+test_that("classification model is constructed (with label metadata)", {
+  test_requires_version("3.0.0")
+  bin <- testthat_tbl("iris") %>%
+    dplyr::mutate(lab = ifelse(Species == "setosa", "y", "n"))
+  m <- bin %>% ml_gbt_classifier(lab ~ Petal_Length + Petal_Width)
+  expect_s3_class(m, "ml_model_classification")
+})
+
+test_that("clustering model is constructed", {
+  test_requires_version("3.0.0")
+  m <- ml_kmeans(
+    testthat_tbl("iris"),
+    Species ~ Petal_Length + Petal_Width,
+    k = 2
+  )
+  expect_s3_class(m, "ml_model_clustering")
+})
+
+test_that("recommendation model (ALS) is constructed", {
+  test_requires_version("3.0.0")
+  ratings <- sdf_copy_to(
+    sc,
+    data.frame(
+      user = c(0L, 0L, 1L, 1L),
+      item = c(0L, 1L, 0L, 1L),
+      rating = c(4, 2, 3, 5)
+    ),
+    "mmc_rat",
+    overwrite = TRUE
+  )
+  m <- ml_als(ratings, rating ~ user + item)
+  expect_s3_class(m, "ml_model_recommendation")
+})
+
+test_clear_cache()

--- a/tests/testthat/test-ml_multilayer_perceptron.R
+++ b/tests/testthat/test-ml_multilayer_perceptron.R
@@ -1,3 +1,334 @@
+# ---------------------------------------------------------------------------
+# Connection-free contract tests. The live tests below are version-capped at
+# Spark <= 3.3, so they never run on CI's Spark 3.5/4.1 -- this file would be 0%
+# without these. We mock the JVM-facing layer (spark_pipeline_stage / invoke /
+# jobj_set_param / new_ml_*) and assert the calls the R code emits, covering the
+# construction chain, the version-gated constructors, and the dispatchers without
+# a live MLP fit. Placed ABOVE the top-level test_requires_version() gate so they
+# always run. (force(jobj) in each mock keeps the lazy magrittr chain in order.)
+# ---------------------------------------------------------------------------
+mlp_fake_sc <- structure(list(), class = "spark_connection")
+
+capture_mlp_calls <- function(expr) {
+  calls <- list()
+  rec <- function(e) {
+    calls[[length(calls) + 1]] <<- e
+    "<jobj>"
+  }
+  with_mocked_bindings(
+    spark_pipeline_stage = function(sc, class, uid, ...) {
+      rec(list(
+        call = "spark_pipeline_stage",
+        class = class,
+        uid = uid,
+        params = list(...)
+      ))
+    },
+    jobj_set_param = function(jobj, setter, ...) {
+      force(jobj)
+      rec(list(call = setter))
+    },
+    invoke = function(jobj, method, ...) {
+      force(jobj)
+      rec(list(call = method))
+    },
+    invoke_static = function(sc, class, method, ...) rec(list(call = method)),
+    spark_version = function(x) numeric_version("3.5.0"),
+    spark_connection = function(x, ...) mlp_fake_sc,
+    new_ml_multilayer_perceptron_classifier = function(jobj) {
+      force(jobj)
+      rec(list(call = "new_ml_multilayer_perceptron_classifier"))
+    },
+    .package = "sparklyr",
+    force(expr)
+  )
+  calls
+}
+
+test_that("ml_multilayer_perceptron_classifier() builds the classifier stage", {
+  calls <- capture_mlp_calls(
+    ml_multilayer_perceptron_classifier(
+      mlp_fake_sc,
+      layers = c(4, 3),
+      max_iter = 50L,
+      step_size = 0.01,
+      tol = 1e-5,
+      block_size = 256L,
+      solver = "gd",
+      seed = 42L,
+      uid = "mlp_1"
+    )
+  )
+
+  expect_equal(
+    vapply(calls, `[[`, character(1), "call"),
+    c(
+      "spark_pipeline_stage",
+      "setLayers",
+      "setMaxIter",
+      "setStepSize",
+      "setTol",
+      "setBlockSize",
+      "setSolver",
+      "setSeed",
+      "setThresholds",
+      "setProbabilityCol",
+      "setRawPredictionCol",
+      "new_ml_multilayer_perceptron_classifier"
+    )
+  )
+  stage <- calls[[1]]
+  expect_equal(
+    stage$class,
+    "org.apache.spark.ml.classification.MultilayerPerceptronClassifier"
+  )
+  expect_equal(stage$uid, "mlp_1")
+  expect_equal(
+    stage$params,
+    list(
+      features_col = "features",
+      label_col = "label",
+      prediction_col = "prediction"
+    )
+  )
+})
+
+test_that("ml_multilayer_perceptron_classifier() sets initial weights when given", {
+  calls <- capture_mlp_calls(
+    ml_multilayer_perceptron_classifier(
+      mlp_fake_sc,
+      layers = c(4, 3),
+      initial_weights = 1:5,
+      uid = "mlp_2"
+    )
+  )
+  expect_true(
+    "setInitialWeights" %in% vapply(calls, `[[`, character(1), "call")
+  )
+})
+
+test_that("new_ml_multilayer_perceptron_classifier() picks class by Spark version", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    spark_version = function(x) numeric_version("3.5.0"),
+    new_ml_probabilistic_classifier = function(jobj, class) {
+      list(kind = "prob", class = class)
+    },
+    new_ml_predictor = function(jobj, class) list(kind = "pred"),
+    .package = "sparklyr",
+    {
+      res <- new_ml_multilayer_perceptron_classifier("<jobj>")
+      expect_equal(res$kind, "prob")
+      expect_equal(res$class, "ml_multilayer_perceptron_classifier")
+    }
+  )
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    spark_version = function(x) numeric_version("2.2.0"),
+    new_ml_probabilistic_classifier = function(jobj, class) list(kind = "prob"),
+    new_ml_predictor = function(jobj, class) list(kind = "pred"),
+    .package = "sparklyr",
+    expect_equal(new_ml_multilayer_perceptron_classifier("<jobj>")$kind, "pred")
+  )
+})
+
+test_that("new_ml_..._classification_model() wraps a probabilistic model (>= 2.3)", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    spark_version = function(x) numeric_version("3.5.0"),
+    invoke = function(jobj, method, ...) {
+      if (method == "layers") c(4L, 10L, 3L) else NULL
+    },
+    read_spark_vector = function(jobj, name) c(0.1, 0.2),
+    new_ml_probabilistic_classification_model = function(
+      jobj,
+      weights,
+      layers,
+      class
+    ) {
+      list(layers = layers, weights = weights, class = class)
+    },
+    .package = "sparklyr",
+    {
+      res <- new_ml_multilayer_perceptron_classification_model("<jobj>")
+      expect_equal(res$layers, c(4L, 10L, 3L))
+      expect_equal(res$class, "ml_multilayer_perceptron_classification_model")
+    }
+  )
+})
+
+test_that("new_ml_..._classification_model() resolves jobj-wrapped layers", {
+  resolved <- FALSE
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    spark_version = function(x) numeric_version("3.5.0"),
+    invoke = function(jobj, method, ...) {
+      if (method == "layers") {
+        structure(list(), class = "spark_jobj")
+      } else if (method == "%>%") {
+        resolved <<- TRUE
+        c(4L, 3L)
+      } else {
+        NULL
+      }
+    },
+    read_spark_vector = function(jobj, name) c(0.1),
+    new_ml_probabilistic_classification_model = function(
+      jobj,
+      weights,
+      layers,
+      class
+    ) {
+      list(layers = layers)
+    },
+    .package = "sparklyr",
+    {
+      res <- new_ml_multilayer_perceptron_classification_model("<jobj>")
+      expect_true(resolved)
+      expect_equal(res$layers, c(4L, 3L))
+    }
+  )
+})
+
+test_that("new_ml_..._classification_model() builds a prediction model (< 2.3)", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    spark_version = function(x) numeric_version("2.2.0"),
+    invoke = function(jobj, method, ...) {
+      if (method == "layers") c(4L, 3L) else NULL
+    },
+    read_spark_vector = function(jobj, name) c(0.1, 0.2),
+    new_ml_prediction_model = function(jobj, layers, weights, class) {
+      list(layers = layers, class = class)
+    },
+    .package = "sparklyr",
+    {
+      res <- new_ml_multilayer_perceptron_classification_model("<jobj>")
+      expect_equal(res$layers, c(4L, 3L))
+      expect_equal(res$class, "ml_multilayer_perceptron_classification_model")
+    }
+  )
+})
+
+test_that("ml_multilayer_perceptron_classifier(ml_pipeline) adds the stage", {
+  forwarded <- NULL
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    ml_multilayer_perceptron_classifier.spark_connection = function(
+      x,
+      layers,
+      ...
+    ) {
+      forwarded <<- layers
+      "<stage>"
+    },
+    ml_add_stage = function(x, stage) list(stage = stage),
+    .package = "sparklyr",
+    {
+      res <- ml_multilayer_perceptron_classifier(
+        structure(list(), class = "ml_pipeline"),
+        layers = c(4, 3),
+        uid = "u"
+      )
+      expect_equal(res$stage, "<stage>")
+      expect_equal(forwarded, c(4, 3))
+    }
+  )
+})
+
+test_that("ml_multilayer_perceptron_classifier(tbl_spark) fits or builds a model", {
+  # no formula -> ml_fit()
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    ml_standardize_formula = function(formula, response, features) NULL,
+    ml_multilayer_perceptron_classifier.spark_connection = function(x, ...) {
+      "<stage>"
+    },
+    ml_fit = function(stage, x) list(fitted = stage),
+    .package = "sparklyr",
+    {
+      res <- ml_multilayer_perceptron_classifier(
+        structure(list(), class = "tbl_spark"),
+        layers = c(4, 3)
+      )
+      expect_equal(res$fitted, "<stage>")
+    }
+  )
+  # formula -> ml_construct_model_supervised()
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    ml_standardize_formula = function(formula, response, features) {
+      "Species ~ ."
+    },
+    ml_multilayer_perceptron_classifier.spark_connection = function(x, ...) {
+      "<stage>"
+    },
+    ml_construct_model_supervised = function(
+      constructor,
+      predictor,
+      formula,
+      ...
+    ) {
+      list(model = predictor, formula = formula)
+    },
+    .package = "sparklyr",
+    {
+      res <- ml_multilayer_perceptron_classifier(
+        structure(list(), class = "tbl_spark"),
+        formula = "Species ~ .",
+        layers = c(4, 3)
+      )
+      expect_equal(res$model, "<stage>")
+    }
+  )
+})
+
+test_that("ml_multilayer_perceptron() is a deprecated alias", {
+  with_mocked_bindings(
+    spark_connection = function(x, ...) mlp_fake_sc,
+    ml_multilayer_perceptron_classifier.spark_connection = function(x, ...) {
+      "<stage>"
+    },
+    ml_add_stage = function(x, stage) "<pipeline>",
+    .package = "sparklyr",
+    expect_warning(
+      ml_multilayer_perceptron(
+        structure(list(), class = "ml_pipeline"),
+        layers = c(4, 3)
+      ),
+      "deprecated"
+    )
+  )
+})
+
+test_that("new_ml_model_multilayer_perceptron_classification() forwards to constructor", {
+  with_mocked_bindings(
+    new_ml_model_classification = function(
+      pipeline_model,
+      formula,
+      dataset,
+      label_col,
+      features_col,
+      predicted_label_col,
+      class
+    ) {
+      list(class = class)
+    },
+    .package = "sparklyr",
+    {
+      res <- new_ml_model_multilayer_perceptron_classification(
+        "<pm>",
+        "f",
+        "ds",
+        "label",
+        "features",
+        "pred"
+      )
+      expect_equal(res$class, "ml_model_multilayer_perceptron_classification")
+    }
+  )
+})
+
 test_requires_version(min_version = "2.4", max_version = "3.3")
 
 skip_connection("ml_multilayer_perceptron")

--- a/tests/testthat/test-ml_persistence.R
+++ b/tests/testthat/test-ml_persistence.R
@@ -246,4 +246,22 @@ test_that("we can fit a pipeline saved then loaded from ml_model", {
   )
 })
 
+test_that("ml_save.default overwrites an existing path", {
+  bin <- ft_binarizer(sc, "in", "out", threshold = 0.5)
+  path <- tempfile("ftbin_ow")
+  ml_save(bin, path)
+  expect_message(
+    ml_save(bin, path, overwrite = TRUE),
+    "successfully saved"
+  )
+  reloaded <- ml_load(sc, path)
+  expect_equal(ml_param_map(bin), ml_param_map(reloaded))
+})
+
+test_that("ml_load errors when metadata cannot be read", {
+  dir <- tempfile("empty_ml_")
+  dir.create(dir)
+  expect_error(ml_load(sc, dir), "ML could not be loaded")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_pipeline.R
+++ b/tests/testthat/test-ml_pipeline.R
@@ -228,4 +228,17 @@ test_that("ml_transform take list of transformers (#1444)", {
   expect_equal(transformed1, transformed2)
 })
 
+test_that("pipeline printing, column metadata, and stage-adding", {
+  iris_tbl <- testthat_tbl("iris")
+  expect_gt(length(capture.output(print(ml_pipeline(sc)))), 0)
+
+  feat <- iris_tbl %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  expect_false(is.null(ml_column_metadata(feat, "features")))
+
+  p <- ml_pipeline(sc) %>%
+    ml_add_stage(ft_binarizer(sc, "Petal_Length", "b", threshold = 2))
+  expect_s3_class(p, "ml_pipeline")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_power_iteration.R
+++ b/tests/testthat/test-ml_power_iteration.R
@@ -1,3 +1,16 @@
+# Connection-free: the Spark < 2.4 guard can't run live (CI is on 3.5/4.1), so
+# cover it by mocking the version check.
+test_that("ml_power_iteration() requires Spark 2.4+", {
+  with_mocked_bindings(
+    spark_version = function(x) numeric_version("2.2.0"),
+    .package = "sparklyr",
+    expect_error(
+      ml_power_iteration(structure(list(), class = "spark_connection")),
+      "only supported in Spark 2.4"
+    )
+  )
+})
+
 skip_connection("ml_power_iteration")
 skip_on_livy()
 skip_on_arrow_devel()

--- a/tests/testthat/test-ml_print_utils.R
+++ b/tests/testthat/test-ml_print_utils.R
@@ -11,4 +11,26 @@ test_that("input_cols print correctly", {
   )
 })
 
+test_that("ml_print helpers render estimators, model summaries, and transformers", {
+  sc <- testthat_spark_connection()
+  iris_tbl <- testthat_tbl("iris")
+
+  # estimator -> class + (column) params
+  expect_true(any(grepl("Parameters", capture.output(print(ml_kmeans(sc, k = 2))))))
+
+  # regression model summary -> residuals + detailed coefficients
+  m <- iris_tbl %>%
+    ml_linear_regression(Sepal_Length ~ Petal_Length + Petal_Width)
+  out <- capture.output(summary(m))
+  expect_true(any(grepl("Residuals|Coefficients", out)))
+
+  # transformer info section
+  tm <- ml_fit(
+    ft_standard_scaler(sc, "f", "s"),
+    iris_tbl %>% ft_vector_assembler("Petal_Length", "f")
+  )
+  expect_gt(length(capture.output(print(tm))), 0)
+})
+
 test_clear_cache()
+

--- a/tests/testthat/test-ml_print_utils.R
+++ b/tests/testthat/test-ml_print_utils.R
@@ -33,4 +33,3 @@ test_that("ml_print helpers render estimators, model summaries, and transformers
 })
 
 test_clear_cache()
-

--- a/tests/testthat/test-ml_print_utils.R
+++ b/tests/testthat/test-ml_print_utils.R
@@ -16,7 +16,10 @@ test_that("ml_print helpers render estimators, model summaries, and transformers
   iris_tbl <- testthat_tbl("iris")
 
   # estimator -> class + (column) params
-  expect_true(any(grepl("Parameters", capture.output(print(ml_kmeans(sc, k = 2))))))
+  expect_true(any(grepl(
+    "Parameters",
+    capture.output(print(ml_kmeans(sc, k = 2)))
+  )))
 
   # regression model summary -> residuals + detailed coefficients
   m <- iris_tbl %>%

--- a/tests/testthat/test-ml_stat.R
+++ b/tests/testthat/test-ml_stat.R
@@ -84,4 +84,35 @@ test_that("ml_corr() errors on bad column specification", {
   )
 })
 
+test_that("ml_corr single-column guard + ml_chisquare_test input variants", {
+  iris_tbl <- testthat_tbl("iris")
+  # a single column must be a vector column
+  expect_error(
+    ml_corr(iris_tbl, columns = "Petal_Length"),
+    "must be a column of Vectors"
+  )
+  expect_s3_class(
+    ml_corr(iris_tbl, columns = c("Petal_Length", "Petal_Width")),
+    "data.frame"
+  )
+
+  # assembled features + numeric label
+  feat <- iris_tbl %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features") %>%
+    dplyr::mutate(lbl = as.numeric(Petal_Length > 2))
+  expect_s3_class(
+    ml_chisquare_test(feat, features = "features", label = "lbl"),
+    "data.frame"
+  )
+  # non-assembled features + string label (string-indexed + r_formula path)
+  expect_s3_class(
+    ml_chisquare_test(
+      iris_tbl,
+      features = c("Petal_Length", "Petal_Width"),
+      label = "Species"
+    ),
+    "data.frame"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_transformer.R
+++ b/tests/testthat/test-ml_transformer.R
@@ -130,7 +130,10 @@ test_that("transform/fit methods reject the wrong object types", {
   iris_tbl <- testthat_tbl("iris")
   transformer <- ft_binarizer(sc, "x", "y")
 
-  expect_error(ml_fit(transformer, iris_tbl), "only applicable to 'ml_estimator'")
+  expect_error(
+    ml_fit(transformer, iris_tbl),
+    "only applicable to 'ml_estimator'"
+  )
   expect_error(
     ml_fit_and_transform(transformer, iris_tbl),
     "only applicable to 'ml_estimator'"

--- a/tests/testthat/test-ml_transformer.R
+++ b/tests/testthat/test-ml_transformer.R
@@ -57,4 +57,101 @@ test_that("one can program with ft_ function (.spark_connection)", {
   }
 })
 
+test_that("print methods for transformers and estimators produce output", {
+  transformer <- ft_binarizer(sc, "x", "y", threshold = 0.5)
+  expect_output(print(transformer))
+  estimator <- ml_logistic_regression(sc)
+  expect_output(print(estimator))
+})
+
+test_that("ml_predict dispatches across model families", {
+  test_requires("dplyr")
+  iris_tbl <- testthat_tbl("iris")
+  mtcars_tbl <- testthat_tbl("mtcars")
+
+  # classification (probabilistic) -> probability_ columns appended
+  clf <- ml_logistic_regression(iris_tbl, Species ~ Sepal_Length + Sepal_Width)
+  expect_s3_class(clf$model, "ml_classification_model")
+  p_clf <- ml_predict(clf, iris_tbl)
+  expect_true(any(grepl("^probability_", colnames(p_clf))))
+
+  # classification (non-probabilistic) -> predictions returned as-is
+  iris_bin <- iris_tbl %>%
+    mutate(is_versicolor = ifelse(Species == "versicolor", "v", "o")) %>%
+    select(-Species)
+  svc <- ml_linear_svc(iris_bin, is_versicolor ~ .)
+  expect_true(inherits(ml_predict(svc), "tbl_spark"))
+
+  # regression, using the model's own dataset when none is supplied
+  reg <- ml_linear_regression(mtcars_tbl, mpg ~ wt)
+  expect_true("prediction" %in% colnames(ml_predict(reg)))
+
+  # clustering
+  km <- ml_kmeans(iris_tbl, ~ Sepal_Length + Sepal_Width, k = 2)
+  expect_true(inherits(ml_predict(km), "tbl_spark"))
+})
+
+test_that("ml_predict on a recommendation model", {
+  ratings <- copy_to(
+    sc,
+    data.frame(
+      user = c(0L, 0L, 1L, 1L),
+      item = c(0L, 1L, 0L, 1L),
+      rating = c(4, 2, 3, 5)
+    ),
+    name = random_string("ratings_"),
+    overwrite = TRUE
+  )
+  # the formula interface yields an ml_model_recommendation (vs. a bare
+  # transformer), which routes ml_predict() through the recommendation method
+  als <- ml_als(ratings, rating ~ user + item, rank = 2, max_iter = 2)
+  expect_s3_class(als, "ml_model_recommendation")
+  expect_true(inherits(ml_predict(als), "tbl_spark"))
+})
+
+test_that("ml_fit / ml_transform / ml_fit_and_transform on an estimator", {
+  iris_tbl <- testthat_tbl("iris")
+  prepped <- iris_tbl %>%
+    ft_vector_assembler(c("Sepal_Length", "Sepal_Width"), "features")
+  est <- ml_kmeans(sc, k = 2, features_col = "features")
+
+  model <- ml_fit(est, prepped)
+  expect_true(is_ml_transformer(model))
+
+  expect_true(inherits(ml_transform(model, prepped), "tbl_spark"))
+  expect_true(inherits(ml_transform(list(model), prepped), "tbl_spark"))
+  expect_true(inherits(ml_fit_and_transform(est, prepped), "tbl_spark"))
+
+  # ml_predict.default on a plain transformer routes through ml_transform
+  expect_true(inherits(ml_predict(model, prepped), "tbl_spark"))
+})
+
+test_that("transform/fit methods reject the wrong object types", {
+  iris_tbl <- testthat_tbl("iris")
+  transformer <- ft_binarizer(sc, "x", "y")
+
+  expect_error(ml_fit(transformer, iris_tbl), "only applicable to 'ml_estimator'")
+  expect_error(
+    ml_fit_and_transform(transformer, iris_tbl),
+    "only applicable to 'ml_estimator'"
+  )
+  expect_error(ml_transform("nope", iris_tbl), "must be 'ml_transformer'")
+  expect_error(ml_transform(list("nope"), iris_tbl), "must be 'ml_transformer'")
+})
+
+test_that("deprecated sdf_ transform/fit/predict wrappers delegate", {
+  iris_tbl <- testthat_tbl("iris")
+  mtcars_tbl <- testthat_tbl("mtcars")
+  prepped <- iris_tbl %>%
+    ft_vector_assembler(c("Sepal_Length", "Sepal_Width"), "features")
+  est <- ml_kmeans(sc, k = 2, features_col = "features")
+
+  expect_warning(model <- sdf_fit(prepped, est), "deprecated")
+  expect_warning(sdf_transform(prepped, model), "deprecated")
+  expect_warning(sdf_fit_and_transform(prepped, est), "deprecated")
+
+  reg <- ml_linear_regression(mtcars_tbl, mpg ~ wt)
+  expect_warning(sdf_predict(mtcars_tbl, reg), "deprecated")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-ml_tuning.R
+++ b/tests/testthat/test-ml_tuning.R
@@ -1,3 +1,74 @@
+# ---------------------------------------------------------------------------
+# Connection-free tests for the tuning helpers, validators, and print/summary
+# code. The live CV/TVS fits are skip_slow (excluded from coverage), so cover the
+# pure logic, the error branches, and the model print/summary here (mocking the
+# JVM-facing bits).
+# ---------------------------------------------------------------------------
+
+test_that("ml_validate_params() errors on ambiguous / missing stage names", {
+  expect_error(
+    ml_validate_params(
+      list(foo = list(list(p = 1))),
+      list(foo1 = NULL, foo2 = NULL),
+      list()
+    ),
+    "matches more than one stage"
+  )
+  expect_error(
+    ml_validate_params(
+      list(bar = list(list(p = 1))),
+      list(foo1 = NULL),
+      list()
+    ),
+    "matches no stages"
+  )
+})
+
+test_that("validate_args_tuning() rejects bad estimator/param_maps/evaluator", {
+  base <- list(collect_sub_models = FALSE, parallelism = 1, seed = NULL)
+  expect_error(
+    validate_args_tuning(c(base, list(estimator = structure(1, class = "x")))),
+    "must be an .ml_estimator"
+  )
+  expect_error(
+    validate_args_tuning(c(base, list(estimator_param_maps = 5))),
+    "must be a list"
+  )
+  expect_error(
+    validate_args_tuning(c(base, list(evaluator = structure(1, class = "x")))),
+    "must be an .ml_evaluator"
+  )
+})
+
+test_that("ml_validation_metrics() dispatches by model class", {
+  expect_equal(
+    ml_validation_metrics(
+      structure(list(avg_metrics_df = "A"), class = "ml_cross_validator_model")
+    ),
+    "A"
+  )
+  expect_equal(
+    ml_validation_metrics(
+      structure(
+        list(validation_metrics_df = "B"),
+        class = "ml_train_validation_split_model"
+      )
+    ),
+    "B"
+  )
+  expect_error(
+    ml_validation_metrics(structure(list(), class = "other")),
+    "must be called on"
+  )
+})
+
+test_that("ml_sub_models() errors when sub-models were not collected", {
+  expect_error(
+    ml_sub_models(structure(list(), class = "ml_cross_validator_model")),
+    "collect_sub_models"
+  )
+})
+
 skip_connection("ml_tuning")
 skip_on_livy()
 skip_on_arrow_devel()
@@ -365,6 +436,35 @@ test_that("train validation split print methods", {
     output_file("print/tvs3.txt"),
     print = TRUE
   )
+})
+
+test_that("ml_cross_validator(tbl_spark) fits, prints, and reports metrics", {
+  test_requires_version("2.3.0")
+  sc <- testthat_spark_connection()
+  iris_tbl <- testthat_tbl("iris")
+
+  pipeline <- ml_pipeline(sc) %>%
+    ft_r_formula(Species ~ Petal_Width, uid = "rf_cv") %>%
+    ml_logistic_regression(uid = "lr_cv")
+
+  # small grid + 2 folds keeps this quick enough to run during measurement, and
+  # the tbl_spark entry point fits the model directly (exercises new_*_model,
+  # print/summary, ml_validation_metrics and ml_sub_models for real).
+  model <- ml_cross_validator(
+    iris_tbl,
+    estimator = pipeline,
+    estimator_param_maps = list(lr_cv = list(reg_param = c(0, 0.1))),
+    evaluator = ml_multiclass_classification_evaluator(sc),
+    num_folds = 2,
+    collect_sub_models = TRUE,
+    seed = 1
+  )
+
+  expect_s3_class(model, "ml_cross_validator_model")
+  expect_output(print(model), "Best Model")
+  expect_output(summary(model), "Summary for")
+  expect_equal(nrow(ml_validation_metrics(model)), 2)
+  expect_length(ml_sub_models(model), 2)
 })
 
 test_clear_cache()

--- a/tests/testthat/test-ml_utils.R
+++ b/tests/testthat/test-ml_utils.R
@@ -15,7 +15,10 @@ test_that("possibly_null swallows errors and otherwise returns the value", {
 })
 
 test_that("residuals / ml_feature_importances reject unsupported models", {
-  expect_error(residuals(structure(list(), class = "ml_model")), "not supported")
+  expect_error(
+    residuals(structure(list(), class = "ml_model")),
+    "not supported"
+  )
   expect_error(
     ml_feature_importances(
       structure(list(), class = c("ml_foo_model", "ml_prediction_model"))
@@ -88,18 +91,27 @@ test_that("predict/fitted/ml_model_data and the post_ml_obj dispatchers work", {
   expect_s3_class(ml_model_data(fm_reg), "tbl_spark")
   expect_s3_class(ml_tree_feature_importance(fm_reg), "data.frame")
 
-  bin <- iris_tbl %>% dplyr::mutate(lab = ifelse(Species == "setosa", "yes", "no"))
+  bin <- iris_tbl %>%
+    dplyr::mutate(lab = ifelse(Species == "setosa", "yes", "no"))
   fm_cls <- bin %>% ml_gbt_classifier(lab ~ Petal_Length + Petal_Width)
   expect_length(predict(fm_cls), 150) # predict.ml_model_classification
 
   # post_ml_obj dispatchers: ml_pipeline (add stage) and tbl_spark (no formula -> fit)
   expect_s3_class(
-    ml_gbt_regressor(ml_pipeline(testthat_spark_connection()), Sepal_Length ~ Petal_Length),
+    ml_gbt_regressor(
+      ml_pipeline(testthat_spark_connection()),
+      Sepal_Length ~ Petal_Length
+    ),
     "ml_pipeline"
   )
-  feat <- iris_tbl %>% ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  feat <- iris_tbl %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
   expect_s3_class(
-    ml_gbt_regressor(feat, features_col = "features", label_col = "Sepal_Length"),
+    ml_gbt_regressor(
+      feat,
+      features_col = "features",
+      label_col = "Sepal_Length"
+    ),
     "ml_gbt_regression_model"
   )
 })

--- a/tests/testthat/test-ml_utils.R
+++ b/tests/testthat/test-ml_utils.R
@@ -1,0 +1,107 @@
+skip_connection("ml_utils")
+skip_on_livy()
+skip_on_arrow_devel()
+
+sc <- testthat_spark_connection()
+
+test_that("make_stats_arranger reorders for intercept or is identity", {
+  expect_identical(make_stats_arranger(TRUE)(c(1, 2, 3)), c(3, 1, 2))
+  expect_identical(make_stats_arranger(FALSE)(c(1, 2, 3)), c(1, 2, 3))
+})
+
+test_that("possibly_null swallows errors and otherwise returns the value", {
+  expect_null(possibly_null(function(x) stop("boom"))(1))
+  expect_equal(possibly_null(function(x) x + 1)(1), 2)
+})
+
+test_that("residuals / ml_feature_importances reject unsupported models", {
+  expect_error(residuals(structure(list(), class = "ml_model")), "not supported")
+  expect_error(
+    ml_feature_importances(
+      structure(list(), class = c("ml_foo_model", "ml_prediction_model"))
+    ),
+    "Cannot extract"
+  )
+  expect_error(
+    ml_feature_importances(
+      structure(list(), class = c("ml_model_foo", "ml_model"))
+    ),
+    "not supported"
+  )
+})
+
+test_that("param_min_version errors below min, nulls a default, passes otherwise", {
+  expect_error(
+    param_min_version(sc, "frequencyAsc", "99.0.0", "frequencyDesc"),
+    "only available for Spark"
+  )
+  expect_null(param_min_version(sc, "frequencyDesc", "99.0.0", "frequencyDesc"))
+  expect_equal(param_min_version(sc, "x", NULL), "x")
+})
+
+test_that("spark linalg helpers round-trip vectors/matrices and build columns", {
+  v <- spark_dense_vector(sc, c(1, 2, 3))
+  expect_equal(as.numeric(invoke(v, "toArray")), c(1, 2, 3))
+  expect_null(spark_dense_vector(sc, NULL))
+
+  m <- spark_dense_matrix(sc, matrix(c(1, 2, 3, 4), 2, 2))
+  expect_equal(dim(read_spark_matrix(m)), c(2L, 2L))
+  expect_null(spark_dense_matrix(sc, NULL))
+
+  expect_true(inherits(spark_sql_column(sc, "x", "x_alias"), "spark_jobj"))
+})
+
+test_that("read_spark_vector + ml_short_type work against fitted models", {
+  feat <- sdf_copy_to(sc, iris, "mlu_iris", overwrite = TRUE) %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  scaler <- ml_fit(
+    ft_standard_scaler(sc, "features", "scaled", with_std = TRUE),
+    feat
+  )
+  expect_true(is.numeric(read_spark_vector(spark_jobj(scaler), "std")))
+  expect_match(ml_short_type(ml_kmeans(sc, k = 2)), "KMeans")
+})
+
+test_that("ml_feature_importances returns importances for tree models", {
+  feat <- sdf_copy_to(sc, iris, "mlu_iris2", overwrite = TRUE) %>%
+    ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  # prediction-model path -> numeric vector
+  pm <- ml_fit(
+    ml_gbt_regressor(sc, features_col = "features", label_col = "Sepal_Length"),
+    feat
+  )
+  expect_true(is.numeric(ml_feature_importances(pm)))
+  # ml_model (formula) path -> sorted data frame
+  fm <- testthat_tbl("iris") %>%
+    ml_gbt_regressor(Sepal_Length ~ Petal_Length + Petal_Width)
+  fi <- ml_feature_importances(fm)
+  expect_s3_class(fi, "data.frame")
+  expect_setequal(names(fi), c("feature", "importance"))
+})
+
+test_that("predict/fitted/ml_model_data and the post_ml_obj dispatchers work", {
+  iris_tbl <- testthat_tbl("iris")
+  fm_reg <- iris_tbl %>%
+    ml_gbt_regressor(Sepal_Length ~ Petal_Length + Petal_Width)
+  expect_length(predict(fm_reg), 150) # predict.ml_model_regression
+  expect_length(fitted(fm_reg), 150) # fitted.ml_model_prediction
+  expect_s3_class(ml_model_data(fm_reg), "tbl_spark")
+  expect_s3_class(ml_tree_feature_importance(fm_reg), "data.frame")
+
+  bin <- iris_tbl %>% dplyr::mutate(lab = ifelse(Species == "setosa", "yes", "no"))
+  fm_cls <- bin %>% ml_gbt_classifier(lab ~ Petal_Length + Petal_Width)
+  expect_length(predict(fm_cls), 150) # predict.ml_model_classification
+
+  # post_ml_obj dispatchers: ml_pipeline (add stage) and tbl_spark (no formula -> fit)
+  expect_s3_class(
+    ml_gbt_regressor(ml_pipeline(testthat_spark_connection()), Sepal_Length ~ Petal_Length),
+    "ml_pipeline"
+  )
+  feat <- iris_tbl %>% ft_vector_assembler(c("Petal_Length", "Petal_Width"), "features")
+  expect_s3_class(
+    ml_gbt_regressor(feat, features_col = "features", label_col = "Sepal_Length"),
+    "ml_gbt_regression_model"
+  )
+})
+
+test_clear_cache()

--- a/tests/testthat/test-precondition.R
+++ b/tests/testthat/test-precondition.R
@@ -1,0 +1,72 @@
+skip_connection("precondition")
+skip_on_livy()
+skip_on_arrow_devel()
+
+test_that("ensure_not_na errors on NA (scalar and vector) and passes otherwise", {
+  expect_error(ensure_not_na(NA), "is NA")
+  expect_error(ensure_not_na(c(1, NA)), "contains NA")
+  expect_equal(ensure_not_na(1:3), 1:3)
+})
+
+test_that("ensure_not_null errors on NULL and passes otherwise", {
+  expect_error(ensure_not_null(NULL), "is NULL")
+  expect_equal(ensure_not_null(5), 5)
+})
+
+test_that("require_file_exists / require_directory_exists enforce paths", {
+  f <- tempfile()
+  file.create(f)
+  expect_equal(require_file_exists(f), f)
+  expect_error(require_file_exists("/no/such/path"), "no file at path")
+
+  d <- tempfile()
+  dir.create(d)
+  expect_equal(require_directory_exists(d), d)
+  expect_error(require_directory_exists(f), "no file at path") # f is a file
+})
+
+test_that("ensure_directory returns, creates, and rejects non-directories", {
+  d <- tempfile()
+  dir.create(d)
+  expect_equal(ensure_directory(d), d) # already a directory
+
+  d2 <- file.path(tempfile(), "nested")
+  ensure_directory(d2)
+  expect_true(dir.exists(d2)) # created recursively
+
+  f <- tempfile()
+  file.create(f)
+  expect_error(ensure_directory(f), "not a directory")
+})
+
+test_that("param_name_r_to_spark camel-cases and honors a catalog override", {
+  expect_equal(param_name_r_to_spark("max_iter"), "MaxIter")
+  expect_equal(param_name_r_to_spark("x", list(x = "CustomName")), "CustomName")
+})
+
+test_that("params_validate casts matched params and can fail on unmatched", {
+  est <- structure(list(), class = "ml_estimator")
+  v <- params_validate(est, list(max_iter = 5, reg_param = 0.1))
+  expect_identical(v$max_iter, 5L)
+  expect_identical(v$reg_param, 0.1)
+  # NULL values pass through untouched
+  expect_null(params_validate(est, list(weight_col = NULL))$weight_col)
+  expect_error(
+    params_validate(est, list(not_a_param = 1), unmatched_fail = TRUE),
+    "Could not find"
+  )
+  # pre_ml_estimator dispatches to the same base validator; exercise a choice
+  # validator (family) too
+  v2 <- params_validate(
+    structure(list(), class = "pre_ml_estimator"),
+    list(family = "gaussian")
+  )
+  expect_equal(v2$family, "gaussian")
+})
+
+test_that("stopf and warnf format their messages", {
+  expect_error(stopf("bad %s", "value"), "bad value")
+  expect_warning(warnf("careful %d", 7L), "careful 7")
+})
+
+test_clear_cache()

--- a/tests/testthat/test-sdf_interface.R
+++ b/tests/testthat/test-sdf_interface.R
@@ -543,6 +543,8 @@ test_that("sdf_partition_sizes works as expected", {
 })
 
 test_that("to_avro and from_avro work properly", {
+  # Capped at Spark 4: avro works on 4.x, but the test harness only loads the
+  # avro package on Spark < 4.1 (helper-initialize.R). See plan "Issues to open".
   test_requires_version("2.4.0", max_version = "4")
   skip_databricks_connect()
 

--- a/tests/testthat/test-sdf_interface.R
+++ b/tests/testthat/test-sdf_interface.R
@@ -543,9 +543,7 @@ test_that("sdf_partition_sizes works as expected", {
 })
 
 test_that("to_avro and from_avro work properly", {
-  # Capped at Spark 4: avro works on 4.x, but the test harness only loads the
-  # avro package on Spark < 4.1 (helper-initialize.R). See plan "Issues to open".
-  test_requires_version("2.4.0", max_version = "4")
+  test_requires_version("2.4.0")
   skip_databricks_connect()
 
   df <- dplyr::tibble(

--- a/tests/testthat/test-sdf_interface.R
+++ b/tests/testthat/test-sdf_interface.R
@@ -953,4 +953,99 @@ local({
   })
 })
 
+# ---- additional coverage for previously-untested sdf_* helpers --------------
+
+test_that("sdf_with_unique_id / sdf_with_sequential_id add id columns", {
+  tbl <- sdf_copy_to(sc, data.frame(x = 1:5), "t_ids", overwrite = TRUE)
+  uniq <- tbl %>% sdf_with_unique_id("uid") %>% collect()
+  expect_true("uid" %in% names(uniq))
+  expect_equal(length(unique(uniq$uid)), 5)
+
+  seqd <- tbl %>% sdf_with_sequential_id("sid", from = 1L) %>% collect()
+  expect_setequal(seqd$sid, 1:5)
+})
+
+test_that("sdf_last_index returns the final id", {
+  expect_equal(sdf_len(sc, 7) %>% sdf_last_index("id"), 7)
+})
+
+test_that("sdf_quantile computes basic, multi-column, and weighted quantiles", {
+  tbl <- sdf_copy_to(
+    sc, data.frame(x = 1:5, y = 5:1, w = rep(1, 5)), "t_q", overwrite = TRUE
+  )
+  q <- sdf_quantile(tbl, "x", probabilities = c(0, 0.5, 1))
+  expect_named(q, c("0%", "50%", "100%"))
+  expect_equal(unname(q[["0%"]]), 1)
+  expect_equal(unname(q[["100%"]]), 5)
+
+  qm <- sdf_quantile(tbl, c("x", "y"), probabilities = c(0, 1))
+  expect_true(is.list(qm))
+  expect_named(qm, c("x", "y"))
+
+  qw <- sdf_quantile(tbl, "x", probabilities = 0.5, weight.column = "w")
+  expect_length(qw, 1)
+})
+
+test_that("sdf_checkpoint forces computation", {
+  invoke(spark_context(sc), "setCheckpointDir", tempfile("ckpt"))
+  res <- sdf_len(sc, 3) %>% sdf_checkpoint() %>% collect()
+  expect_equal(nrow(res), 3)
+})
+
+test_that("`[.tbl_spark` selects, drops, indexes, and empties columns", {
+  tbl <- sdf_copy_to(sc, data.frame(x = 1:3, y = 4:6), "t_sub", overwrite = TRUE)
+  expect_equal(colnames(tbl["x"]), "x")
+  expect_setequal(colnames(tbl[c("x", "y")]), c("x", "y"))
+  expect_equal(colnames(tbl[1]), "x")
+  expect_equal(ncol(collect(tbl[NULL])), 0)
+  expect_true(inherits(tbl[], "tbl_spark"))
+})
+
+test_that("sdf_import errors when the table already exists", {
+  sdf_copy_to(sc, data.frame(x = 1), "t_exists", overwrite = TRUE)
+  expect_error(
+    sdf_copy_to(sc, data.frame(x = 2), "t_exists", overwrite = FALSE),
+    "already exists"
+  )
+})
+
+test_that("sdf_sample works without a seed", {
+  tbl <- sdf_copy_to(sc, data.frame(x = 1:100), "t_samp", overwrite = TRUE)
+  expect_s3_class(sdf_sample(tbl, fraction = 0.5, seed = NULL), "tbl_spark")
+})
+
+test_that("sdf_coalesce rejects a non-positive partition count", {
+  tbl <- sdf_copy_to(sc, data.frame(x = 1:3), "t_coal", overwrite = TRUE)
+  expect_error(sdf_coalesce(tbl, 0), "must be positive")
+})
+
+test_that("sdf_register accepts a tbl_spark and a named list of jobjs", {
+  tbl <- sdf_copy_to(sc, data.frame(x = 1:3), "t_reg1", overwrite = TRUE)
+  expect_s3_class(sdf_register(tbl, "t_reg_named"), "tbl_spark")
+
+  jobjs <- list(spark_dataframe(tbl), spark_dataframe(tbl))
+  registered <- sdf_register(jobjs, c("reg_a", "reg_b"))
+  expect_named(registered, c("reg_a", "reg_b"))
+  expect_true(all(c("reg_a", "reg_b") %in% src_tbls(sc)))
+})
+
+test_that("sdf_expand_grid handles empty input and warns on unknown broadcast vars", {
+  expect_equal(nrow(collect(sdf_expand_grid(sc))), 0)
+  expect_warning(
+    sdf_expand_grid(sc, a = 1:2, b = c("p", "q"), broadcast_vars = c(nope)),
+    "not among the list"
+  )
+})
+
+test_that("sdf_to_avro passes through columns outside the requested subset", {
+  test_requires_version("2.4.0")
+  skip_databricks_connect()
+  sdf <- sdf_copy_to(
+    sc, data.frame(a = 1:3, b = letters[1:3]), "t_avro_sub", overwrite = TRUE
+  )
+  out <- sdf_to_avro(sdf, cols = "a") %>% sdf_collect()
+  expect_setequal(colnames(out), c("a", "b"))
+  expect_equal(out$b, letters[1:3]) # b untouched -> transform_sdf else branch
+})
+
 test_clear_cache()

--- a/tests/testthat/test-sdf_interface.R
+++ b/tests/testthat/test-sdf_interface.R
@@ -971,7 +971,10 @@ test_that("sdf_last_index returns the final id", {
 
 test_that("sdf_quantile computes basic, multi-column, and weighted quantiles", {
   tbl <- sdf_copy_to(
-    sc, data.frame(x = 1:5, y = 5:1, w = rep(1, 5)), "t_q", overwrite = TRUE
+    sc,
+    data.frame(x = 1:5, y = 5:1, w = rep(1, 5)),
+    "t_q",
+    overwrite = TRUE
   )
   q <- sdf_quantile(tbl, "x", probabilities = c(0, 0.5, 1))
   expect_named(q, c("0%", "50%", "100%"))
@@ -993,7 +996,12 @@ test_that("sdf_checkpoint forces computation", {
 })
 
 test_that("`[.tbl_spark` selects, drops, indexes, and empties columns", {
-  tbl <- sdf_copy_to(sc, data.frame(x = 1:3, y = 4:6), "t_sub", overwrite = TRUE)
+  tbl <- sdf_copy_to(
+    sc,
+    data.frame(x = 1:3, y = 4:6),
+    "t_sub",
+    overwrite = TRUE
+  )
   expect_equal(colnames(tbl["x"]), "x")
   expect_setequal(colnames(tbl[c("x", "y")]), c("x", "y"))
   expect_equal(colnames(tbl[1]), "x")
@@ -1041,7 +1049,10 @@ test_that("sdf_to_avro passes through columns outside the requested subset", {
   test_requires_version("2.4.0")
   skip_databricks_connect()
   sdf <- sdf_copy_to(
-    sc, data.frame(a = 1:3, b = letters[1:3]), "t_avro_sub", overwrite = TRUE
+    sc,
+    data.frame(a = 1:3, b = letters[1:3]),
+    "t_avro_sub",
+    overwrite = TRUE
   )
   out <- sdf_to_avro(sdf, cols = "a") %>% sdf_collect()
   expect_setequal(colnames(out), c("a", "b"))

--- a/tests/testthat/test-sdf_io.R
+++ b/tests/testthat/test-sdf_io.R
@@ -54,4 +54,70 @@ test_that("sdf_distinct works properly", {
   )
 })
 
+test_that("sdf_distinct() works on a spark_jobj", {
+  jobj <- sdf_copy_to(sc, data.frame(x = c(1, 1, 2)), overwrite = TRUE) %>%
+    spark_dataframe()
+  res <- sdf_distinct(jobj)
+  expect_true(inherits(res, "spark_jobj"))
+  expect_equal(invoke(res, "count"), 2)
+})
+
+test_that("sdf_nrow() and sdf_ncol() report dimensions", {
+  sdf <- sdf_copy_to(sc, data.frame(x = 1:3, y = 4:6), overwrite = TRUE)
+  expect_equal(sdf_nrow(sdf), 3)
+  expect_equal(sdf_ncol(sdf), 2)
+})
+
+test_that("sdf_seq(), sdf_len() and sdf_along() build index DataFrames", {
+  # integer type, default repartition
+  expect_equal(sdf_nrow(sdf_seq(sc, 1, 5)), 5)
+  # integer64 type, explicit repartition
+  expect_equal(
+    sdf_nrow(sdf_seq(sc, 1, 5, type = "integer64", repartition = 2)),
+    5
+  )
+  # sdf_len() delegates to sdf_seq()
+  expect_equal(sdf_nrow(sdf_len(sc, 4)), 4)
+  # sdf_along() takes its length from the object
+  expect_equal(sdf_nrow(sdf_along(sc, letters[1:3])), 3)
+})
+
+test_that("sdf_sql() and df_from_sql() build/collect from a query", {
+  expect_equal(
+    sdf_sql(sc, "SELECT 1 AS a, 2 AS b") %>% collect(),
+    dplyr::tibble(a = 1L, b = 2L)
+  )
+  expect_equal(df_from_sql(sc, "SELECT 1 AS a")$a, 1L)
+})
+
+test_that("sdf_save_table()/sdf_load_table() round-trip (deprecated)", {
+  skip_databricks_connect()
+  sdf <- sdf_copy_to(sc, data.frame(x = 1:3), overwrite = TRUE)
+  name <- random_string("sdf_io_tbl_")
+  on.exit(
+    DBI::dbExecute(sc, paste0("DROP TABLE IF EXISTS `", name, "`")),
+    add = TRUE
+  )
+
+  expect_warning(sdf_save_table(sdf, name, overwrite = TRUE), "deprecated")
+  # append path adds another 3 rows
+  suppressWarnings(sdf_save_table(sdf, name, append = TRUE))
+
+  loaded <- suppressWarnings(sdf_load_table(sc, name))
+  expect_equal(sdf_nrow(loaded), 6)
+})
+
+test_that("sdf_save_parquet()/sdf_load_parquet() round-trip (deprecated)", {
+  path <- file.path(tempdir(), random_string("sdf_io_parq_"))
+  on.exit(unlink(path, recursive = TRUE), add = TRUE)
+  sdf <- sdf_copy_to(sc, data.frame(x = 1:3), overwrite = TRUE)
+
+  expect_warning(sdf_save_parquet(sdf, path, overwrite = TRUE), "deprecated")
+  # append path adds another 3 rows
+  suppressWarnings(sdf_save_parquet(sdf, path, append = TRUE))
+
+  loaded <- suppressWarnings(sdf_load_parquet(sc, path))
+  expect_equal(sdf_nrow(loaded), 6)
+})
+
 test_clear_cache()

--- a/tests/testthat/test-sdf_wrapper.R
+++ b/tests/testthat/test-sdf_wrapper.R
@@ -1,3 +1,37 @@
+# ---------------------------------------------------------------------------
+# Connection-free unit test for collect_from_rds(). It deserializes the RDS
+# layout that spark_write_rds() produces (a length-5 list: column names, then
+# the timestamp / date / struct column indices, then the column data), so it can
+# be exercised with a hand-built fixture and no live Spark session. Placed above
+# the skip_connection() gate so it runs regardless.
+# ---------------------------------------------------------------------------
+test_that("collect_from_rds() restores timestamp, date, and struct columns", {
+  path <- withr::local_tempfile(fileext = ".rds")
+
+  col_data <- list(
+    ts = c(0, 86400), # seconds since epoch -> POSIXct
+    dt = c(0, 1), # days since epoch -> Date
+    st = list('{"a":1}', '{"a":2}'), # JSON strings (list column) -> parsed
+    plain = c(1, 2) # left untouched
+  )
+  # data[[1]] names; data[[2..4]] the 1-based timestamp/date/struct col indices.
+  saveRDS(
+    list(c("ts", "dt", "st", "plain"), 1L, 2L, 3L, col_data),
+    path
+  )
+
+  result <- collect_from_rds(path)
+
+  expect_s3_class(result$ts, "POSIXct")
+  expect_s3_class(result$dt, "Date")
+  expect_equal(result$dt, as.Date(c("1970-01-01", "1970-01-02")))
+  # struct column is a list column, each element parsed from JSON
+  expect_type(result$st, "list")
+  expect_equal(result$st[[1]][[1]]$a, 1L)
+  # non-special column passes through unchanged
+  expect_equal(result$plain, c(1, 2))
+})
+
 skip_connection("sdf_wrapper")
 skip_on_livy()
 
@@ -433,6 +467,12 @@ test_that("sdf_collect() preserves NA_real_", {
   expect_equal(sdf %>% collect(), df)
 })
 
+test_stream("sdf_collect() routes a streaming DataFrame to the stream collector", {
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";")
+  collected <- sdf_collect(stream)
+  expect_s3_class(collected, "data.frame")
+})
+
 test_that("`[.tbl_spark` works as expected", {
   skip_on_arrow_devel()
   df <- dplyr::tibble(
@@ -690,6 +730,34 @@ test_that("sdf_schema() works on a tbl_spark and a spark_jobj", {
   expect_equal(schema_default, schema_tbl)
 })
 
+test_that("sdf_schema() recurses into nested struct and array columns", {
+  # `s` is a struct; `arr` is an array-of-structs. With both expand flags on,
+  # the struct is described as nested fields (the recursion branch) and the
+  # array-of-structs as type "array" carrying an `element_type` attribute.
+  sdf <- dplyr::tbl(
+    sc,
+    dplyr::sql(
+      "SELECT named_struct('x', 1, 'y', 'a') AS s,
+              array(named_struct('a', 1, 'b', 2)) AS arr"
+    )
+  )
+
+  schema <- sdf_schema(
+    sdf,
+    expand_nested_cols = TRUE,
+    expand_struct_cols = TRUE
+  )
+
+  # struct column -> nested list of its fields (recursion)
+  expect_true(is.list(schema$s$type))
+  expect_setequal(names(schema$s$type), c("x", "y"))
+
+  # array-of-structs column -> type "array" with the element struct attached
+  expect_equal(as.character(schema$arr$type), "array")
+  element_type <- attr(schema$arr$type, "element_type")
+  expect_setequal(names(element_type), c("a", "b"))
+})
+
 test_that("sdf_read_column.spark_jobj reads a column from a Spark DataFrame", {
   iris_tbl <- testthat_tbl("iris")
   sdf <- spark_dataframe(iris_tbl)
@@ -734,6 +802,15 @@ test_that("get_sdf_storage_level() returns a storage level jobj", {
   expect_true(inherits(level, "spark_jobj"))
 })
 
+test_that("sdf_pivot() errors on a formula that is not two-sided", {
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    sdf_pivot(iris_tbl, Sepal_Length ~ Sepal_Width ~ Species),
+    "two-sided formula"
+  )
+})
+
 test_that("sdf_pivot() errors when a variable appears on both sides", {
   iris_tbl <- testthat_tbl("iris")
 
@@ -741,6 +818,28 @@ test_that("sdf_pivot() errors when a variable appears on both sides", {
     sdf_pivot(iris_tbl, Species ~ Species),
     "both sides"
   )
+})
+
+test_that("sdf_pivot() errors when the pivot side has more than one column", {
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    sdf_pivot(iris_tbl, Species ~ Sepal_Length + Sepal_Width),
+    "pivot column is not length one"
+  )
+})
+
+test_that("sdf_pivot() supports a multi-element character fun.aggregate", {
+  iris_tbl <- testthat_tbl("iris")
+
+  result <- iris_tbl %>%
+    sdf_pivot(
+      Species ~ Petal_Width,
+      fun.aggregate = c("sum", "Sepal_Length")
+    ) %>%
+    collect()
+
+  expect_gt(nrow(result), 0)
 })
 
 test_that("sdf_pivot() errors on missing variables", {

--- a/tests/testthat/test-sdf_wrapper.R
+++ b/tests/testthat/test-sdf_wrapper.R
@@ -673,4 +673,93 @@ test_that("we can separate struct columns (#690)", {
   )
 })
 
+test_that("sdf_schema() works on a tbl_spark and a spark_jobj", {
+  iris_tbl <- testthat_tbl("iris")
+
+  schema_tbl <- sdf_schema(iris_tbl)
+  expect_setequal(
+    names(schema_tbl),
+    c("Sepal_Length", "Sepal_Width", "Petal_Length", "Petal_Width", "Species")
+  )
+  expect_equal(schema_tbl$Species$name, "Species")
+  expect_equal(schema_tbl$Species$type, "StringType")
+  expect_equal(schema_tbl$Sepal_Length$type, "DoubleType")
+
+  # default method (operating on a spark_jobj) yields the same schema
+  schema_default <- sdf_schema(spark_dataframe(iris_tbl))
+  expect_equal(schema_default, schema_tbl)
+})
+
+test_that("sdf_read_column.spark_jobj reads a column from a Spark DataFrame", {
+  iris_tbl <- testthat_tbl("iris")
+  sdf <- spark_dataframe(iris_tbl)
+
+  species <- sdf_read_column(sdf, "Species")
+
+  expect_setequal(unique(species), c("setosa", "versicolor", "virginica"))
+  expect_equal(length(species), 150)
+})
+
+test_that("spark_dataframe.spark_connection runs SQL against the connection", {
+  iris_tbl <- testthat_tbl("iris")
+
+  sdf <- spark_dataframe(
+    sc,
+    sprintf("SELECT * FROM %s", dbplyr::remote_name(iris_tbl))
+  )
+
+  expect_true(inherits(sdf, "spark_jobj"))
+  expect_setequal(
+    as.character(invoke(sdf, "columns")),
+    c("Sepal_Length", "Sepal_Width", "Petal_Length", "Petal_Width", "Species")
+  )
+})
+
+test_that("sdf_split() randomly splits a Spark DataFrame", {
+  mtcars_tbl <- testthat_tbl("mtcars")
+
+  splits <- sdf_split(mtcars_tbl, weights = c(0.6, 0.4), seed = 42L)
+
+  expect_equal(length(splits), 2)
+  total <- sum(vapply(splits, function(s) invoke(s, "count"), numeric(1)))
+  expect_equal(total, nrow(mtcars))
+})
+
+test_that("get_sdf_storage_level() returns a storage level jobj", {
+  mtcars_tbl <- testthat_tbl("mtcars")
+  sdf <- spark_dataframe(mtcars_tbl)
+
+  level <- get_sdf_storage_level(sdf)
+
+  expect_true(inherits(level, "spark_jobj"))
+})
+
+test_that("sdf_pivot() errors when a variable appears on both sides", {
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    sdf_pivot(iris_tbl, Species ~ Species),
+    "both sides"
+  )
+})
+
+test_that("sdf_pivot() errors on missing variables", {
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    sdf_pivot(iris_tbl, Species ~ NoSuchColumn),
+    "missing variables"
+  )
+})
+
+
+test_that("sdf_pivot() errors on an unsupported fun.aggregate type", {
+  iris_tbl <- testthat_tbl("iris")
+
+  expect_error(
+    sdf_pivot(iris_tbl, Sepal_Length ~ Species, fun.aggregate = 1L),
+    "unsupported 'fun.aggregate' type"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-spark_apply.R
+++ b/tests/testthat/test-spark_apply.R
@@ -1,3 +1,91 @@
+# ---------------------------------------------------------------------------
+# Connection-free tests for spark_apply()'s pure helpers and the early guards
+# that run before any Spark interaction. Placed above the skip_connection() gate
+# so they run without a live session.
+# ---------------------------------------------------------------------------
+
+test_that("spark_apply() rejects a non-string partition_index_param", {
+  # This guard runs before spark_connection(x), so any x reaches it.
+  expect_error(
+    spark_apply(1, identity, partition_index_param = 1L),
+    "partition_index_param"
+  )
+})
+
+test_that("spark_apply_serializer() handles the qs and custom options", {
+  withr::local_options(sparklyr.spark_apply.serializer = "qs")
+  if (is.null(core_get_package_function("qs", "qserialize"))) {
+    expect_error(spark_apply_serializer(), "qs")
+  } else {
+    expect_type(spark_apply_serializer(), "closure")
+  }
+
+  # a non-qs, non-NULL option is wrapped as list(serializer = ...)
+  withr::local_options(sparklyr.spark_apply.serializer = "custom")
+  res <- spark_apply_serializer()
+  expect_true(is.list(res))
+  expect_equal(res$serializer, "custom")
+})
+
+test_that("spark_apply_deserializer() errors for qs when qs is unavailable", {
+  withr::local_options(sparklyr.spark_apply.serializer = "qs")
+  if (is.null(core_get_package_function("qs", "qdeserialize"))) {
+    expect_error(spark_apply_deserializer(), "qs")
+  } else {
+    expect_type(spark_apply_deserializer(), "closure")
+  }
+})
+
+test_that("spark_apply_packages() warns and returns TRUE when offline", {
+  withr::local_envvar(sparklyr.apply.packagesdb = "")
+  genv_set_avail_package_cache(NULL)
+  withr::defer(genv_set_avail_package_cache(NULL))
+
+  with_mocked_bindings(
+    available.packages = function(...) stop("offline"),
+    .package = "sparklyr",
+    {
+      expect_warning(res <- spark_apply_packages("purrr"), "Failed to run")
+      expect_true(res)
+    }
+  )
+})
+
+test_that("spark_apply_log() is a no-op outside a worker session", {
+  expect_silent(spark_apply_log("hello"))
+})
+
+test_that("get_spark_apply_bundle_path() returns a .tar bundle path as-is", {
+  fake_sc <- structure(list(sessionId = "s1"), class = "spark_connection")
+  expect_equal(
+    get_spark_apply_bundle_path(fake_sc, "/some/bundle.tar"),
+    "/some/bundle.tar"
+  )
+})
+
+test_that("get_spark_apply_bundle_path() adds a not-yet-added bundle to context", {
+  fake_sc <- structure(list(sessionId = "s1"), class = "spark_connection")
+  added <- NULL
+
+  with_mocked_bindings(
+    spark_apply_bundle = function(packages, base, sid) "/tmp/bundle-xyz.tar",
+    invoke_static = function(sc, class, method, name) {
+      "/nonexistent/sparkfile.tar"
+    },
+    spark_context = function(sc) "ctx",
+    invoke = function(jobj, method, path) {
+      added <<- path
+      NULL
+    },
+    .package = "sparklyr",
+    {
+      res <- get_spark_apply_bundle_path(fake_sc, TRUE)
+      expect_equal(res, "/tmp/bundle-xyz.tar")
+      expect_equal(added, "/tmp/bundle-xyz.tar")
+    }
+  )
+})
+
 skip_connection("spark_apply")
 skip_on_livy()
 test_requires("dplyr")
@@ -606,6 +694,58 @@ test_that("barrier-spark_apply works", {
     address$address[1],
     perl = TRUE
   ))
+})
+
+test_that("spark_apply() validates barrier and group_by arguments", {
+  # barrier mode requires explicit column names
+  expect_error(
+    spark_apply(iris_tbl, function(e) e, barrier = TRUE),
+    "Barrier execution requires explicit columns names"
+  )
+  # group_by must reference existing columns
+  expect_error(
+    spark_apply(iris_tbl, function(e) e, group_by = "NoSuchColumn"),
+    "Not all group_by columns found"
+  )
+})
+
+test_stream("spark_apply() rejects group_by on a streaming dataframe", {
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";")
+  expect_error(
+    spark_apply(
+      stream,
+      function(e) e,
+      group_by = "Species",
+      columns = c(Species = "character")
+    ),
+    "'group_by' is unsupported with streams"
+  )
+})
+
+test_that("spark_apply(schema = TRUE) returns the inferred columns", {
+  skip_if_dbplyr_dev()
+  inferred <- sdf_len(sc, 3) %>%
+    spark_apply(function(e) e, schema = TRUE)
+  expect_true(length(names(inferred)) > 0)
+})
+
+test_that("spark_apply() supports the RDD code path", {
+  skip_if_dbplyr_dev()
+  result <- sdf_len(sc, 3) %>%
+    spark_apply(function(e) e, rdd = TRUE) %>%
+    collect()
+  expect_equal(nrow(result), 3)
+})
+
+test_that("spark_apply_bundle() bundles a named package", {
+  with_mocked_bindings(
+    `available.packages` = available_packages_mock,
+    {
+      path <- spark_apply_bundle(packages = "R6", base_path = tempdir())
+      expect_true(file.exists(path))
+      unlink(path, recursive = TRUE)
+    }
+  )
 })
 
 test_clear_cache()

--- a/tests/testthat/test-spark_apply.R
+++ b/tests/testthat/test-spark_apply.R
@@ -731,6 +731,15 @@ test_that("spark_apply(schema = TRUE) returns the inferred columns", {
 
 test_that("spark_apply() supports the RDD code path", {
   skip_if_dbplyr_dev()
+  # The legacy RDD code path (rdd = TRUE) is broken on Spark 4.x regardless of
+  # arrow: the non-arrow collect fails to encode the createDataFrame rows
+  # (EXPRESSION_ENCODING_FAILED) and the arrow path can't deserialize the RDD
+  # schema-inference sample. It works on Spark 3.x, which the coverage runs use.
+  skip_on_arrow()
+  skip_if(
+    spark_version(sc) >= "4.0.0",
+    "spark_apply(rdd = TRUE) is unsupported on Spark 4.x"
+  )
   result <- sdf_len(sc, 3) %>%
     spark_apply(function(e) e, rdd = TRUE) %>%
     collect()
@@ -739,7 +748,13 @@ test_that("spark_apply() supports the RDD code path", {
 
 test_that("spark_apply() supports the RDD code path with group_by", {
   skip_if_dbplyr_dev()
-  skip_on_arrow_devel()
+  # see the ungrouped RDD test above: rdd = TRUE is unsupported on Spark 4.x
+  # (encoding failure) and under arrow (schema-inference sample can't be read).
+  skip_on_arrow()
+  skip_if(
+    spark_version(sc) >= "4.0.0",
+    "spark_apply(rdd = TRUE) is unsupported on Spark 4.x"
+  )
   # group_by + rdd = TRUE exercises ApplyUtils.groupBy on the RDD (the grouped
   # branch of the RDD path), which the ungrouped RDD/barrier tests don't reach.
   result <- spark_apply(

--- a/tests/testthat/test-spark_apply.R
+++ b/tests/testthat/test-spark_apply.R
@@ -737,6 +737,23 @@ test_that("spark_apply() supports the RDD code path", {
   expect_equal(nrow(result), 3)
 })
 
+test_that("spark_apply() supports the RDD code path with group_by", {
+  skip_if_dbplyr_dev()
+  skip_on_arrow_devel()
+  # group_by + rdd = TRUE exercises ApplyUtils.groupBy on the RDD (the grouped
+  # branch of the RDD path), which the ungrouped RDD/barrier tests don't reach.
+  result <- spark_apply(
+    iris_tbl,
+    function(e) nrow(e),
+    names = "n",
+    group_by = "Species",
+    rdd = TRUE
+  ) %>%
+    collect()
+  expect_equal(nrow(result), 3) # one row per species
+  expect_equal(sum(result$n), 150) # all rows accounted for
+})
+
 test_that("spark_apply_bundle() bundles a named package", {
   with_mocked_bindings(
     `available.packages` = available_packages_mock,

--- a/tests/testthat/test-spark_compat.R
+++ b/tests/testthat/test-spark_compat.R
@@ -1,0 +1,88 @@
+skip_connection("spark_compat")
+skip_on_livy()
+skip_on_arrow_devel()
+
+test_that("spark_require_version enforces minimum and maximum versions", {
+  with_mocked_bindings(
+    spark_version = function(sc) numeric_version("3.5.0"),
+    .package = "sparklyr",
+    {
+      # within range -> TRUE
+      expect_true(spark_require_version("sc", "3.0.0"))
+      expect_true(spark_require_version("sc", "3.0.0", required_max = "4.0.0"))
+
+      # below the minimum -> error
+      expect_error(
+        spark_require_version("sc", "4.0.0", module = "feat"),
+        "feat requires Spark 4.0.0 or higher"
+      )
+
+      # at/above the maximum -> error
+      expect_error(
+        spark_require_version(
+          "sc",
+          "3.0.0",
+          module = "feat",
+          required_max = "3.5.0"
+        ),
+        "feat is removed in Spark 3.5.0"
+      )
+    }
+  )
+})
+
+test_that("spark_require_version infers the module from the calling function", {
+  with_mocked_bindings(
+    spark_version = function(sc) numeric_version("2.0.0"),
+    .package = "sparklyr",
+    {
+      my_feature <- function() spark_require_version("sc", "3.0.0")
+      expect_error(my_feature(), "my_feature requires Spark 3.0.0 or higher")
+    }
+  )
+})
+
+test_that("is_required_spark compares versions for connections and jobjs", {
+  with_mocked_bindings(
+    spark_version = function(x) numeric_version("3.5.0"),
+    .package = "sparklyr",
+    {
+      sc <- structure(list(), class = "spark_connection")
+      expect_true(is_required_spark(sc, "3.0.0"))
+      expect_false(is_required_spark(sc, "4.0.0"))
+    }
+  )
+
+  # the spark_jobj method resolves the connection and delegates
+  with_mocked_bindings(
+    spark_connection = function(x) {
+      structure(list(), class = "spark_connection")
+    },
+    spark_version = function(x) numeric_version("3.5.0"),
+    .package = "sparklyr",
+    {
+      jobj <- structure(list(), class = "spark_jobj")
+      expect_true(is_required_spark(jobj, "3.0.0"))
+      expect_false(is_required_spark(jobj, "4.0.0"))
+    }
+  )
+})
+
+test_that("spark_param_deprecated warns with the default and explicit version", {
+  expect_warning(
+    spark_param_deprecated("foo"),
+    "'foo' parameter is deprecated in Spark 3.x"
+  )
+  expect_warning(
+    spark_param_deprecated("bar", version = "4.0"),
+    "'bar' parameter is deprecated in Spark 4.0"
+  )
+})
+
+test_that("package_version2 accepts strings and numeric_version objects", {
+  expect_identical(package_version2("1.2.3"), package_version("1.2.3"))
+  expect_identical(
+    package_version2(numeric_version("1.2.3")),
+    package_version("1.2.3")
+  )
+})

--- a/tests/testthat/test-spark_compile.R
+++ b/tests/testthat/test-spark_compile.R
@@ -106,6 +106,215 @@ test_that("make_version_filter('master') resolves duplicates to the newest", {
   expect_identical(filter(files), "java/spark-4.0.0/A.scala")
 })
 
+test_that("find_scalac() resolves a discovered compiler and skips dirs without one", {
+  loc <- withr::local_tempdir()
+  # a matching install that lacks the bin/scalac binary -> skipped -> errors
+  dir.create(file.path(loc, "scala-2.12.0"))
+  expect_error(find_scalac("2.12", locations = loc), "failed to discover scala")
+
+  # a matching install with the binary present -> returned
+  dir.create(file.path(loc, "scala-2.12.5", "bin"), recursive = TRUE)
+  scalac <- file.path(loc, "scala-2.12.5", "bin", "scalac")
+  file.create(scalac)
+  expect_identical(find_scalac("2.12", locations = loc), scalac)
+})
+
+test_that("scalac_default_locations() returns a single path on Windows", {
+  with_mocked_bindings(
+    os_is_windows = function() TRUE,
+    .package = "sparklyr",
+    expect_identical(scalac_default_locations(), path.expand("~/scala"))
+  )
+})
+
+test_that("get_scalac_version() parses the version out of scalac -version", {
+  with_mocked_bindings(
+    system = function(...) "Scala compiler version 2.12.20 -- Copyright",
+    .package = "base",
+    expect_identical(get_scalac_version("scalac"), "2.12.20")
+  )
+})
+
+test_that("find_jar() falls back to `which jar` when not under JAVA_HOME", {
+  fake_home <- withr::local_tempdir() # no bin/jar inside
+  with_mocked_bindings(
+    system2 = function(...) "/usr/bin/jar",
+    .package = "base",
+    withr::with_envvar(list(JAVA_HOME = fake_home), {
+      expect_identical(find_jar(), "/usr/bin/jar")
+    })
+  )
+})
+
+test_that("list_sparklyr_jars() finds the shipped sparklyr jars", {
+  jars <- list_sparklyr_jars()
+  expect_true(length(jars) > 0)
+  expect_true(all(grepl("sparklyr-.+\\.jar$", basename(jars))))
+})
+
+test_that("spark_gen_embedded_sources() writes the worker bootstrap line", {
+  out <- withr::local_tempfile(fileext = ".R")
+  spark_gen_embedded_sources(output = out)
+  lines <- readLines(out)
+  expect_match(
+    lines[[length(lines)]],
+    "do.call\\(spark_worker_main"
+  )
+})
+
+test_that("sparklyr_jar_verify_spark() reports installed and missing versions", {
+  # all specs already installed -> "Ok"
+  with_mocked_bindings(
+    spark_installed_versions = function() {
+      data.frame(spark = c("2.4.8", "3.0.3", "3.5.4", "4.0.0"))
+    },
+    .package = "sparklyr",
+    expect_message(sparklyr_jar_verify_spark(), "Ok")
+  )
+
+  # nothing installed, install = FALSE -> "Not found" without installing
+  with_mocked_bindings(
+    spark_installed_versions = function() data.frame(spark = character()),
+    .package = "sparklyr",
+    expect_message(sparklyr_jar_verify_spark(install = FALSE), "Not found")
+  )
+
+  # nothing installed, install = TRUE -> spark_install is invoked
+  installed <- character()
+  with_mocked_bindings(
+    spark_installed_versions = function() data.frame(spark = character()),
+    spark_install = function(version, ...) installed <<- c(installed, version),
+    .package = "sparklyr",
+    suppressMessages(sparklyr_jar_verify_spark(install = TRUE))
+  )
+  expect_setequal(installed, c("2.4.8", "3.0.3", "3.5.4", "4.0.0"))
+})
+
+test_that("spark_default_compilation_spec() builds one spec per jar target", {
+  with_mocked_bindings(
+    find_scalac = function(version, locations) "/path/to/scalac",
+    find_jar = function() "/path/to/jar",
+    spark_home_dir = function(version, ...) "/path/to/home",
+    .package = "sparklyr",
+    {
+      specs <- spark_default_compilation_spec(pkg = "sparklyr")
+      expect_length(specs, 4)
+      expect_setequal(
+        vapply(specs, function(x) x$spark_version, character(1)),
+        c("2.4.8", "3.0.3", "3.5.4", "4.0.0")
+      )
+      # the 4.0.0 spec carries the explicit jar name from the spec list
+      v4 <- Filter(function(x) x$spark_version == "4.0.0", specs)[[1]]
+      expect_identical(v4$jar_name, "sparklyr-master-2.13.jar")
+    }
+  )
+})
+
+test_that("compile_package_jars() handles explicit, master, and download specs", {
+  compiled <- list()
+  capture <- function(jar_name, spark_home, ...) {
+    compiled[[length(compiled) + 1]] <<- list(
+      jar_name = jar_name,
+      spark_home = spark_home
+    )
+    TRUE
+  }
+
+  # explicit spark_home -> straight to spark_compile, no install
+  with_mocked_bindings(
+    spark_compile = capture,
+    .package = "sparklyr",
+    compile_package_jars(
+      spec = list(spark_home = "/explicit", jar_name = "explicit.jar")
+    )
+  )
+  expect_identical(compiled[[1]]$spark_home, "/explicit")
+
+  # spark_version == "master" -> resolves home from spark_install_find
+  compiled <- list()
+  with_mocked_bindings(
+    spark_compile = capture,
+    spark_install_find = function(...) {
+      list(sparkVersion = "3.5.4", sparkVersionDir = "/installed/home")
+    },
+    .package = "sparklyr",
+    compile_package_jars(
+      spec = list(spark_version = "master", jar_name = "master.jar")
+    )
+  )
+  expect_identical(compiled[[1]]$spark_home, "/installed/home")
+
+  # spark_version set -> downloads + resolves home via spark_home_dir
+  compiled <- list()
+  with_mocked_bindings(
+    spark_compile = capture,
+    spark_install = function(...) invisible(NULL),
+    spark_home_dir = function(version, ...) "/downloaded/home",
+    .package = "sparklyr",
+    suppressMessages(compile_package_jars(
+      spec = list(spark_version = "3.5.4", jar_name = "dl.jar")
+    ))
+  )
+  expect_identical(compiled[[1]]$spark_home, "/downloaded/home")
+
+  # no args -> falls back to spark_default_compilation_spec
+  compiled <- list()
+  with_mocked_bindings(
+    spark_compile = capture,
+    spark_default_compilation_spec = function(...) {
+      list(list(spark_home = "/default", jar_name = "default.jar"))
+    },
+    .package = "sparklyr",
+    compile_package_jars()
+  )
+  expect_identical(compiled[[1]]$jar_name, "default.jar")
+})
+
+test_that("download_scalac() downloads + extracts, and skips existing files", {
+  # tgz path (non-Windows): downloads and untars each compiler
+  dest <- withr::local_tempdir()
+  downloaded <- character()
+  with_mocked_bindings(
+    download_file = function(url, destfile, ...) {
+      downloaded <<- c(downloaded, basename(destfile))
+      file.create(destfile)
+      0L
+    },
+    untar = function(...) 0L,
+    .package = "sparklyr",
+    suppressMessages(download_scalac(dest_path = dest))
+  )
+  expect_length(downloaded, 3)
+
+  # second run with files already present -> nothing re-downloaded
+  downloaded <- character()
+  with_mocked_bindings(
+    download_file = function(url, destfile, ...) {
+      downloaded <<- c(downloaded, basename(destfile))
+      0L
+    },
+    untar = function(...) 0L,
+    .package = "sparklyr",
+    suppressMessages(download_scalac(dest_path = dest))
+  )
+  expect_length(downloaded, 0)
+
+  # zip path (Windows): unzip instead of untar
+  dest_win <- withr::local_tempdir()
+  unzipped <- 0
+  with_mocked_bindings(
+    os_is_windows = function() TRUE,
+    download_file = function(url, destfile, ...) {
+      file.create(destfile)
+      0L
+    },
+    unzip = function(...) unzipped <<- unzipped + 1,
+    .package = "sparklyr",
+    suppressMessages(download_scalac(dest_path = dest_win))
+  )
+  expect_equal(unzipped, 3)
+})
+
 # ---- End-to-end jar build (intentionally skipped: too slow for CI) -----------
 
 test_that("jar file is created", {

--- a/tests/testthat/test-spark_compile.R
+++ b/tests/testthat/test-spark_compile.R
@@ -401,7 +401,10 @@ test_that("compile, then update + verify embedded sources (real build)", {
   )
   withr::with_dir(
     bad_dir,
-    system2("jar", c("uf", tampered, file.path("sparklyr", "embedded_sources.R")))
+    system2(
+      "jar",
+      c("uf", tampered, file.path("sparklyr", "embedded_sources.R"))
+    )
   )
   with_mocked_bindings(
     list_sparklyr_jars = function() tampered,

--- a/tests/testthat/test-spark_compile.R
+++ b/tests/testthat/test-spark_compile.R
@@ -315,67 +315,98 @@ test_that("download_scalac() downloads + extracts, and skips existing files", {
   expect_equal(unzipped, 3)
 })
 
-# ---- End-to-end jar build (intentionally skipped: too slow for CI) -----------
+# ---- End-to-end build -> update -> verify (real toolchain) ------------------
+# One real build covers the shell-out core of three functions instead of mocking
+# them away (which would assert nothing about whether they work):
+#   * spark_compile()                  -- real scalac + jar, ONE spec only
+#   * spark_update_embedded_sources()  -- real `jar uf` to refresh embedded srcs
+#   * spark_verify_embedded_sources()  -- real `jar xf` + diffobj, BOTH branches
+# We only fake *scope* -- sparklyr_jar_spec_list() (build one spec, not four) and
+# list_sparklyr_jars() (point at the throwaway jar, never inst/java) -- never the
+# work. CI installs Scala via download_scalac() and a Spark version for the
+# suite, so the toolchain is present; locally it skips unless a matching scalac
+# is installed. The repo is left byte-identical (jar in a tempdir, working dir
+# and java/embedded_sources.R restored). It can't assert the jar loads into a
+# JVM -- that's covered downstream by the suite running against the built jars.
+# No skip_on_cran(): the find_scalac() guard already skips when the toolchain is
+# absent (as on CRAN), and skip_on_cran() would also hide this from local covr.
 
-test_that("jar file is created", {
-  skip(
-    "This test takes too long to run, and is not necessary for daily operations"
+test_that("compile, then update + verify embedded sources (real build)", {
+  skip_on_livy()
+  skip_on_arrow_devel()
+
+  installed <- spark_installed_versions()
+  skip_if(nrow(installed) == 0, "no Spark installed")
+
+  # Prefer a 3.x install (Scala 2.12, the canonical build target); otherwise
+  # take the first install and pair Scala by Spark major version.
+  prefer <- grep("^3[.]", installed$spark)
+  sv <- installed$spark[[if (length(prefer)) prefer[[1]] else 1L]]
+  major <- as.integer(strsplit(sv, "[.]")[[1]][[1]])
+  scala_v <- switch(as.character(major), "2" = "2.11", "3" = "2.12", "2.13")
+
+  scalac <- tryCatch(find_scalac(scala_v), error = function(e) NULL)
+  skip_if(is.null(scalac), sprintf("scala %s compiler not installed", scala_v))
+
+  # spark_gen_embedded_sources() reads dir("R"), and update() rewrites
+  # java/embedded_sources.R -- run from the package root and restore that file so
+  # the repo is left untouched.
+  root <- rprojroot::find_package_root_file()
+  withr::local_dir(root)
+  embedded_src <- file.path("java", "embedded_sources.R")
+  original_embedded <- readLines(embedded_src)
+  withr::defer(writeLines(original_embedded, embedded_src))
+
+  # Build the jar into a tempdir, NOT the package's inst/java.
+  withr::local_envvar(R_SPARKINSTALL_COMPILE_JAR_PATH = withr::local_tempdir())
+
+  # 1. Build one jar for real (mock only the spec list, down to one entry).
+  with_mocked_bindings(
+    sparklyr_jar_spec_list = function() list(list(spark = sv, scala = scala_v)),
+    {
+      spec <- spark_default_compilation_spec()
+      expect_length(spec, 1)
+      suppressMessages(compile_package_jars(spec = spec))
+    },
+    .package = "sparklyr"
   )
-  skip_connection("spark_compile")
+  built <- normalizePath(list.files(
+    Sys.getenv("R_SPARKINSTALL_COMPILE_JAR_PATH"),
+    pattern = "[.]jar$",
+    full.names = TRUE
+  ))
+  expect_length(built, 1)
 
-  number_of_jars <- 4
-
-  jar_folder <- path.expand("~/testjar")
-
-  s_version <- testthat_spark_env_version()
-
-  major_v <- strsplit(s_version, "\\.")[[1]][[1]]
-
-  if (major_v >= 1) {
-    scala_v <- "2.10"
-  }
-  if (major_v >= 2) {
-    scala_v <- "2.11"
-  }
-  if (major_v >= 3) {
-    scala_v <- "2.12"
-  }
-
-  jar_name <- sprintf("%s-%s-test.jar", s_version, scala_v)
-
-  scs <- spark_compilation_spec(
-    spark_version = s_version,
-    scalac_path = find_scalac(scala_v),
-    jar_name = jar_name,
-    jar_path = find_jar(),
-    scala_filter = make_version_filter(s_version)
+  # 2. update() refreshes the jar's embedded sources; 3. verify() then finds them
+  #    in sync. Mock list_sparklyr_jars() so both touch ONLY the throwaway jar.
+  with_mocked_bindings(
+    list_sparklyr_jars = function() built,
+    {
+      suppressMessages(spark_update_embedded_sources())
+      expect_no_error(suppressMessages(spark_verify_embedded_sources()))
+    },
+    .package = "sparklyr"
   )
 
-  Sys.setenv("R_SPARKINSTALL_COMPILE_JAR_PATH" = jar_folder)
-
-  compile_package_jars(scs)
-
-  expect_true(
-    file.exists(file.path(jar_folder, jar_name))
+  # 4. verify()'s failure branch, made deterministic by tampering a copy (rather
+  #    than relying on the shipped jars being stale): splice bogus sources in and
+  #    confirm verify stops.
+  tampered <- file.path(withr::local_tempdir(), basename(built))
+  file.copy(built, tampered)
+  bad_dir <- withr::local_tempdir()
+  dir.create(file.path(bad_dir, "sparklyr"))
+  writeLines(
+    "# not the real embedded sources",
+    file.path(bad_dir, "sparklyr", "embedded_sources.R")
   )
-
-  expect_message(
-    sparklyr_jar_verify_spark(),
-    "- Spark version"
+  withr::with_dir(
+    bad_dir,
+    system2("jar", c("uf", tampered, file.path("sparklyr", "embedded_sources.R")))
   )
-
-  expect_length(
-    sparklyr_jar_spec_list(),
-    number_of_jars
-  )
-
-  expect_silent(
-    download_scalac()
-  )
-
-  expect_is(
-    make_version_filter(s_version),
-    "function"
+  with_mocked_bindings(
+    list_sparklyr_jars = function() tampered,
+    expect_error(suppressMessages(spark_verify_embedded_sources())),
+    .package = "sparklyr"
   )
 })
 

--- a/tests/testthat/test-spark_compile.R
+++ b/tests/testthat/test-spark_compile.R
@@ -7,10 +7,24 @@
 #   3. The end-to-end jar build test, which is intentionally skipped: it is too
 #      slow for routine/CI runs. Retained for manual/local use, not deleted.
 
+# The build/download helpers are intentionally chatty (scalac download progress,
+# `cat()` status lines, and the full diffobj diff on a verify mismatch). None of
+# that is useful as test output, so run those calls through here to swallow
+# stdout, stderr, and messages while still letting errors propagate.
+quiet_run <- function(expr) {
+  invisible(utils::capture.output(
+    utils::capture.output(
+      suppressMessages(suppressWarnings(expr)),
+      type = "message"
+    ),
+    type = "output"
+  ))
+}
+
 test_that("'find_scalac' can find scala version", {
   skip_on_livy()
   skip_on_arrow_devel()
-  ensure_download_scalac(scalac_download_path)
+  quiet_run(ensure_download_scalac(scalac_download_path))
   expect_true(scalac_is_available("2.11", scalac_download_path))
   expect_true(scalac_is_available("2.12", scalac_download_path))
 })
@@ -18,7 +32,7 @@ test_that("'find_scalac' can find scala version", {
 test_that("'spark_default_compilation_spec' can create default specification", {
   skip_on_livy()
   skip_on_arrow_devel()
-  ensure_download_scalac(scalac_download_path)
+  quiet_run(ensure_download_scalac(scalac_download_path))
   dp <- list.files(scalac_download_path)
   expect_gte(length(dp), 3)
 })
@@ -290,7 +304,7 @@ test_that("download_scalac() downloads + extracts, and skips existing files", {
     },
     untar = function(...) 0L,
     .package = "sparklyr",
-    suppressMessages(download_scalac(dest_path = dest))
+    quiet_run(download_scalac(dest_path = dest))
   )
   expect_length(downloaded, 3)
 
@@ -303,7 +317,7 @@ test_that("download_scalac() downloads + extracts, and skips existing files", {
     },
     untar = function(...) 0L,
     .package = "sparklyr",
-    suppressMessages(download_scalac(dest_path = dest))
+    quiet_run(download_scalac(dest_path = dest))
   )
   expect_length(downloaded, 0)
 
@@ -318,7 +332,7 @@ test_that("download_scalac() downloads + extracts, and skips existing files", {
     },
     unzip = function(...) unzipped <<- unzipped + 1,
     .package = "sparklyr",
-    suppressMessages(download_scalac(dest_path = dest_win))
+    quiet_run(download_scalac(dest_path = dest_win))
   )
   expect_equal(unzipped, 3)
 })
@@ -386,7 +400,7 @@ test_that("compile, then update + verify embedded sources (real build)", {
     {
       spec <- spark_default_compilation_spec()
       expect_length(spec, 1)
-      suppressMessages(compile_package_jars(spec = spec))
+      quiet_run(compile_package_jars(spec = spec))
     },
     .package = "sparklyr"
   )
@@ -402,8 +416,8 @@ test_that("compile, then update + verify embedded sources (real build)", {
   with_mocked_bindings(
     list_sparklyr_jars = function() built,
     {
-      suppressMessages(spark_update_embedded_sources())
-      expect_no_error(suppressMessages(spark_verify_embedded_sources()))
+      quiet_run(spark_update_embedded_sources())
+      expect_no_error(quiet_run(spark_verify_embedded_sources()))
     },
     .package = "sparklyr"
   )
@@ -428,7 +442,7 @@ test_that("compile, then update + verify embedded sources (real build)", {
   )
   with_mocked_bindings(
     list_sparklyr_jars = function() tampered,
-    expect_error(suppressMessages(spark_verify_embedded_sources())),
+    expect_error(quiet_run(spark_verify_embedded_sources())),
     .package = "sparklyr"
   )
 })

--- a/tests/testthat/test-spark_compile.R
+++ b/tests/testthat/test-spark_compile.R
@@ -147,6 +147,14 @@ test_that("find_jar() falls back to `which jar` when not under JAVA_HOME", {
 })
 
 test_that("list_sparklyr_jars() finds the shipped sparklyr jars", {
+  # list_sparklyr_jars() looks in <root>/inst/java, which only exists in a
+  # source checkout -- on an installed package inst/java is relocated to
+  # <pkg>/java. This (build-time) function is only ever called from source, so
+  # skip when the source layout isn't present (installed-package test run).
+  skip_if(
+    !dir.exists(file.path(rprojroot::find_package_root_file(), "inst", "java")),
+    "package source tree not available (installed-package test run)"
+  )
   jars <- list_sparklyr_jars()
   expect_true(length(jars) > 0)
   expect_true(all(grepl("sparklyr-.+\\.jar$", basename(jars))))
@@ -348,10 +356,22 @@ test_that("compile, then update + verify embedded sources (real build)", {
   scalac <- tryCatch(find_scalac(scala_v), error = function(e) NULL)
   skip_if(is.null(scalac), sprintf("scala %s compiler not installed", scala_v))
 
+  # This test compiles from and rewrites the package *source* tree
+  # (java/*.scala, R/worker*.R, java/embedded_sources.R). Those files are not
+  # present when the suite runs against an *installed* package (covr::codecov,
+  # R CMD check), so skip there. It still runs from a source checkout -- e.g.
+  # local `coverage_lines()`, which measures from the repo root even though it
+  # sets CODE_COVERAGE=true (so skip_covr() would wrongly skip it there too).
+  root <- rprojroot::find_package_root_file()
+  embedded_src <- file.path(root, "java", "embedded_sources.R")
+  skip_if(
+    !file.exists(embedded_src),
+    "package source tree not available (installed-package test run)"
+  )
+
   # spark_gen_embedded_sources() reads dir("R"), and update() rewrites
   # java/embedded_sources.R -- run from the package root and restore that file so
   # the repo is left untouched.
-  root <- rprojroot::find_package_root_file()
   withr::local_dir(root)
   embedded_src <- file.path("java", "embedded_sources.R")
   original_embedded <- readLines(embedded_src)

--- a/tests/testthat/test-spark_context.R
+++ b/tests/testthat/test-spark_context.R
@@ -27,6 +27,13 @@ test_that("configuration getter works", {
   }
 })
 
+test_that("spark_session_config() rejects unsupported value types", {
+  expect_error(
+    spark_session_config(sc, "spark.sql.shuffle.partitions.local", list(1)),
+    "logical, integer .long., and character"
+  )
+})
+
 test_that("spark_adaptive_query_execution() works", {
   spark_session_config(sc, "spark.sql.adaptive.enabled", FALSE)
   spark_adaptive_query_execution(sc, TRUE)
@@ -171,6 +178,220 @@ test_that("spark_auto_broadcast_join_threshold() works", {
       unlist(),
     as.character(threshold)
   )
+})
+
+test_that("spark_coalesce_min_num_partitions() works", {
+  test_requires_version("3.0.0")
+
+  spark_session_config(sc, "spark.sql.adaptive.enabled", FALSE)
+  spark_session_config(
+    sc,
+    "spark.sql.adaptive.coalescePartitions.enabled",
+    FALSE
+  )
+
+  num_partitions <- 4
+  spark_coalesce_min_num_partitions(sc, num_partitions)
+
+  expect_equal(
+    spark_session_config(
+      sc,
+      "spark.sql.adaptive.coalescePartitions.minPartitionNum"
+    ) %>%
+      unname() %>%
+      unlist(),
+    as.character(num_partitions)
+  )
+  expect_equal(
+    spark_coalesce_min_num_partitions(sc) %>% unname() %>% unlist(),
+    as.character(num_partitions)
+  )
+})
+
+test_that("spark_context_config() and hive_context_config() return named entries", {
+  cfg <- spark_context_config(sc)
+  expect_type(cfg, "list")
+  expect_true(length(names(cfg)) > 0)
+
+  hive_cfg <- hive_context_config(sc)
+  expect_type(hive_cfg, "list")
+})
+
+test_that("spark_version() returns a cleaned, cached numeric_version", {
+  v <- spark_version(sc)
+  expect_s3_class(v, "numeric_version")
+  # second call should hit the cached branch and return the same value
+  expect_identical(spark_version(sc), v)
+})
+
+# ---- Connection-free helpers ----------------------------------------------
+
+test_that("spark_version_clean() strips suffixes and trailing dots", {
+  expect_equal(spark_version_clean("2.4.8"), "2.4.8")
+  expect_equal(spark_version_clean("3.0.0-preview"), "3.0.0")
+  expect_equal(spark_version_clean("3.5.0-SNAPSHOT"), "3.5.0")
+})
+
+test_that("spark_version_from_home_version() reads the env variable", {
+  withr::with_envvar(c(SPARK_HOME_VERSION = "3.2.1"), {
+    expect_equal(spark_version_from_home_version(), "3.2.1")
+  })
+  withr::with_envvar(c(SPARK_HOME_VERSION = ""), {
+    expect_null(spark_version_from_home_version())
+  })
+})
+
+test_that("spark_version_from_home() resolves through each detection strategy", {
+  empty_home <- withr::local_tempdir()
+
+  # useDefault: a supplied default short-circuits everything
+  expect_equal(
+    spark_version_from_home(empty_home, default = "3.1.2"),
+    "3.1.2"
+  )
+
+  withr::with_envvar(c(SPARK_HOME_VERSION = ""), {
+    # useEnvironmentVariable
+    withr::with_envvar(c(SPARK_HOME_VERSION = "3.2.1"), {
+      expect_equal(spark_version_from_home(empty_home), "3.2.1")
+    })
+
+    # useReleaseFile
+    release_home <- withr::local_tempdir()
+    writeLines(
+      "Spark 3.3.0 built for Hadoop 3.3.4",
+      file.path(release_home, "RELEASE")
+    )
+    expect_equal(spark_version_from_home(release_home), "3.3.0")
+
+    # useAssemblies
+    asm_home <- withr::local_tempdir()
+    dir.create(file.path(asm_home, "lib"))
+    file.create(file.path(
+      asm_home,
+      "lib",
+      "spark-assembly-2.4.0-hadoop2.7.jar"
+    ))
+    expect_equal(spark_version_from_home(asm_home), "2.4.0")
+
+    # useSparkSubmit: reached only when the file-based strategies find nothing
+    with_mocked_bindings(
+      system2 = function(...) c("Welcome", "   version 3.4.1", "Using"),
+      .package = "base",
+      expect_equal(spark_version_from_home(empty_home), "3.4.1")
+    )
+
+    # all strategies exhausted -> error
+    with_mocked_bindings(
+      system2 = function(...) c("no version here"),
+      .package = "base",
+      expect_error(
+        spark_version_from_home(empty_home),
+        "Failed to detect version"
+      )
+    )
+  })
+})
+
+test_that("spark_version_latest() picks the newest matching version", {
+  with_mocked_bindings(
+    spark_available_versions = function(...) {
+      data.frame(spark = c("3.4.1", "4.0.0", "3.5.0"))
+    },
+    .package = "sparklyr",
+    {
+      expect_equal(spark_version_latest(), "4.0.0")
+      expect_equal(spark_version_latest("3.5"), "3.5.0")
+      # no match falls back to the overall latest
+      expect_equal(spark_version_latest("2.1"), "4.0.0")
+    }
+  )
+})
+
+test_that("spark_home_dir() returns the install dir or NULL on failure", {
+  with_mocked_bindings(
+    spark_install_find = function(...) list(sparkVersionDir = "/opt/spark"),
+    .package = "sparklyr",
+    expect_equal(spark_home_dir(version = "3.5.0"), "/opt/spark")
+  )
+
+  with_mocked_bindings(
+    spark_install_find = function(...) stop("not found"),
+    .package = "sparklyr",
+    expect_null(spark_home_dir(version = "9.9.9"))
+  )
+})
+
+test_that("spark_home_set() sets SPARK_HOME, with and without a path", {
+  withr::local_envvar(c(SPARK_HOME = ""))
+
+  spark_home_set(file.path("custom", "spark"))
+  expect_equal(Sys.getenv("SPARK_HOME"), file.path("custom", "spark"))
+
+  # NULL path -> looks up an install and emits the verbose message
+  with_mocked_bindings(
+    spark_install_find = function(...) list(sparkVersionDir = "/opt/latest"),
+    .package = "sparklyr",
+    expect_message(spark_home_set(), "Setting SPARK_HOME")
+  )
+  expect_equal(Sys.getenv("SPARK_HOME"), "/opt/latest")
+})
+
+# ---- Session-level variable accessors (genv_*) ----------------------------
+
+test_that("genv_* getters and setters round-trip session state", {
+  restore <- function(getter, setter) {
+    orig <- getter()
+    withr::defer(setter(orig), envir = parent.frame())
+  }
+
+  restore(genv_get_last_error, genv_set_last_error)
+  genv_set_last_error("boom")
+  expect_equal(genv_get_last_error(), "boom")
+
+  restore(genv_get_extension_packages, genv_set_extension_packages)
+  genv_set_extension_packages(c("pkgA", "pkgB"))
+  expect_equal(genv_get_extension_packages(), c("pkgA", "pkgB"))
+
+  restore(genv_get_spark_versions_json, genv_set_spark_versions_json)
+  genv_set_spark_versions_json(list(a = 1))
+  expect_equal(genv_get_spark_versions_json(), list(a = 1))
+
+  restore(genv_get_param_mapping_s_to_r, genv_set_param_mapping_s_to_r)
+  genv_set_param_mapping_s_to_r(list(s = "r"))
+  expect_equal(genv_get_param_mapping_s_to_r(), list(s = "r"))
+
+  restore(genv_get_param_mapping_r_to_s, genv_set_param_mapping_r_to_s)
+  genv_set_param_mapping_r_to_s(list(r = "s"))
+  expect_equal(genv_get_param_mapping_r_to_s(), list(r = "s"))
+
+  restore(genv_get_ml_class_mapping, genv_set_ml_class_mapping)
+  genv_set_ml_class_mapping(list(cls = "ml"))
+  expect_equal(genv_get_ml_class_mapping(), list(cls = "ml"))
+
+  restore(genv_get_ml_package_mapping, genv_set_ml_package_mapping)
+  genv_set_ml_package_mapping(list(cls = "pkg"))
+  expect_equal(genv_get_ml_package_mapping(), list(cls = "pkg"))
+
+  restore(genv_get_avail_package_cache, genv_set_avail_package_cache)
+  genv_set_avail_package_cache(list(cache = TRUE))
+  expect_equal(genv_get_avail_package_cache(), list(cache = TRUE))
+})
+
+test_that("genv do_spark options helpers set, read, and clear", {
+  orig <- genv_get_do_spark()
+  withr::defer(genv_set_do_spark(orig))
+
+  genv_set_do_spark(list(name = "session", options = new.env()))
+  expect_equal(genv_get_do_spark("name"), "session")
+  expect_type(genv_get_do_spark(), "list")
+
+  genv_set_do_spark_options(c("opt1", "opt2"), list(10L, 20L))
+  expect_equal(get("opt1", envir = .gls_env$do_spark$options), 10L)
+  expect_equal(get("opt2", envir = .gls_env$do_spark$options), 20L)
+
+  genv_clear_do_spark_options()
+  expect_length(ls(.gls_env$do_spark$options), 0)
 })
 
 test_clear_cache()

--- a/tests/testthat/test-spark_ide.R
+++ b/tests/testthat/test-spark_ide.R
@@ -1,0 +1,426 @@
+# A fake Spark connection so the RStudio IDE helpers can be exercised without a
+# live Spark session. All Spark/DBI calls the helpers make are mocked per-test.
+fake_ide_scon <- function(
+  master = "local[8]",
+  app_name = "sparklyr",
+  method = "shell"
+) {
+  structure(
+    list(master = master, app_name = app_name, method = method),
+    class = "spark_connection"
+  )
+}
+
+# ------------------------------ browse_url ------------------------------------
+test_that("browse_url does nothing for an empty url", {
+  expect_invisible(browse_url(""))
+})
+
+test_that("browse_url opens a non-empty url when rstudioapi is unavailable", {
+  opened <- NULL
+  with_mocked_bindings(
+    isAvailable = function(...) FALSE,
+    .package = "rstudioapi",
+    with_mocked_bindings(
+      browseURL = function(url, ...) opened <<- url,
+      .package = "utils",
+      browse_url("http://localhost:4040")
+    )
+  )
+  expect_equal(opened, "http://localhost:4040")
+})
+
+test_that("browse_url translates local urls when rstudioapi is available", {
+  opened <- NULL
+  with_mocked_bindings(
+    isAvailable = function(...) TRUE,
+    translateLocalUrl = function(url, absolute = FALSE) {
+      paste0("translated:", url)
+    },
+    .package = "rstudioapi",
+    with_mocked_bindings(
+      browseURL = function(url, ...) opened <<- url,
+      .package = "utils",
+      browse_url("http://localhost:4040")
+    )
+  )
+  # a trailing slash is appended before translation
+  expect_equal(opened, "translated:http://localhost:4040/")
+})
+
+# ------------------------------ host helpers ----------------------------------
+test_that("to_host_display collapses a local[n] master to 'local'", {
+  expect_equal(to_host_display(fake_ide_scon(master = "local[8]")), "local")
+  expect_equal(to_host_display(fake_ide_scon(master = "local[*]")), "local")
+  expect_equal(
+    to_host_display(fake_ide_scon(master = "spark://host:7077")),
+    "spark://host:7077"
+  )
+})
+
+test_that("to_host combines the host display and the app name", {
+  sc <- fake_ide_scon(master = "local[2]", app_name = "myapp")
+  expect_equal(to_host(sc), "local - myapp")
+})
+
+test_that("external_viewer prefers the observer, falling back to the viewer", {
+  obs <- list(id = "observer")
+  vw <- list(id = "viewer")
+
+  withr::local_options(connectionObserver = obs, connectionViewer = vw)
+  expect_identical(external_viewer(), obs)
+
+  withr::local_options(connectionObserver = NULL)
+  expect_identical(external_viewer(), vw)
+
+  withr::local_options(connectionViewer = NULL)
+  expect_null(external_viewer())
+})
+
+# ----------------------------- DB object helpers ------------------------------
+test_that("connection_list_tables returns sorted names, optionally with type", {
+  sc <- fake_ide_scon()
+  with_mocked_bindings(
+    connection_is_open = function(sc) TRUE,
+    dbListTables = function(con) c("beta", "alpha"),
+    .package = "sparklyr",
+    {
+      expect_equal(connection_list_tables(sc), c("alpha", "beta"))
+
+      df <- connection_list_tables(sc, includeType = TRUE)
+      expect_equal(df$name, c("alpha", "beta"))
+      expect_equal(df$type, c("table", "table"))
+    }
+  )
+})
+
+test_that("connection_list_tables handles a null connection", {
+  expect_equal(connection_list_tables(NULL), character())
+
+  df <- connection_list_tables(NULL, includeType = TRUE)
+  expect_equal(nrow(df), 0L)
+  expect_equal(names(df), c("name", "type"))
+})
+
+test_that("connection_list_columns describes the columns of a table", {
+  sc <- fake_ide_scon()
+  with_mocked_bindings(
+    connection_is_open = function(sc) TRUE,
+    dbGetQuery = function(con, sql) {
+      data.frame(a = 1L, b = "x", stringsAsFactors = FALSE)
+    },
+    .package = "sparklyr",
+    {
+      cols <- connection_list_columns(sc, table = "t")
+      expect_equal(cols$name, c("a", "b"))
+      expect_type(cols$type, "character")
+    }
+  )
+})
+
+test_that("connection_list_columns returns NULL for a closed connection", {
+  with_mocked_bindings(
+    connection_is_open = function(sc) FALSE,
+    .package = "sparklyr",
+    expect_null(connection_list_columns(fake_ide_scon(), table = "t"))
+  )
+})
+
+test_that("connection_preview_table runs a limited query", {
+  sc <- fake_ide_scon()
+  captured <- NULL
+  with_mocked_bindings(
+    connection_is_open = function(sc) TRUE,
+    dbGetQuery = function(con, sql) {
+      captured <<- sql
+      data.frame(x = 1)
+    },
+    .package = "sparklyr",
+    {
+      res <- connection_preview_table(sc, "mytable", 10)
+      expect_equal(res, data.frame(x = 1))
+      expect_match(captured, "SELECT \\* FROM mytable LIMIT 10")
+    }
+  )
+})
+
+test_that("connection_preview_table returns NULL for a closed connection", {
+  with_mocked_bindings(
+    connection_is_open = function(sc) FALSE,
+    .package = "sparklyr",
+    expect_null(connection_preview_table(fake_ide_scon(), "t", 5))
+  )
+})
+
+test_that("spark_ide_objects/columns/preview dispatch to the DB helpers", {
+  sc <- fake_ide_scon()
+  with_mocked_bindings(
+    connection_is_open = function(sc) TRUE,
+    dbListTables = function(con) "tbl",
+    dbGetQuery = function(con, sql) data.frame(a = 1L),
+    .package = "sparklyr",
+    {
+      objs <- spark_ide_objects(
+        sc,
+        catalog = NULL,
+        schema = NULL,
+        name = NULL,
+        type = NULL
+      )
+      expect_equal(objs$name, "tbl")
+
+      cols <- spark_ide_columns(sc, table = "tbl")
+      expect_equal(cols$name, "a")
+
+      prev <- spark_ide_preview(sc, rowLimit = 5, table = "tbl")
+      expect_equal(prev, data.frame(a = 1L))
+    }
+  )
+})
+
+# --------------------------- connection lifecycle -----------------------------
+test_that("spark_ide_connection_closed notifies the external viewer", {
+  closed <- NULL
+  obs <- list(
+    connectionClosed = function(type, host) {
+      closed <<- list(type = type, host = host)
+    }
+  )
+  withr::local_options(connectionObserver = obs, connectionViewer = NULL)
+
+  spark_ide_connection_closed(fake_ide_scon(
+    master = "local[1]",
+    app_name = "a"
+  ))
+  expect_equal(closed$type, "Spark")
+  expect_equal(closed$host, "local - a")
+})
+
+test_that("spark_ide_connection_closed is a no-op without a viewer", {
+  withr::local_options(connectionObserver = NULL, connectionViewer = NULL)
+  expect_null(spark_ide_connection_closed(fake_ide_scon()))
+})
+
+test_that("spark_ide_connection_updated notifies the viewer for normal tables", {
+  updated <- NULL
+  obs <- list(
+    connectionUpdated = function(type, host, hint) updated <<- hint
+  )
+  withr::local_options(connectionObserver = obs, connectionViewer = NULL)
+
+  spark_ide_connection_updated(fake_ide_scon(), hint = "mytable")
+  expect_equal(updated, "mytable")
+})
+
+test_that("spark_ide_connection_updated skips sparklyr temp tables", {
+  updated <- NULL
+  obs <- list(
+    connectionUpdated = function(type, host, hint) updated <<- hint
+  )
+  withr::local_options(connectionObserver = obs, connectionViewer = NULL)
+
+  spark_ide_connection_updated(fake_ide_scon(), hint = "sparklyr_tmp_123")
+  expect_null(updated)
+})
+
+# ------------------------------- action buttons -------------------------------
+test_that("spark_ide_actions builds actions for a yarn shell connection", {
+  sc <- fake_ide_scon(method = "shell")
+  edited <- NULL
+  browsed <- character()
+  with_mocked_bindings(
+    spark_web = function(sc, ...) "http://web",
+    spark_connection_is_yarn = function(sc) TRUE,
+    spark_connection_yarn_ui = function(sc) "http://yarn",
+    spark_log = function(sc, ...) c("line1", "line2"),
+    spark_log_file = function(sc) "spark.log",
+    browse_url = function(url) browsed <<- c(browsed, url),
+    # `file.edit` is imported via `import(utils)`, so it lives in the sparklyr
+    # namespace and must be mocked there (not in "utils").
+    file.edit = function(...) edited <<- ..1,
+    .package = "sparklyr",
+    {
+      actions <- spark_ide_connection_actions(sc)
+      expect_setequal(names(actions), c("Spark", "YARN", "Log", "Help"))
+
+      # invoke the callbacks so their bodies are covered too
+      actions$Spark$callback()
+      actions$YARN$callback()
+      actions$Log$callback()
+      expect_equal(edited, "spark.log")
+      expect_true("http://web" %in% browsed)
+      expect_true("http://yarn" %in% browsed)
+    }
+  )
+})
+
+test_that("spark_ide_actions builds livy actions without a web url", {
+  sc <- fake_ide_scon(method = "livy")
+  sc$master <- "http://livy"
+  sc$sessionId <- "42"
+  visited <- character()
+  with_mocked_bindings(
+    spark_web = function(sc, ...) "",
+    spark_connection_is_yarn = function(sc) FALSE,
+    spark_log = function(sc, ...) "line1",
+    .package = "sparklyr",
+    {
+      with_mocked_bindings(
+        browseURL = function(url, ...) visited <<- c(visited, url),
+        .package = "utils",
+        {
+          actions <- spark_ide_connection_actions(sc)
+          expect_false("Spark" %in% names(actions))
+          expect_setequal(names(actions), c("Livy", "Log", "Help"))
+
+          actions$Livy$callback()
+          actions$Log$callback()
+          actions$Help$callback()
+          expect_true(any(grepl("/ui$", visited)))
+          expect_true(any(grepl("/log$", visited)))
+        }
+      )
+    }
+  )
+})
+
+test_that("spark_ide_actions SQL action uses a global `sc` and previews a table", {
+  sc <- fake_ide_scon(method = "shell")
+  opened <- NULL
+
+  # simulate the RStudio API helper being available in the search path; the
+  # callback captures it via get(".rs.api.documentNew")
+  assign(
+    ".rs.api.documentNew",
+    function(type, contents, ...) opened <<- contents,
+    envir = globalenv()
+  )
+  withr::defer(rm(".rs.api.documentNew", envir = globalenv()))
+
+  with_mocked_bindings(
+    spark_web = function(sc, ...) "",
+    spark_connection_is_yarn = function(sc) FALSE,
+    spark_log = function(sc, ...) "x",
+    dbListTables = function(con) "fruits",
+    .package = "sparklyr",
+    {
+      actions <- spark_ide_actions(sc)
+      expect_true("SQL" %in% names(actions))
+
+      # a global `sc` identical to the connection -> used directly as the name
+      assign("sc", sc, envir = globalenv())
+      withr::defer(rm("sc", envir = globalenv()))
+
+      actions$SQL$callback()
+      expect_match(opened, "-- !preview conn=sc")
+      expect_match(opened, "SELECT \\* FROM `fruits`")
+    }
+  )
+})
+
+test_that("spark_ide_actions SQL action resolves the connection variable name", {
+  sc <- fake_ide_scon(method = "shell")
+  opened <- NULL
+  assign(
+    ".rs.api.documentNew",
+    function(type, contents, ...) opened <<- contents,
+    envir = globalenv()
+  )
+  withr::defer(rm(".rs.api.documentNew", envir = globalenv()))
+
+  with_mocked_bindings(
+    spark_web = function(sc, ...) "",
+    spark_connection_is_yarn = function(sc) FALSE,
+    spark_log = function(sc, ...) "x",
+    dbListTables = function(con) character(),
+    .package = "sparklyr",
+    {
+      sql <- spark_ide_actions(sc)$SQL$callback
+
+      # no global `sc`, but another variable holds the connection
+      assign("my_spark", sc, envir = globalenv())
+      sql()
+      expect_match(opened, "-- !preview conn=my_spark")
+      expect_match(opened, "SELECT 1") # no tables -> fallback query
+      rm("my_spark", envir = globalenv())
+
+      # connection not held by any global variable -> empty name
+      sql()
+      expect_match(opened, "-- !preview conn=")
+    }
+  )
+})
+
+# ----------------- connection registration (live Spark) -----------------------
+# `on_connection_opened()` hands a bundle of callbacks to the RStudio IDE. We
+# register a capturing fake observer/viewer, then invoke those callbacks
+# ourselves against a real Spark connection to confirm the wiring works.
+test_that("on_connection_opened registers v1.1 observer callbacks (live)", {
+  sc <- testthat_spark_connection()
+  testthat_tbl("mtcars")
+
+  captured <- NULL
+  withr::local_options(
+    connectionObserver = list(connectionOpened = function(...) {
+      captured <<- list(...)
+    }),
+    connectionViewer = NULL
+  )
+
+  spark_ide_connection_open(
+    sc,
+    env = globalenv(),
+    connect_call = "spark_connect(master = 'local')"
+  )
+
+  expect_equal(captured$type, "Spark")
+  expect_type(captured$listObjectTypes(), "list")
+
+  objs <- captured$listObjects(catalog = NULL, schema = NULL)
+  expect_true("mtcars" %in% objs$name)
+
+  cols <- captured$listColumns(table = "mtcars")
+  expect_true("mpg" %in% cols$name)
+
+  expect_equal(nrow(captured$previewObject(rowLimit = 5, table = "mtcars")), 5L)
+
+  # invoke disconnect with spark_disconnect mocked so the shared session survives
+  disconnected <- FALSE
+  with_mocked_bindings(
+    spark_disconnect = function(sc, ...) disconnected <<- TRUE,
+    .package = "sparklyr",
+    captured$disconnect()
+  )
+  expect_true(disconnected)
+})
+
+test_that("on_connection_opened registers a v1.0 viewer finder (live)", {
+  sc <- testthat_spark_connection()
+
+  captured <- NULL
+  withr::local_options(
+    connectionObserver = NULL,
+    connectionViewer = list(connectionOpened = function(...) {
+      captured <<- list(...)
+    })
+  )
+
+  spark_ide_connection_open(
+    sc,
+    env = globalenv(),
+    connect_call = "spark_connect()"
+  )
+
+  expect_equal(captured$type, "Spark")
+
+  # finder locates the variable holding a matching, open connection
+  e <- new.env()
+  assign("my_sc", sc, envir = e)
+  assign("not_a_conn", 42, envir = e)
+  expect_equal(captured$finder(e, to_host(sc)), "my_sc")
+
+  # no matching connection in scope -> NULL
+  empty <- new.env()
+  assign("x", 1, envir = empty)
+  expect_null(captured$finder(empty, "no-such-host"))
+})

--- a/tests/testthat/test-spark_sql.R
+++ b/tests/testthat/test-spark_sql.R
@@ -1,0 +1,46 @@
+skip_connection("spark_sql")
+skip_on_livy()
+skip_on_arrow_devel()
+
+sc <- testthat_spark_connection()
+
+test_that("spark_db_desc / spark_sql_query_explain describe and explain", {
+  desc <- spark_db_desc(sc)
+  expect_match(desc, "spark connection")
+  expect_match(desc, "master=")
+
+  explained <- spark_sql_query_explain(sc, dbplyr::sql("SELECT 1"))
+  expect_match(as.character(explained), "EXPLAIN")
+})
+
+test_that("spark_sql_query_save builds a CREATE OR REPLACE VIEW statement", {
+  saved <- spark_sql_query_save(sc, dbplyr::sql("SELECT 1"), "v_tmp_sql", temporary = TRUE)
+  expect_match(as.character(saved), "CREATE OR REPLACE")
+  expect_match(as.character(saved), "VIEW")
+})
+
+test_that("apply_config sets prefixed key/value pairs on a Spark object", {
+  conf <- invoke_new(sc, "org.apache.spark.SparkConf")
+  out <- apply_config(conf, list(spark.x = TRUE, spark.y = "z"), "set", "")
+  expect_true(inherits(out, "spark_jobj"))
+  # empty params returns the object unchanged
+  expect_identical(apply_config(conf, list(), "set", ""), conf)
+})
+
+test_that("spark_db_query_fields / spark_sql_query_fields read column names", {
+  tbl <- sdf_copy_to(sc, data.frame(a = 1:3, b = c("x", "y", "z")), "sql_flds", overwrite = TRUE)
+  flds <- spark_db_query_fields(sc, dbplyr::sql("SELECT * FROM sql_flds"))
+  expect_setequal(flds, c("a", "b"))
+
+  qf <- spark_sql_query_fields(sc, dbplyr::sql("SELECT * FROM sql_flds"))
+  expect_match(as.character(qf), "a")
+})
+
+test_that("spark_db_analyze runs ANALYZE on a non-temporary table", {
+  # persisted table so SHOW TABLES reports isTemporary = FALSE
+  DBI::dbExecute(sc, "CREATE TABLE IF NOT EXISTS anz_tbl AS SELECT 1 AS a")
+  on.exit(DBI::dbExecute(sc, "DROP TABLE IF EXISTS anz_tbl"), add = TRUE)
+  expect_error(spark_db_analyze(sc, "anz_tbl"), NA)
+})
+
+test_clear_cache()

--- a/tests/testthat/test-spark_sql.R
+++ b/tests/testthat/test-spark_sql.R
@@ -50,7 +50,9 @@ test_that("spark_db_analyze runs ANALYZE on a non-temporary table", {
   # persisted table so SHOW TABLES reports isTemporary = FALSE
   DBI::dbExecute(sc, "CREATE TABLE IF NOT EXISTS anz_tbl AS SELECT 1 AS a")
   on.exit(DBI::dbExecute(sc, "DROP TABLE IF EXISTS anz_tbl"), add = TRUE)
-  expect_error(spark_db_analyze(sc, "anz_tbl"), NA)
+  # dbplyr's sql_table_analyze() hook passes the table as an identifier; a bare
+  # string would be escaped as a string literal ('anz_tbl') and fail to parse.
+  expect_error(spark_db_analyze(sc, dbplyr::ident("anz_tbl")), NA)
 })
 
 test_clear_cache()

--- a/tests/testthat/test-spark_sql.R
+++ b/tests/testthat/test-spark_sql.R
@@ -14,7 +14,12 @@ test_that("spark_db_desc / spark_sql_query_explain describe and explain", {
 })
 
 test_that("spark_sql_query_save builds a CREATE OR REPLACE VIEW statement", {
-  saved <- spark_sql_query_save(sc, dbplyr::sql("SELECT 1"), "v_tmp_sql", temporary = TRUE)
+  saved <- spark_sql_query_save(
+    sc,
+    dbplyr::sql("SELECT 1"),
+    "v_tmp_sql",
+    temporary = TRUE
+  )
   expect_match(as.character(saved), "CREATE OR REPLACE")
   expect_match(as.character(saved), "VIEW")
 })
@@ -28,7 +33,12 @@ test_that("apply_config sets prefixed key/value pairs on a Spark object", {
 })
 
 test_that("spark_db_query_fields / spark_sql_query_fields read column names", {
-  tbl <- sdf_copy_to(sc, data.frame(a = 1:3, b = c("x", "y", "z")), "sql_flds", overwrite = TRUE)
+  tbl <- sdf_copy_to(
+    sc,
+    data.frame(a = 1:3, b = c("x", "y", "z")),
+    "sql_flds",
+    overwrite = TRUE
+  )
   flds <- spark_db_query_fields(sc, dbplyr::sql("SELECT * FROM sql_flds"))
   expect_setequal(flds, c("a", "b"))
 

--- a/tests/testthat/test-spark_submit.R
+++ b/tests/testthat/test-spark_submit.R
@@ -82,4 +82,186 @@ test_that("sparklyr.nested can query nested columns", {
   )
 })
 
+test_that("spark_submit() defaults verbose + console logging for batch jobs", {
+  # with neither option set, spark_submit turns both on before connecting;
+  # shell_connection is mocked so no real batch job is submitted
+  withr::local_options(sparklyr.verbose = NULL, sparklyr.log.console = NULL)
+  src <- withr::local_tempfile(fileext = ".R")
+  writeLines("1", src)
+
+  captured <- NULL
+  with_mocked_bindings(
+    shell_connection = function(..., config, batch) {
+      captured <<- config
+      NULL
+    },
+    .package = "sparklyr",
+    spark_submit(master = "local", file = src, config = list())
+  )
+  expect_true(captured$sparklyr.verbose)
+  expect_true(captured$sparklyr.log.console)
+})
+
+# ---- Extension registration + dependency resolution (connection-free) ------
+
+test_that("spark_dependency() constructs a dependency object", {
+  dep <- spark_dependency(
+    jars = "a.jar",
+    packages = "g:a:1",
+    repositories = "r"
+  )
+  expect_s3_class(dep, "spark_dependency")
+  expect_equal(dep$jars, "a.jar")
+  expect_equal(dep$packages, "g:a:1")
+  expect_equal(dep$repositories, "r")
+  expect_null(dep$initializer)
+})
+
+test_that("register_extension appends to registered_extensions", {
+  orig <- registered_extensions()
+  withr::defer(genv_set_extension_packages(orig))
+
+  genv_set_extension_packages(character())
+  register_extension("pkgA")
+  register_extension(c("pkgB", "pkgC"))
+  expect_equal(registered_extensions(), c("pkgA", "pkgB", "pkgC"))
+})
+
+test_that("spark_dependencies() returns sparklyr's own jar dependency", {
+  dep <- spark_dependencies(numeric_version("3.5.0"), "2.12")
+  expect_s3_class(dep, "spark_dependency")
+  expect_match(dep$jars, "sparklyr-3.5-2.12.jar")
+})
+
+test_that("spark_dependencies_from_extension finds and calls the extension", {
+  # sparklyr itself exports a spark_dependencies() function
+  dep <- spark_dependencies_from_extension(
+    numeric_version("3.5.0"),
+    numeric_version("2.12"),
+    "sparklyr"
+  )
+  expect_type(dep, "list")
+  expect_s3_class(dep[[1]], "spark_dependency")
+})
+
+test_that("spark_dependencies_from_extension errors when the function is missing", {
+  expect_error(
+    spark_dependencies_from_extension(
+      numeric_version("3.5.0"),
+      numeric_version("2.12"),
+      "stats"
+    ),
+    "spark_dependencies function not found"
+  )
+})
+
+test_that("spark_dependencies_from_extensions derives scala version by spark version", {
+  # the scala-version derivation runs before the (empty) extension loop, so
+  # these three calls cover the <2.0 / <3.0 / else branches
+  for (v in c("1.6.0", "2.4.0", "3.5.0")) {
+    res <- spark_dependencies_from_extensions(
+      numeric_version(v),
+      scala_version = NULL,
+      extensions = list(),
+      config = list()
+    )
+    expect_named(
+      res,
+      c(
+        "jars",
+        "packages",
+        "initializers",
+        "catalog_jars",
+        "repositories",
+        "dbplyr_sql_variant"
+      )
+    )
+  }
+})
+
+test_that("spark_dependencies_from_extensions merges jars, packages, catalog and sql variants", {
+  fake_dep <- structure(
+    list(
+      jars = "ext.jar",
+      packages = "org:ext:1.0",
+      initializer = NULL,
+      catalog = "ext.jar",
+      repositories = "myrepo",
+      dbplyr_sql_variant = list(
+        scalar = list(my_fn = "translation"),
+        aggregate = list(),
+        window = list()
+      )
+    ),
+    class = "spark_dependency"
+  )
+
+  with_mocked_bindings(
+    spark_dependencies_from_extension = function(...) list(fake_dep),
+    .package = "sparklyr",
+    {
+      # character catalog template ("%s" present)
+      res <- spark_dependencies_from_extensions(
+        numeric_version("3.5.0"),
+        "2.12",
+        extensions = list("ext"),
+        config = list(sparklyr.extensions.catalog = "/catalog/%s")
+      )
+      expect_true("ext.jar" %in% res$jars)
+      expect_true("org:ext:1.0" %in% res$packages)
+      expect_equal(res$dbplyr_sql_variant$scalar$my_fn, "translation")
+      expect_true(any(grepl("ext.jar", res$catalog_jars)))
+
+      # default catalog (TRUE) exercises the "%s"-append + non-character branch
+      res2 <- spark_dependencies_from_extensions(
+        numeric_version("3.5.0"),
+        "2.12",
+        extensions = list("ext"),
+        config = list()
+      )
+      expect_true(length(res2$catalog_jars) > 0)
+    }
+  )
+})
+
+# ---- sparklyr_jar_path ------------------------------------------------------
+
+test_that("sparklyr_jar_path resolves shipped jars across versions", {
+  # exact match
+  expect_match(
+    sparklyr_jar_path(numeric_version("3.5.0"), "2.12"),
+    "sparklyr-3.5-2.12.jar"
+  )
+  # Spark 4.x maps to the master jar
+  expect_match(
+    sparklyr_jar_path(numeric_version("4.0.0")),
+    "sparklyr-master-2.13.jar"
+  )
+  # scala default (<3.0 -> 2.12) + closest-version fallback (2.4-2.12 absent)
+  expect_match(
+    sparklyr_jar_path(numeric_version("2.4.0")),
+    "sparklyr-2.4-2.11.jar"
+  )
+  # in-between version falls back to the closest lower shipped jar
+  expect_match(
+    sparklyr_jar_path(numeric_version("3.2.0"), "2.99"),
+    "sparklyr-3.0-2.12.jar"
+  )
+})
+
+test_that("sparklyr_jar_path honors the .test_on_spark_master override", {
+  withr::defer(
+    if (exists(".test_on_spark_master", envir = .GlobalEnv)) {
+      rm(".test_on_spark_master", envir = .GlobalEnv)
+    }
+  )
+  assign(".test_on_spark_master", TRUE, envir = .GlobalEnv)
+
+  # no exact jar for scala 2.99 -> override picks the master jar
+  expect_match(
+    sparklyr_jar_path(numeric_version("2.4.0"), "2.99"),
+    "sparklyr-master-2.13.jar"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-stream.R
+++ b/tests/testthat/test-stream.R
@@ -242,6 +242,8 @@ test_stream("Adds watermark step", {
 })
 
 test_stream("stream can read and write from Delta", {
+  # Capped at Spark 4: delta is not supported on Spark 4.x in sparklyr yet
+  # (DeltaCatalog class missing). See plan "Issues to open".
   test_requires_version("3.0.0", max_version = "4")
 
   delta_in <- file.path(base_dir, "delta-in")

--- a/tests/testthat/test-stream.R
+++ b/tests/testthat/test-stream.R
@@ -242,8 +242,8 @@ test_stream("Adds watermark step", {
 })
 
 test_stream("stream can read and write from Delta", {
-  # Capped at Spark 4: delta is not supported on Spark 4.x in sparklyr yet
-  # (DeltaCatalog class missing). See plan "Issues to open".
+  # Capped at Spark 4.1+: no compatible delta-spark build exists yet — delta-spark
+  # 4.0.0 (the latest) throws NoSuchMethodError on Spark 4.1. Works on Spark 3.x/4.0.
   test_requires_version("3.0.0", max_version = "4")
 
   delta_in <- file.path(base_dir, "delta-in")

--- a/tests/testthat/test-stream.R
+++ b/tests/testthat/test-stream.R
@@ -456,4 +456,179 @@ test_that("stream_register() stores the stream when jobs API is unavailable", {
   )
 })
 
+test_that("stream_register() wires up the RStudio jobs API when available", {
+  # When the jobs API is available, register attaches a job handle, records
+  # initial progress, and builds the info/stop job actions. We mock the jobs API
+  # (its helpers live behind `# nocov` in jobs_api.R) and then invoke the
+  # captured actions to cover their bodies.
+  state_env <- new.env()
+  fake_sc <- structure(
+    list(
+      state = state_env,
+      config = list(),
+      method = "shell",
+      master = "local",
+      app_name = "sparklyr"
+    ),
+    class = "spark_connection"
+  )
+  fake_stream <- structure(list(), class = "spark_stream")
+
+  captured_actions <- NULL
+  progress <- list()
+  console <- NULL
+
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_jobj_id = function(x) "jobj-job",
+    spark_config_logical = function(config, name, default) TRUE,
+    rstudio_jobs_api_available = function() TRUE,
+    rstudio_jobs_api = function() {
+      list(
+        add_job_progress = function(job, units) {
+          progress[[length(progress) + 1]] <<- units
+        },
+        remove_job = function(job) NULL
+      )
+    },
+    rstudio_jobs_api_new = function(name, units, actions) {
+      captured_actions <<- actions
+      "job-handle"
+    },
+    stream_id = function(x) "stream-1",
+    stream_stop = function(stream) "stopped",
+    sendToConsole = function(...) console <<- paste0(...),
+    .package = "sparklyr",
+    {
+      result <- stream_register(fake_stream)
+      expect_equal(result$job, "job-handle")
+      expect_equal(progress[[1]], 10L)
+
+      # exercise the captured job actions; info() searches the global env for the
+      # connection, so make it findable there.
+      assign("the_sc", fake_sc, envir = .GlobalEnv)
+      withr::defer(rm("the_sc", envir = .GlobalEnv))
+      captured_actions$info("id")
+      expect_match(console, "stream_find")
+      expect_equal(captured_actions$stop("id"), "stopped")
+    }
+  )
+})
+
+test_that("stream_stop()/stream_unregister() drive the jobs API for a job-backed stream", {
+  state_env <- new.env()
+  state_env$streams <- new.env()
+  fake_sc <- structure(list(state = state_env), class = "spark_connection")
+  fake_stream <- structure(list(job = "job-handle"), class = "spark_stream")
+  state_env$streams[["jobj-j"]] <- fake_stream
+
+  removed <- FALSE
+  progress <- NULL
+
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_jobj_id = function(x) "jobj-j",
+    rstudio_jobs_api = function() {
+      list(
+        add_job_progress = function(job, units) progress <<- units,
+        remove_job = function(job) removed <<- TRUE
+      )
+    },
+    invoke = function(jobj, method, ...) {
+      if (method == "stop") "stopped" else NULL
+    },
+    .package = "sparklyr",
+    {
+      result <- stream_stop(fake_stream)
+      expect_equal(result, "stopped")
+      expect_equal(progress, 100L) # add_job_progress(job, 100L)
+      expect_true(removed) # stream_unregister() -> remove_job
+      expect_null(state_env$streams[["jobj-j"]])
+    }
+  )
+})
+
+test_that("stream_validate() returns the stream when there is no exception", {
+  fake_sc <- structure(list(config = list()), class = "spark_connection")
+  fake_stream <- structure(list(), class = "spark_stream")
+
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_config_value = function(config, name, default) 0,
+    stream_status = function(stream) list(message = "waiting for data"),
+    invoke = function(jobj, method, ...) {
+      if (method == "isEmpty") TRUE else "jobj"
+    },
+    .package = "sparklyr",
+    expect_identical(stream_validate(fake_stream), fake_stream)
+  )
+})
+
+test_that("stream_validate() raises the exception cause (getMessage then toString)", {
+  fake_sc <- structure(list(config = list()), class = "spark_connection")
+  fake_stream <- structure(list(), class = "spark_stream")
+
+  make_invoke <- function(message_value) {
+    function(jobj, method, ...) {
+      switch(
+        method,
+        isEmpty = FALSE,
+        getMessage = message_value,
+        toString = "boom-tostring",
+        "jobj"
+      )
+    }
+  }
+
+  # cause has a message -> getMessage path
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_config_value = function(config, name, default) 0,
+    stream_status = function(stream) list(message = "waiting"),
+    invoke = make_invoke("boom-message"),
+    .package = "sparklyr",
+    expect_error(stream_validate(fake_stream), "boom-message")
+  )
+
+  # cause message is NULL -> toString fallback
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_config_value = function(config, name, default) 0,
+    stream_status = function(stream) list(message = "waiting"),
+    invoke = make_invoke(NULL),
+    .package = "sparklyr",
+    expect_error(stream_validate(fake_stream), "boom-tostring")
+  )
+})
+
+test_that("stream_generate_test() iterates and reschedules through later", {
+  out <- withr::local_tempdir()
+
+  # Run the scheduled work synchronously so the recursive generator drains in
+  # one call. The generator fetches `later` via get(asNamespace("later")), which
+  # picks up this mocked binding.
+  with_mocked_bindings(
+    later = function(fn, delay = 0) fn(),
+    .package = "later",
+    stream_generate_test(
+      df = data.frame(x = 1:2),
+      path = out,
+      distribution = c(5, 1),
+      iterations = 3,
+      interval = 0
+    )
+  )
+
+  expect_true(all(file.exists(file.path(out, paste0("stream_", 1:3, ".csv")))))
+})
+
+test_that("stream_lag() errors on a non-streaming dataframe", {
+  mtcars_tbl <- testthat_tbl("mtcars")
+
+  expect_error(
+    stream_lag(mtcars_tbl, cols = c(prev = mpg ~ 1)),
+    "expected a streaming dataframe"
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-stream.R
+++ b/tests/testthat/test-stream.R
@@ -261,4 +261,197 @@ test_that("to_milliseconds() responds as expected", {
   expect_error(to_milliseconds(list()))
 })
 
+test_that("to_milliseconds() converts every supported unit", {
+  # milliseconds
+  expect_equal(to_milliseconds("5ms"), 5)
+  expect_equal(to_milliseconds("5 msec"), 5)
+  expect_equal(to_milliseconds("5 msecs"), 5)
+  expect_equal(to_milliseconds("5 millisecond"), 5)
+  expect_equal(to_milliseconds("5 milliseconds"), 5)
+  # seconds
+  expect_equal(to_milliseconds("2s"), 2000)
+  expect_equal(to_milliseconds("2 sec"), 2000)
+  expect_equal(to_milliseconds("2 secs"), 2000)
+  expect_equal(to_milliseconds("2 seconds"), 2000)
+  # minutes
+  expect_equal(to_milliseconds("1m"), 60000)
+  expect_equal(to_milliseconds("1 min"), 60000)
+  expect_equal(to_milliseconds("1 mins"), 60000)
+  expect_equal(to_milliseconds("1 minute"), 60000)
+  expect_equal(to_milliseconds("1 minutes"), 60000)
+  # hours
+  expect_equal(to_milliseconds("1h"), 3600000)
+  expect_equal(to_milliseconds("1 hr"), 3600000)
+  expect_equal(to_milliseconds("1 hrs"), 3600000)
+  expect_equal(to_milliseconds("1 hour"), 3600000)
+  expect_equal(to_milliseconds("1 hours"), 3600000)
+  # days
+  expect_equal(to_milliseconds("1d"), 86400000)
+  expect_equal(to_milliseconds("1 day"), 86400000)
+  expect_equal(to_milliseconds("1 days"), 86400000)
+})
+
+test_that("to_milliseconds() rejects unknown units and malformed strings", {
+  # well-formed number + unrecognized unit
+  expect_error(
+    to_milliseconds("5 fortnights"),
+    "not a valid time duration"
+  )
+  # string that does not match the <number><unit> pattern at all
+  expect_error(
+    to_milliseconds("abc"),
+    "not a valid time duration"
+  )
+})
+
+test_that("stream_trigger_interval() builds the expected structure", {
+  default <- stream_trigger_interval()
+  expect_s3_class(default, "stream_trigger_interval")
+  expect_equal(default$interval, 1000)
+
+  custom <- stream_trigger_interval(interval = 250)
+  expect_s3_class(custom, "stream_trigger_interval")
+  expect_equal(custom$interval, 250)
+})
+
+test_that("stream_trigger_continuous() builds the expected structure", {
+  default <- stream_trigger_continuous()
+  expect_s3_class(default, "stream_trigger_continuous")
+  expect_equal(default$interval, 5000)
+
+  custom <- stream_trigger_continuous(checkpoint = 2000)
+  expect_s3_class(custom, "stream_trigger_continuous")
+  expect_equal(custom$interval, 2000)
+})
+
+test_that("stream_trigger_create() dispatches per trigger class", {
+  # Capture the static method requested by each trigger type.
+  captured <- list()
+  with_mocked_bindings(
+    invoke_static = function(sc, class, method, value) {
+      captured <<- list(class = class, method = method, value = value)
+      "trigger"
+    },
+    .package = "sparklyr",
+    {
+      stream_trigger_create(stream_trigger_interval(interval = 750), sc = "sc")
+      expect_equal(
+        captured$class,
+        "org.apache.spark.sql.streaming.Trigger"
+      )
+      expect_equal(captured$method, "ProcessingTime")
+      expect_identical(captured$value, 750L)
+
+      stream_trigger_create(
+        stream_trigger_continuous(checkpoint = 1500),
+        sc = "sc"
+      )
+      expect_equal(captured$method, "Continuous")
+      expect_identical(captured$value, 1500L)
+    }
+  )
+})
+
+test_that("stream_generate_test() errors when 'later' is unavailable", {
+  with_mocked_bindings(
+    installed.packages = function(...) matrix("not-later"),
+    .package = "sparklyr",
+    expect_error(stream_generate_test(), "later")
+  )
+})
+
+test_that("stream_generate_test() coerces input and creates the path", {
+  out <- tempfile("stream_gen_")
+  on.exit(unlink(out, recursive = TRUE), add = TRUE)
+
+  # A single iteration with a non-data-frame input exercises the coercion and
+  # directory-creation branches and writes exactly one file synchronously.
+  expect_silent(
+    stream_generate_test(
+      df = 1:5,
+      path = out,
+      distribution = 3,
+      iterations = 1,
+      interval = 0
+    )
+  )
+  expect_true(dir.exists(out))
+  expect_true(file.exists(file.path(out, "stream_1.csv")))
+})
+
+test_that("stream_stop() stops the stream and unregisters it", {
+  # No live Spark: fake stream object carrying its own jobj id, with every
+  # Spark interaction mocked. Covers the no-job branch of stream_stop() plus
+  # stream_unregister() removing the stream from connection state.
+  state_env <- new.env()
+  state_env$streams <- new.env()
+  fake_sc <- structure(list(state = state_env), class = "spark_connection")
+  fake_stream <- structure(list(), class = "spark_stream")
+  state_env$streams[["jobj-1"]] <- fake_stream
+
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_jobj_id = function(x) "jobj-1",
+    invoke = function(jobj, method, ...) {
+      if (method == "stop") "stopped" else NULL
+    },
+    .package = "sparklyr",
+    {
+      result <- stream_stop(fake_stream)
+      expect_equal(result, "stopped")
+      # stream removed from the connection's stream registry
+      expect_null(state_env$streams[["jobj-1"]])
+    }
+  )
+})
+
+test_that("stream_unregister() returns early on NULL input", {
+  expect_null(stream_unregister(NULL))
+})
+
+test_that("stream_unregister_all() unregisters each tracked stream", {
+  # streams are stored as a named list on the connection state (not an env);
+  # stream_unregister() removes entries with `[[id]] <- NULL`
+  state_env <- new.env()
+  state_env$streams <- list(
+    "jobj-a" = structure(list(id = "jobj-a"), class = "spark_stream"),
+    "jobj-b" = structure(list(id = "jobj-b"), class = "spark_stream")
+  )
+  fake_sc <- structure(list(state = state_env), class = "spark_connection")
+
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_jobj_id = function(x) x$id,
+    .package = "sparklyr",
+    {
+      stream_unregister_all(fake_sc)
+      expect_equal(length(state_env$streams), 0)
+    }
+  )
+})
+
+test_that("stream_register() stores the stream when jobs API is unavailable", {
+  # When the RStudio jobs API is not available, register simply records the
+  # stream in connection state and returns it unchanged.
+  state_env <- new.env()
+  fake_sc <- structure(
+    list(state = state_env, config = list()),
+    class = "spark_connection"
+  )
+  fake_stream <- structure(list(), class = "spark_stream")
+
+  with_mocked_bindings(
+    spark_connection = function(x, ...) fake_sc,
+    spark_jobj_id = function(x) "jobj-reg",
+    rstudio_jobs_api_available = function() FALSE,
+    spark_config_logical = function(config, name, default) default,
+    .package = "sparklyr",
+    {
+      result <- stream_register(fake_stream)
+      expect_identical(result, fake_stream)
+      expect_identical(state_env$streams[["jobj-reg"]], fake_stream)
+    }
+  )
+})
+
 test_clear_cache()

--- a/tests/testthat/test-stream_data.R
+++ b/tests/testthat/test-stream_data.R
@@ -1,0 +1,166 @@
+skip_connection("stream_data")
+skip_on_livy()
+skip_on_arrow_devel()
+skip_databricks_connect()
+test_requires("dplyr")
+
+sc <- testthat_spark_connection()
+
+test_stream("csv stream round-trips through read and write", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_csv(iris_out)
+
+  stream_stop(stream)
+  expect_is(stream_id(stream), "character")
+})
+
+test_stream("stream_read_csv honors an explicit column schema", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  # passing a named character vector exercises spark_data_build_types() in
+  # stream_read_generic() instead of the schema-inference path
+  stream <- stream_read_csv(
+    sc,
+    get_test_data_path("weekdays"),
+    columns = c(day = "character", x = "integer")
+  )
+
+  expect_true(sdf_is_streaming(spark_dataframe(stream)))
+  expect_setequal(colnames(stream), c("day", "x"))
+})
+
+test_stream("stream_read_csv accepts a Spark schema object as columns", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  # a spark_jobj passed as `columns` is used verbatim as the schema, exercising
+  # the `"spark_jobj" %in% class(columns)` branch of stream_read_generic()
+  schema <- stream_read_csv(sc, get_test_data_path("weekdays")) %>%
+    spark_dataframe() %>%
+    invoke("schema")
+
+  stream <- stream_read_csv(
+    sc,
+    get_test_data_path("weekdays"),
+    columns = schema
+  )
+
+  expect_true(sdf_is_streaming(spark_dataframe(stream)))
+  expect_setequal(colnames(stream), c("day", "x"))
+})
+
+test_stream("text stream round-trips through read and write", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  stream <- stream_read_text(sc, iris_in) %>%
+    stream_write_text(iris_out)
+
+  stream_stop(stream)
+  succeed()
+})
+
+test_stream("json stream round-trips through read and write", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  json_in <- file.path(base_dir, "json-in")
+
+  stream_in <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_json(json_in)
+
+  stream_out <- stream_read_json(sc, json_in) %>%
+    stream_write_csv(iris_out)
+
+  stream_stop(stream_in)
+  stream_stop(stream_out)
+  succeed()
+})
+
+test_stream("parquet stream round-trips through read and write", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  parquet_in <- file.path(base_dir, "parquet-in")
+
+  stream_in <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_parquet(parquet_in)
+
+  stream_out <- stream_read_parquet(sc, parquet_in) %>%
+    stream_write_csv(iris_out, delimiter = "|")
+
+  stream_stop(stream_in)
+  stream_stop(stream_out)
+  succeed()
+})
+
+test_stream("orc stream round-trips through read and write", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  orc_in <- file.path(base_dir, "orc-in")
+
+  stream_in <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_orc(orc_in)
+
+  stream_out <- stream_read_orc(sc, orc_in) %>%
+    stream_write_csv(iris_out)
+
+  stream_stop(stream_in)
+  stream_stop(stream_out)
+  succeed()
+})
+
+test_stream("stream_write_console writes a stream to the console", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_console()
+
+  stream_stop(stream)
+  succeed()
+})
+
+test_stream("stream_write_memory accepts an explicit output mode", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_memory("iris_explicit", mode = "append")
+
+  stream_stop(stream)
+  succeed()
+})
+
+test_stream("stream_write_memory infers the output mode when omitted", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  # omitting `mode` exercises the UnsupportedOperationChecker branch that
+  # auto-selects between "append" and "complete"
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_memory("iris_inferred")
+
+  stream_stop(stream)
+  succeed()
+})
+
+test_stream("stream write partitions output by the given columns", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_csv(iris_out, partition_by = "Species")
+
+  stream_stop(stream)
+
+  sub_dirs <- dir(iris_out_dir)
+  expect_true("Species=setosa" %in% sub_dirs)
+})
+
+test_stream("stream_write_*() rejects a non-streaming DataFrame", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+
+  static <- sdf_len(sc, 10)
+
+  expect_error(
+    stream_write_csv(static, iris_out),
+    "requires streaming context"
+  )
+})
+
+test_clear_cache()

--- a/tests/testthat/test-stream_data.R
+++ b/tests/testthat/test-stream_data.R
@@ -163,4 +163,22 @@ test_stream("stream_write_*() rejects a non-streaming DataFrame", {
   )
 })
 
+test_stream("stream_read_socket creates a streaming source", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+  # the socket source is created lazily (no server is contacted until start)
+  s <- stream_read_socket(
+    sc,
+    options = list(host = "localhost", port = "9999")
+  )
+  expect_true(inherits(s, "tbl_spark"))
+})
+
+test_stream("stream_write_table + stream_read_table round-trip a table", {
+  test_requires_version("2.0.0", "Spark streaming requires Spark 2.0 or above")
+  stream <- stream_read_csv(sc, iris_in, delimiter = ";") %>%
+    stream_write_table("sd_stream_tbl", format = "parquet")
+  stream_stop(stream)
+  expect_true(inherits(stream_read_table(sc, "sd_stream_tbl"), "tbl_spark"))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-stream_ui.R
+++ b/tests/testthat/test-stream_ui.R
@@ -1,0 +1,199 @@
+# ---------------------------------------------------------------------------
+# Local tests for the streaming Shiny/r2d3 UI helpers. No live Spark or browser:
+# the Spark invocations are mocked and the Shiny server logic is driven with
+# shiny::testServer (runGadget is mocked so nothing actually launches).
+# ---------------------------------------------------------------------------
+
+skip_if_not_installed("shiny")
+skip_if_not_installed("r2d3")
+
+fake_progress <- function() {
+  list(
+    sources = list(description = "source-1"),
+    sink = list(description = "sink-1"),
+    timestamp = "2024-01-01T00:00:00.000Z",
+    inputRowsPerSecond = 5.7,
+    processedRowsPerSecond = 3.2
+  )
+}
+
+test_that("stream_package_check() errors only for missing packages", {
+  expect_silent(stream_package_check("shiny"))
+  expect_error(
+    stream_package_check("a_package_that_does_not_exist_123"),
+    "package is required"
+  )
+})
+
+test_that("stream_progress() returns NULL or parsed JSON", {
+  # lastProgress is NULL -> NULL
+  with_mocked_bindings(
+    invoke = function(jobj, method, ...) NULL,
+    .package = "sparklyr",
+    expect_null(stream_progress("stream"))
+  )
+
+  # lastProgress present -> toString parsed from JSON
+  with_mocked_bindings(
+    invoke = function(jobj, method, ...) {
+      if (method == "lastProgress") {
+        "lp"
+      } else {
+        '{"timestamp":"t","inputRowsPerSecond":5}'
+      }
+    },
+    .package = "sparklyr",
+    {
+      progress <- stream_progress("stream")
+      expect_equal(progress$timestamp, "t")
+      expect_equal(progress$inputRowsPerSecond, 5)
+    }
+  )
+})
+
+test_that("stream_stats() seeds and accumulates per-interval stats", {
+  with_mocked_bindings(
+    stream_progress = function(stream) fake_progress(),
+    .package = "sparklyr",
+    {
+      stats <- stream_stats("stream")
+      expect_equal(stats$sources, "source-1")
+      expect_equal(stats$sink, "sink-1")
+      expect_length(stats$stats, 1)
+      # floored numeric rates
+      expect_equal(stats$stats[[1]]$rps[["in"]], 5)
+      expect_equal(stats$stats[[1]]$rps[["out"]], 3)
+
+      # a second collection appends to the existing stats
+      stats <- stream_stats("stream", stats)
+      expect_length(stats$stats, 2)
+    }
+  )
+
+  # non-numeric rates fall back to 0
+  with_mocked_bindings(
+    stream_progress = function(stream) {
+      p <- fake_progress()
+      p$inputRowsPerSecond <- NULL
+      p$processedRowsPerSecond <- NULL
+      p
+    },
+    .package = "sparklyr",
+    {
+      stats <- stream_stats("stream")
+      expect_equal(stats$stats[[1]]$rps[["in"]], 0)
+      expect_equal(stats$stats[[1]]$rps[["out"]], 0)
+    }
+  )
+})
+
+test_that("stream_render() collects over an interval then builds an r2d3 widget", {
+  rendered <- NULL
+  with_mocked_bindings(
+    stream_stats = function(stream, stats = list()) {
+      list(sources = "s", sink = "k", stats = list(list(timestamp = "t")))
+    },
+    .package = "sparklyr",
+    with_mocked_bindings(
+      Sys.sleep = function(...) invisible(NULL),
+      .package = "base",
+      with_mocked_bindings(
+        r2d3 = function(data, ...) {
+          rendered <<- data
+          structure(list(), class = "r2d3_fake")
+        },
+        .package = "r2d3",
+        {
+          # collect branch (stats = NULL): loops `collect` times
+          widget <- stream_render(stream = "x", collect = 2)
+          expect_s3_class(widget, "r2d3_fake")
+          expect_equal(rendered$sources, list("s"))
+
+          # stats supplied: skips the collection loop
+          widget2 <- stream_render(
+            stats = list(
+              sources = "s",
+              sink = "k",
+              stats = list()
+            )
+          )
+          expect_s3_class(widget2, "r2d3_fake")
+        }
+      )
+    )
+  )
+})
+
+test_that("stream_view() builds the UI and a server that pushes progress", {
+  captured <- new.env()
+
+  with_mocked_bindings(
+    stream_progress = function(stream) fake_progress(),
+    .package = "sparklyr",
+    with_mocked_bindings(
+      runGadget = function(ui, server) {
+        captured$ui <- ui
+        captured$server <- server
+        invisible(NULL)
+      },
+      .package = "shiny",
+      {
+        result <- stream_view("fake-stream")
+        expect_identical(result, "fake-stream")
+      }
+    )
+  )
+
+  expect_false(is.null(captured$ui))
+  expect_true(is.function(captured$server))
+
+  # drive the captured server to exercise the render + observe logic
+  messages <- list()
+  with_mocked_bindings(
+    stream_progress = function(stream) fake_progress(),
+    .package = "sparklyr",
+    shiny::testServer(captured$server, {
+      session$flushReact()
+      expect_false(is.null(output$plot))
+    })
+  )
+})
+
+test_that("reactiveSpark() requires shiny and polls a stream when present", {
+  # shiny not installed -> stop
+  with_mocked_bindings(
+    installed.packages = function(...) matrix("not-shiny"),
+    .package = "sparklyr",
+    expect_error(reactiveSpark("x"), "shiny")
+  )
+
+  # full path: every Spark call mocked, polled through testServer
+  fake_df <- data.frame(value = 1L)
+  with_mocked_bindings(
+    spark_connection = function(x) "sc",
+    spark_dataframe = function(x) "sdf",
+    invoke = function(jobj, method, ...) jobj,
+    invoke_static = function(...) "expr",
+    stream_write_memory = function(x, name, ...) "stream",
+    stream_stop = function(stream) invisible(NULL),
+    spark_session = function(sc) "session",
+    sdf_collect = function(x, ...) fake_df,
+    random_string = function(prefix) paste0(prefix, "tbl"),
+    .package = "sparklyr",
+    {
+      server <- function(input, output, session) {
+        # explicit session (non-NULL branch)
+        rs <- reactiveSpark("x", intervalMillis = 5, session = session)
+        output$tbl <- shiny::renderTable(rs())
+        # session = NULL -> falls back to getDefaultReactiveDomain()
+        rs_default <- reactiveSpark("x", intervalMillis = 5)
+        output$tbl2 <- shiny::renderTable(rs_default())
+      }
+      shiny::testServer(server, {
+        session$flushReact()
+        expect_false(is.null(output$tbl))
+        expect_false(is.null(output$tbl2))
+      })
+    }
+  )
+})

--- a/tests/testthat/test-tbl_spark.R
+++ b/tests/testthat/test-tbl_spark.R
@@ -1,0 +1,29 @@
+skip_connection("tbl_spark")
+skip_on_livy()
+skip_on_arrow_devel()
+
+sc <- testthat_spark_connection()
+
+test_that("dim / type_sum / tbl_quote_name behave as expected", {
+  tbl <- testthat_tbl("iris")
+  d <- dim(tbl)
+  expect_length(d, 2)
+  expect_equal(d[[2]], 5L)
+  expect_type(type_sum(spark_dataframe(tbl)), "character")
+
+  expect_equal(tbl_quote_name(sc, "a.b"), "`a`.`b`")
+  sc_ns <- sc
+  sc_ns$config[["sparklyr.dplyr.period.splits"]] <- FALSE
+  expect_match(as.character(tbl_quote_name(sc_ns, "a.b")), "a.b", fixed = TRUE)
+})
+
+test_that("tbl_cache / tbl_uncache / tbl_change_db / src_databases", {
+  copy_to(sc, data.frame(x = 1:3), "tc_tbl", overwrite = TRUE)
+  expect_null(tbl_cache(sc, "tc_tbl", force = TRUE))
+  expect_null(tbl_uncache(sc, "tc_tbl"))
+  expect_null(tbl_change_db(sc, "default"))
+  # SHOW DATABASES exposes the 'namespace' column on Spark 3.x
+  expect_true("default" %in% src_databases(sc, "namespace"))
+})
+
+test_clear_cache()

--- a/tests/testthat/test-tidiers_ml_regression.R
+++ b/tests/testthat/test-tidiers_ml_regression.R
@@ -229,4 +229,48 @@ test_that("isotonic_regression.tidy() works", {
   check_tidy(gl1, exp.row = 1, exp.names = c("isotonic", "num_boundaries"))
 })
 
+test_that("glm tidiers cover the remaining branches", {
+  sc <- testthat_spark_connection()
+  test_requires("broom")
+  test_requires_version("2.0.0")
+  mtcars_tbl <- testthat_tbl("mtcars")
+
+  glmfit1 <- ml_generalized_linear_regression(
+    mtcars_tbl,
+    response = "mpg",
+    features = "wt"
+  )
+  lmfit1 <- ml_linear_regression(mtcars_tbl, "mpg ~ wt")
+
+  # exponentiate with an explicit, non-log/logit link warns (the `link` is set
+  # branch, vs. the family-based branch the existing tests cover)
+  glm_link <- ml_generalized_linear_regression(
+    mtcars_tbl,
+    response = "mpg",
+    features = c("wt", "disp"),
+    family = "gaussian",
+    link = "identity"
+  )
+  expect_warning(tidy(glm_link, exponentiate = TRUE), "Exponentiating")
+
+  # augment on training data with a non-"working" residual type takes the
+  # sdf_residuals() + ml_predict() path (regression: ml_predict drops the
+  # residuals column, so it must be re-attached)
+  au_resp <- augment(glmfit1, type.residuals = "response") %>% collect()
+  expect_true(all(c("fitted", "resid") %in% colnames(au_resp)))
+  # `response` residual == observed - fitted, which verifies row alignment
+  expect_equal(au_resp$mpg - au_resp$fitted, au_resp$resid, tolerance = 1e-6)
+
+  au_dev <- augment(glmfit1, type.residuals = "deviance") %>% collect()
+  expect_true(all(c("fitted", "resid") %in% colnames(au_dev)))
+
+  # the parsnip-style wrapper delegates to augment() on the underlying $fit
+  wrapped <- structure(
+    list(fit = lmfit1),
+    class = "_ml_model_linear_regression"
+  )
+  au_w <- augment(wrapped) %>% collect()
+  expect_true(all(c("fitted", "resid") %in% colnames(au_w)))
+})
+
 test_clear_cache()

--- a/tests/testthat/test-tidiers_utils.R
+++ b/tests/testthat/test-tidiers_utils.R
@@ -1,0 +1,84 @@
+skip_connection("tidiers_utils")
+skip_on_livy()
+skip_on_arrow_devel()
+test_requires("dplyr")
+
+sc <- testthat_spark_connection()
+
+# pure helpers ----------------------------------------------------------------
+
+test_that("tidy/augment/glance.ml_model stubs error for unsupported models", {
+  x <- structure(list(), class = c("ml_model_made_up", "ml_model"))
+  expect_error(tidy(x), "'tidy\\(\\)' not yet supported for")
+  expect_error(augment(x), "'augment\\(\\)' not yet supported for")
+  expect_error(glance(x), "'glance\\(\\)' not yet supported for")
+})
+
+test_that("unrowname strips row names", {
+  df <- data.frame(a = 1:2)
+  rownames(df) <- c("foo", "bar")
+  out <- unrowname(df)
+  expect_equal(rownames(out), c("1", "2"))
+})
+
+test_that("fix_data_frame keeps default row names in place", {
+  df <- data.frame(a = 1:3, b = 4:6)
+  out <- fix_data_frame(df, newnames = c("x", "y"))
+  expect_s3_class(out, "tbl_df")
+  expect_equal(colnames(out), c("x", "y"))
+  expect_equal(nrow(out), 3)
+})
+
+test_that("fix_data_frame moves non-default row names into a term column", {
+  m <- matrix(1:4, nrow = 2, dimnames = list(c("aa", "bb"), c("c1", "c2")))
+  out <- fix_data_frame(m)
+  expect_equal(colnames(out)[1], "term")
+  expect_equal(out$term, c("aa", "bb"))
+
+  # newnames rename the non-term columns
+  out2 <- fix_data_frame(m, newnames = c("p", "q"))
+  expect_equal(colnames(out2), c("term", "p", "q"))
+})
+
+test_that("fix_data_frame rejects a mismatched newnames length", {
+  df <- data.frame(a = 1:3, b = 4:6)
+  expect_error(
+    fix_data_frame(df, newnames = c("only_one")),
+    "newnames must be NULL or have length equal to number of columns"
+  )
+})
+
+test_that("check_newdata flags a `newdata` argument", {
+  expect_error(check_newdata(newdata = 1), "new_data")
+  expect_silent(check_newdata(new_data = 1))
+})
+
+# live helpers (fitted model) -------------------------------------------------
+
+test_that("broom_augment_supervised and extract_model_metrics run on a model", {
+  test_requires("dplyr")
+  mtcars_tbl <- testthat_tbl("mtcars")
+  model <- ml_linear_regression(mtcars_tbl, mpg ~ wt + cyl)
+
+  # augment() -> broom_augment_supervised(): adds a .prediction column, reusing
+  # the training set when newdata is omitted
+  aug <- broom_augment_supervised(model)
+  expect_true(".prediction" %in% colnames(aug))
+
+  # glance() routes through extract_model_metrics() to assemble a 1-row summary
+  gl <- glance(model)
+  expect_s3_class(gl, "data.frame")
+  expect_equal(nrow(gl), 1)
+})
+
+test_that("broom_augment_supervised renames the classification predicted_label", {
+  test_requires("dplyr")
+  iris_tbl <- testthat_tbl("iris")
+  # a classifier's predictions carry a `predicted_label` column, exercising the
+  # `predicted_label` -> `.predicted_label` rename branch
+  clf <- ml_decision_tree_classifier(iris_tbl, Species ~ Sepal_Length + Sepal_Width)
+  aug <- broom_augment_supervised(clf)
+  expect_true(".predicted_label" %in% colnames(aug))
+})
+
+test_clear_cache()

--- a/tests/testthat/test-tidiers_utils.R
+++ b/tests/testthat/test-tidiers_utils.R
@@ -76,7 +76,10 @@ test_that("broom_augment_supervised renames the classification predicted_label",
   iris_tbl <- testthat_tbl("iris")
   # a classifier's predictions carry a `predicted_label` column, exercising the
   # `predicted_label` -> `.predicted_label` rename branch
-  clf <- ml_decision_tree_classifier(iris_tbl, Species ~ Sepal_Length + Sepal_Width)
+  clf <- ml_decision_tree_classifier(
+    iris_tbl,
+    Species ~ Sepal_Length + Sepal_Width
+  )
   aug <- broom_augment_supervised(clf)
   expect_true(".predicted_label" %in% colnames(aug))
 })

--- a/tests/testthat/test-tidyr_pivot_longer.R
+++ b/tests/testthat/test-tidyr_pivot_longer.R
@@ -294,4 +294,172 @@ test_that("Error if the `col` can't be selected.", {
   )
 })
 
+# string-splitting helpers ------------------------------------------------
+
+test_that("build_output_names supports numeric names_sep", {
+  out <- build_output_names(
+    cols = c("abXcd", "efXgh"),
+    names_to = c("a", "b"),
+    names_prefix = NULL,
+    names_sep = 2,
+    names_pattern = NULL
+  )
+
+  expect_equal(out$a, c("ab", "ef"))
+  expect_equal(out$b, c("Xcd", "Xgh"))
+})
+
+test_that(".strsep splits at positive and negative positions", {
+  out <- .strsep(c("abcde", "vwxyz"), c(2, -1))
+
+  expect_equal(out[[1]], c("ab", "vw"))
+  expect_equal(out[[2]], c("cd", "xy"))
+  expect_equal(out[[3]], c("e", "z"))
+})
+
+test_that(".str_separate errors on non-character `into`", {
+  expect_error(
+    .str_separate("a_b", into = 1:2, sep = "_"),
+    "`into` must be a character vector"
+  )
+})
+
+test_that(".str_separate errors on invalid `sep` type", {
+  expect_error(
+    .str_separate("a_b", into = c("a", "b"), sep = TRUE),
+    "`sep` must be either numeric or character"
+  )
+})
+
+test_that(".str_separate dispatches on numeric vs character sep", {
+  num_out <- .str_separate(c("abcd"), into = c("a", "b"), sep = 2)
+  expect_equal(num_out$a, "ab")
+  expect_equal(num_out$b, "cd")
+
+  chr_out <- .str_separate("x_y", into = c("a", "b"), sep = "_")
+  expect_equal(chr_out$a, "x")
+  expect_equal(chr_out$b, "y")
+})
+
+test_that(".str_separate drops NA names from `into`", {
+  out <- .str_separate("x_y", into = c("a", NA), sep = "_")
+  expect_equal(names(out), "a")
+  expect_equal(out$a, "x")
+})
+
+test_that(".str_split_fixed warns and drops extra pieces (extra = 'warn')", {
+  expect_warning(
+    res <- .str_split_fixed("a_b_c", sep = "_", n = 2),
+    "Additional pieces discarded"
+  )
+  expect_equal(res[[1]], "a")
+  expect_equal(res[[2]], "b")
+})
+
+test_that(".str_split_fixed merges trailing pieces (extra = 'merge')", {
+  res <- .str_split_fixed("a_b_c", sep = "_", n = 2, extra = "merge")
+  expect_equal(res[[1]], "a")
+  expect_equal(res[[2]], "b_c")
+})
+
+test_that(".str_split_fixed drops extra pieces silently (extra = 'drop')", {
+  res <- .str_split_fixed("a_b_c", sep = "_", n = 2, extra = "drop")
+  expect_equal(res[[1]], "a")
+  expect_equal(res[[2]], "b")
+})
+
+test_that(".str_split_fixed deprecates extra = 'error'", {
+  expect_warning(
+    .str_split_fixed("a_b", sep = "_", n = 2, extra = "error"),
+    "deprecated"
+  )
+})
+
+test_that(".str_split_fixed warns and returns n pieces on missing input", {
+  # NB: the returned values are not asserted here — .simplify_pieces() has an
+  # off-by-one in its fill-right path (see planning doc follow-ups); we only
+  # cover the warning + shape.
+  expect_warning(
+    res <- .str_split_fixed("a", sep = "_", n = 2),
+    "Missing pieces filled with `NA`"
+  )
+  expect_length(res, 2)
+})
+
+test_that(".str_split_fixed accepts fill = 'right'", {
+  res <- .str_split_fixed("a_b", sep = "_", n = 3, fill = "right")
+  expect_length(res, 3)
+})
+
+test_that(".simplify_pieces handles exact, too-big, and too-small rows", {
+  pieces <- list(
+    c("a", "b"),
+    c("c", "d", "e"),
+    "f",
+    NA
+  )
+  simp <- .simplify_pieces(pieces, p = 2, fill_left = FALSE)
+
+  expect_equal(simp$too_big, 2L)
+  expect_equal(simp$too_sml, 3L)
+  # row 3 ("f") has length 1 < p=2: with fill_left=FALSE the
+  # `j < length(x)` guard is never TRUE, so both columns get NA
+  expect_equal(simp$strings[[1]], c("a", "c", NA, NA))
+  expect_equal(simp$strings[[2]], c("b", "d", NA, NA))
+})
+
+test_that(".list_indices truncates long vectors", {
+  expect_equal(.list_indices(1:3), "1, 2, 3")
+  expect_match(.list_indices(1:30), "\\.\\.\\.$")
+})
+
+test_that(".str_split_n respects n_max", {
+  out <- .str_split_n("a_b_c", "_", n_max = 2)
+  expect_equal(out[[1]], c("a", "b_c"))
+
+  out_all <- .str_split_n("a_b_c", "_")
+  expect_equal(out_all[[1]], c("a", "b", "c"))
+})
+
+test_that(".str_extract pulls regex capture groups", {
+  out <- .str_extract(
+    c("x1", "y2"),
+    into = c("letter", "num"),
+    regex = "([a-z])([0-9])"
+  )
+  expect_equal(out$letter, c("x", "y"))
+  expect_equal(out$num, c("1", "2"))
+})
+
+test_that(".str_extract converts types when convert = TRUE", {
+  out <- .str_extract(
+    "x1",
+    into = c("letter", "num"),
+    regex = "([a-z])([0-9])",
+    convert = TRUE
+  )
+  expect_type(out$num, "integer")
+  expect_equal(out$num, 1L)
+})
+
+test_that(".str_extract collapses duplicated `into` names", {
+  out <- .str_extract(
+    "ab",
+    into = c("x", "x"),
+    regex = "(.)(.)"
+  )
+  expect_equal(names(out), "x")
+  expect_equal(out$x, "ab")
+})
+
+test_that(".str_extract drops NA names from `into`", {
+  out <- .str_extract(
+    "x1",
+    into = c("letter", NA),
+    regex = "([a-z])([0-9])"
+  )
+  expect_equal(names(out), "letter")
+  expect_equal(out$letter, "x")
+})
+
 test_clear_cache()

--- a/tests/testthat/test-tidyr_pivot_utils.R
+++ b/tests/testthat/test-tidyr_pivot_utils.R
@@ -1,0 +1,34 @@
+skip_connection("tidyr_pivot_utils")
+skip_on_livy()
+skip_on_arrow_devel()
+
+test_that("canonicalize_spec rejects non-data-frames", {
+  expect_error(
+    canonicalize_spec(list(.name = "n", .value = "v")),
+    "`spec` must be a data frame"
+  )
+})
+
+test_that("canonicalize_spec requires .name and .value columns", {
+  expect_error(
+    canonicalize_spec(data.frame(x = 1)),
+    "`spec` must have `.name` and `.value` columns"
+  )
+  # only one of the two present is still an error
+  expect_error(
+    canonicalize_spec(data.frame(.name = "n")),
+    "`spec` must have `.name` and `.value` columns"
+  )
+})
+
+test_that("canonicalize_spec moves .name and .value to the front", {
+  spec <- data.frame(
+    other = 1,
+    .value = "v",
+    .name = "n",
+    stringsAsFactors = FALSE
+  )
+  out <- canonicalize_spec(spec)
+  expect_equal(names(out), c(".name", ".value", "other"))
+  expect_equal(out$other, 1)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,3 +1,210 @@
+# ---------------------------------------------------------------------------
+# Connection-free unit tests for the pure helpers in R/utils.R. Placed above the
+# skip_connection() gate so they run without a live Spark session.
+# ---------------------------------------------------------------------------
+
+test_that("spark_integ_test_skip() defaults to FALSE", {
+  expect_false(
+    spark_integ_test_skip(structure(list(), class = "spark_connection"), "x")
+  )
+})
+
+test_that("is.installed() detects installed packages", {
+  expect_true(is.installed("stats"))
+  expect_false(is.installed("nonexistentpkgxyz123"))
+})
+
+test_that("utils_starts_with() matches prefixes", {
+  expect_true(utils_starts_with("hello", "he"))
+  expect_false(utils_starts_with("hello", "lo"))
+  expect_false(utils_starts_with("hi", "hello")) # lhs shorter than rhs
+})
+
+test_that("aliased_path() collapses the home directory to ~", {
+  expect_equal(aliased_path(paste0(path.expand("~/"), "foo")), "~/foo")
+  expect_equal(aliased_path("/other/path"), "/other/path")
+})
+
+test_that("transpose_list() transposes a list of vectors", {
+  expect_equal(transpose_list(list(c(1, 2), c(3, 4))), list(c(1, 3), c(2, 4)))
+})
+
+test_that("random_string() uses the prefix and is random", {
+  expect_match(random_string("pre"), "^pre_")
+  expect_false(identical(random_string("p"), random_string("p")))
+})
+
+test_that("printf() formats and prints", {
+  expect_output(printf("%d-%s", 1L, "a"), "1-a")
+})
+
+test_that("regex_replace() applies named replacements in order", {
+  expect_equal(regex_replace("a b.c", " " = "_", "[.]" = "-"), "a_b-c")
+})
+
+test_that("spark_sanitize_names() cleans, disables, and reports", {
+  # opt-out returns names unchanged
+  expect_equal(
+    spark_sanitize_names("a b", list(sparklyr.sanitize.column.names = FALSE)),
+    "a b"
+  )
+  # default: spaces -> '_', duplicates made unique
+  expect_equal(
+    spark_sanitize_names(c("a b", "a b"), list()),
+    c("a_b", "a_b_1")
+  )
+  # verbose path emits a message
+  expect_message(
+    spark_sanitize_names(
+      "a b",
+      list(sparklyr.sanitize.column.names.verbose = TRUE)
+    ),
+    "renamed"
+  )
+})
+
+test_that("spark_normalize_path() normalizes local paths but leaves URLs", {
+  expect_equal(spark_normalize_path("hdfs://host/path"), "hdfs://host/path")
+  expect_equal(
+    spark_normalize_path("foo/bar"),
+    normalizePath("foo/bar", mustWork = FALSE)
+  )
+})
+
+test_that("enumerate() applies f over names and values", {
+  expect_equal(
+    enumerate(list(a = 1, b = 2), function(nm, val) paste0(nm, val)),
+    list(a = "a1", b = "b2")
+  )
+})
+
+test_that("path_program() finds programs and errors when missing", {
+  expect_error(
+    path_program("definitely-not-a-real-program-xyz"),
+    "required but not available"
+  )
+  rscript <- Sys.which("Rscript")
+  if (nzchar(rscript)) {
+    expect_equal(unname(path_program("Rscript")), unname(rscript))
+  }
+})
+
+test_that("infer_active_package_name() reads the DESCRIPTION Package field", {
+  d <- withr::local_tempdir()
+  writeLines("Package: foopkg", file.path(d, "DESCRIPTION"))
+  with_mocked_bindings(
+    package_root = function() d,
+    .package = "sparklyr",
+    expect_equal(infer_active_package_name(), "foopkg")
+  )
+})
+
+test_that("remove_class() drops a class", {
+  x <- structure(1, class = c("a", "b"))
+  expect_equal(class(remove_class(x, "a")), "b")
+})
+
+test_that("trim_whitespace() strips surrounding whitespace", {
+  expect_equal(trim_whitespace("  a b  "), "a b")
+})
+
+test_that("split_separator() differs for livy vs default connections", {
+  livy <- split_separator(structure(list(), class = "livy_connection"))
+  expect_equal(livy$plain, "|~|")
+  def <- split_separator(structure(list(), class = "spark_connection"))
+  expect_equal(def$plain, "\3")
+})
+
+test_that("resolve_fn() calls functions and passes values through", {
+  expect_equal(resolve_fn(function(x) x + 1, 1), 2)
+  expect_equal(resolve_fn(42), 42)
+})
+
+test_that("is.tbl_spark() checks the class", {
+  expect_true(is.tbl_spark(structure(list(), class = "tbl_spark")))
+  expect_false(is.tbl_spark(1))
+})
+
+test_that("`%<-%` assigns multiple variables and validates length", {
+  c(p, q) %<-% list(1, 2)
+  expect_equal(p, 1)
+  expect_equal(q, 2)
+  expect_error(c(p, q) %<-% list(1), "same number")
+})
+
+test_that("sort_named_list() orders entries by name", {
+  expect_equal(sort_named_list(list(b = 2, a = 1)), list(a = 1, b = 2))
+})
+
+test_that("`%>>%` / `%@%` apply a function with a variable arg list", {
+  expect_equal((1 %>>% sum) %@% list(2, 3), 6)
+})
+
+test_that("`%>|%` forwards a chain of invocations to invoke()", {
+  captured <- NULL
+  with_mocked_bindings(
+    invoke = function(jobj, method, ...) {
+      captured <<- list(method = method, args = list(...))
+      "<r>"
+    },
+    .package = "sparklyr",
+    {
+      res <- "<jobj>" %>|% list(list("m1", "a"), list("m2"))
+      expect_equal(res, "<r>")
+      expect_equal(captured$method, "%>%")
+      expect_equal(captured$args, list(list("m1", "a"), list("m2")))
+    }
+  )
+})
+
+test_that("download_file() raises a low timeout for the call and restores it", {
+  withr::local_options(timeout = 60)
+  seen <- NULL
+  with_mocked_bindings(
+    download.file = function(...) {
+      seen <<- getOption("timeout")
+      0L
+    },
+    .package = "sparklyr",
+    download_file("u", "d")
+  )
+  expect_equal(seen, 300)
+  expect_equal(getOption("timeout"), 60)
+})
+
+test_that("get_os() and os_is_windows() report the platform", {
+  expect_true(get_os() %in% c("win", "mac", "unix"))
+  expect_equal(os_is_windows(), get_os() == "win")
+})
+
+test_that("infer_required_r_packages() finds deps via library and attachNamespace", {
+  fn_library <- function(x) {
+    library(stats)
+    x
+  }
+  expect_true("stats" %in% infer_required_r_packages(fn_library))
+
+  fn_attach <- function(x) {
+    attachNamespace("stats")
+    x
+  }
+  expect_true("stats" %in% infer_required_r_packages(fn_attach))
+})
+
+test_that("update_jars() runs the jar build pipeline in order", {
+  calls <- character()
+  rec <- function(name) function(...) calls[[length(calls) + 1]] <<- name
+  with_mocked_bindings(
+    download_scalac = rec("download_scalac"),
+    sparklyr_jar_verify_spark = rec("verify"),
+    compile_package_jars = rec("compile"),
+    spark_update_embedded_sources = rec("embed"),
+    .package = "sparklyr",
+    update_jars()
+  )
+  expect_equal(calls, c("download_scalac", "verify", "compile", "embed"))
+})
+
 skip_connection("utils")
 skip_on_livy()
 skip_on_arrow_devel()
@@ -307,6 +514,40 @@ test_that("pcre_to_java converts [:xdigits:] correctly", {
     expect_split(sprintf("g%sh", delim), "[[:xdigit:]]", list("g", "h"))
     expect_split(sprintf("G%sH|I", delim), "[|[:xdigit:]]", list("G", "H", "I"))
   }
+})
+
+test_that("replicate_colnames() returns a 1-row frame with the same columns", {
+  iris_tbl <- testthat_tbl("iris")
+  res <- replicate_colnames(iris_tbl)
+  expect_setequal(colnames(res), colnames(iris_tbl))
+  expect_equal(nrow(res), 1)
+})
+
+test_that("simulate_vars_spark() builds a typed proxy with matching columns", {
+  iris_tbl <- testthat_tbl("iris")
+  res <- simulate_vars_spark(iris_tbl)
+  expect_setequal(colnames(res), colnames(iris_tbl))
+})
+
+test_that("simulate_vars_spark() can drop grouping columns", {
+  iris_tbl <- testthat_tbl("iris")
+  grouped <- iris_tbl %>% dplyr::group_by(Species)
+  res <- simulate_vars_spark(grouped, drop_groups = TRUE)
+  expect_false("Species" %in% colnames(res))
+})
+
+test_that("tidyselect_data_proxy.tbl_spark returns a proxy under predicates", {
+  iris_tbl <- testthat_tbl("iris")
+  proxy <- tidyselect_data_proxy(iris_tbl)
+  expect_setequal(colnames(proxy), colnames(iris_tbl))
+})
+
+test_that("tidyselect_data_has_predicates.tbl_spark respects the option", {
+  iris_tbl <- testthat_tbl("iris")
+  expect_true(tidyselect_data_has_predicates(iris_tbl))
+
+  withr::local_options(sparklyr.support.predicates = FALSE)
+  expect_false(tidyselect_data_has_predicates(iris_tbl))
 })
 
 test_clear_cache()

--- a/tests/testthat/test-zzz-arrow.R
+++ b/tests/testthat/test-zzz-arrow.R
@@ -47,14 +47,22 @@ test_that("arrow_collect honors n and a per-batch callback", {
 
   # formula callback -> coerced via rlang::as_closure + the cb(batch, iter) arm
   seen2 <- 0L
-  sdf_collect(sdf_len(sc, 6), callback = ~ {
-    seen2 <<- seen2 + nrow(.x)
-  })
+  sdf_collect(
+    sdf_len(sc, 6),
+    callback = ~ {
+      seen2 <<- seen2 + nrow(.x)
+    }
+  )
   expect_equal(seen2, 6)
 })
 
 test_that("arrow_enabled_object disables arrow for vector (VectorUDT) columns", {
-  v <- sdf_copy_to(sc, data.frame(a = 1:3, b = 4:6), "zav", overwrite = TRUE) %>%
+  v <- sdf_copy_to(
+    sc,
+    data.frame(a = 1:3, b = 4:6),
+    "zav",
+    overwrite = TRUE
+  ) %>%
     ft_vector_assembler(c("a", "b"), "features")
   expect_warning(
     enabled <- arrow_enabled_object(spark_dataframe(v)),

--- a/tests/testthat/test-zzz-arrow.R
+++ b/tests/testthat/test-zzz-arrow.R
@@ -1,0 +1,66 @@
+# ---- Arrow round-trip (real serialization path) ----------------------------
+# Lives in a `zzz` file so it sorts LAST: attaching {arrow} puts it on the search
+# path, which flips arrow_enabled() for the rest of the session (every later
+# spark_apply()/collect() would take the arrow path), so we quarantine it here.
+# Gated on {arrow} being installed; the live serialization path (arrow_copy_to /
+# arrow_collect / arrow_read_stream) is otherwise only exercised by the dedicated
+# arrow CI job. The pure arrow_enabled* predicates live in test-arrow.R.
+
+skip_connection("arrow")
+skip_on_livy()
+skip_on_arrow_devel()
+skip_if_not_installed("arrow")
+
+library(arrow)
+
+sc <- testthat_spark_connection()
+
+test_that("copy_to + collect use the arrow serialization path", {
+  expect_true(arrow_enabled(sc, sdf_len(sc, 1)))
+
+  # arrow_copy_to, including the factor -> character branch
+  df <- data.frame(
+    x = 1:10,
+    y = letters[1:10],
+    f = factor(rep(c("a", "b"), 5)),
+    stringsAsFactors = FALSE
+  )
+  tbl <- sdf_copy_to(sc, df, "zarrow", overwrite = TRUE)
+  expect_equal(sdf_nrow(tbl), 10)
+
+  # arrow_collect (bind_rows path) + arrow_read_stream
+  back <- collect(tbl)
+  expect_equal(nrow(back), 10)
+  expect_setequal(back$x, 1:10)
+})
+
+test_that("arrow_collect honors n and a per-batch callback", {
+  expect_equal(nrow(collect(sdf_len(sc, 20), n = 5)), 5)
+
+  # 1-arg callback -> cb(batch)
+  seen <- 0L
+  sdf_collect(
+    sdf_len(sc, 12),
+    callback = function(batch) seen <<- seen + nrow(batch)
+  )
+  expect_equal(seen, 12)
+
+  # formula callback -> coerced via rlang::as_closure + the cb(batch, iter) arm
+  seen2 <- 0L
+  sdf_collect(sdf_len(sc, 6), callback = ~ {
+    seen2 <<- seen2 + nrow(.x)
+  })
+  expect_equal(seen2, 6)
+})
+
+test_that("arrow_enabled_object disables arrow for vector (VectorUDT) columns", {
+  v <- sdf_copy_to(sc, data.frame(a = 1:3, b = 4:6), "zav", overwrite = TRUE) %>%
+    ft_vector_assembler(c("a", "b"), "features")
+  expect_warning(
+    enabled <- arrow_enabled_object(spark_dataframe(v)),
+    "Arrow disabled"
+  )
+  expect_false(enabled)
+})
+
+test_clear_cache()

--- a/tests/testthat/test-zzz-spark_apply.R
+++ b/tests/testthat/test-zzz-spark_apply.R
@@ -1,0 +1,61 @@
+# ---------------------------------------------------------------------------
+# Arrow addendum for spark_apply(). Kept in a separate `zzz` file so it sorts
+# LAST: attaching {arrow} puts it on the search path, which flips
+# arrow_enabled() (it checks `"package:arrow" %in% search()`) for the rest of
+# the session -- so any later test file's spark_apply()/collect() would silently
+# switch to the arrow path. Running last quarantines that.
+#
+# Gated on arrow being *installed* (not on using_arrow()/the CI arrow flag), so
+# it exercises the arrow branches of spark_apply() wherever {arrow} is present.
+# ---------------------------------------------------------------------------
+
+skip_connection("spark_apply")
+skip_on_livy()
+skip_on_arrow_devel()
+skip_if_not_installed("arrow")
+
+library(arrow)
+
+sc <- testthat_spark_connection()
+iris_tbl <- testthat_tbl("iris")
+
+test_that("spark_apply() takes the arrow path for a plain apply", {
+  # with {arrow} attached, arrow_enabled() is TRUE, so this exercises the
+  # arrow setup block (sessionLocalTimeZone + records_per_batch) and the
+  # maxRecordsPerBatch option.
+  expect_true(arrow_enabled(sc, sdf_len(sc, 1)))
+
+  result <- sdf_len(sc, 10) %>%
+    spark_apply(function(df) df * 2L) %>%
+    collect()
+
+  expect_equal(nrow(result), 10)
+  expect_equal(sum(result$id), sum(seq_len(10) * 2L))
+})
+
+test_that("spark_apply() takes the arrow groupBy path", {
+  # group_by + arrow exercises ApplyUtils.groupByArrow.
+  result <- spark_apply(
+    iris_tbl,
+    function(e) nrow(e),
+    names = "n",
+    group_by = "Species"
+  ) %>%
+    collect()
+
+  expect_equal(nrow(result), 3) # one row per species
+  expect_equal(sum(result$n), 150) # all rows accounted for
+})
+
+test_that("spark_apply() disables arrow when fetch_result_as_sdf = FALSE", {
+  # arrow is incompatible with fetch_result_as_sdf = FALSE, so this warns and
+  # falls back to the non-arrow path, returning a list of R objects.
+  expect_warning(
+    res <- sdf_len(sc, 3) %>%
+      spark_apply(function(df) df, fetch_result_as_sdf = FALSE),
+    "Disabling arrow"
+  )
+  expect_type(res, "list")
+})
+
+test_clear_cache()

--- a/utils/archive/configure.R
+++ b/utils/archive/configure.R
@@ -32,4 +32,7 @@ sparklyr::compile_package_jars(spec = spec)
 
 # for now, spark master and spark 3.0.0 are equivalent
 java_dir <- file.path("inst", "java")
-file.rename(file.path(java_dir, "sparklyr-3.0-2.12.jar"), file.path(java_dir, "sparklyr-master-2.12.jar"))
+file.rename(
+  file.path(java_dir, "sparklyr-3.0-2.12.jar"),
+  file.path(java_dir, "sparklyr-master-2.12.jar")
+)

--- a/utils/archive/update_scripts.R
+++ b/utils/archive/update_scripts.R
@@ -8,23 +8,22 @@ r_files <- test_path() %>%
   dir_ls(glob = "*.R")
 
 
-test_files <-  r_files[str_detect(r_files, "test-")]
+test_files <- r_files[str_detect(r_files, "test-")]
 
 test_files %>%
-  map(~{
-    contents <- readLines(.x)
+  map(
+    ~ {
+      contents <- readLines(.x)
 
-    tf <- .x %>%
-      path_file() %>%
-      str_remove("test-") %>%
-      str_remove(".R")
+      tf <- .x %>%
+        path_file() %>%
+        str_remove("test-") %>%
+        str_remove(".R")
 
-    line <- paste0("skip_connection(\"", tf, "\")")
+      line <- paste0("skip_connection(\"", tf, "\")")
 
-    contents <- c(line, contents)
+      contents <- c(line, contents)
 
-    writeLines(contents, .x)
-
-  })
-
-
+      writeLines(contents, .x)
+    }
+  )

--- a/utils/build_jars/update_jars.R
+++ b/utils/build_jars/update_jars.R
@@ -14,6 +14,3 @@ compile_package_jars()
 # are all the R scripts in /R with a name containing "worker" or "core".
 # Embedded sources are the key to how spark_apply() works.
 spark_update_embedded_sources()
-
-
-

--- a/utils/coverage/coverage.R
+++ b/utils/coverage/coverage.R
@@ -49,7 +49,7 @@ library(here)   # non-package util, so here::here() is fair game for path resolu
 
 ## -------- Run coverage for one R script (memoized within the session only)
 coverage_run <- function(file,
-                         spark_version = "4.1.0",
+                         spark_version = "3.5.8",
                          refresh = FALSE) {
   base <- .coverage_base(file)
   if (!refresh && !is.null(.coverage_memo[[base]])) {
@@ -127,7 +127,7 @@ coverage_run <- function(file,
 # ---------------------- Public ----------------
 
 ## -------- One-line summary
-coverage_summary <- function(file, spark_version = "4.1.0", refresh = FALSE) {
+coverage_summary <- function(file, spark_version = "3.5.8", refresh = FALSE) {
   cov <- coverage_run(file, spark_version, refresh)
   dv <- .coverage_table(file, cov)
   covered <- sum(dv$value > 0)
@@ -149,7 +149,7 @@ coverage_lines <- function(file,
                            show = c("uncovered", "all"),
                            context = 1,
                            html = TRUE,
-                           spark_version = "4.1.0",
+                           spark_version = "3.5.8",
                            refresh = FALSE) {
   show <- match.arg(show)
   cov <- coverage_run(file, spark_version, refresh)
@@ -183,7 +183,7 @@ coverage_lines <- function(file,
 
 ## -------- HTML report only, written to a timestamped file. Returns the path
 ##   (does NOT open a browser) so it can be shared / re-opened without re-running.
-coverage_report <- function(file, spark_version = "4.1.0", refresh = FALSE) {
+coverage_report <- function(file, spark_version = "3.5.8", refresh = FALSE) {
   cov <- coverage_run(file, spark_version, refresh)
   out <- file.path(
     .coverage_reports_dir(),

--- a/utils/coverage/coverage.R
+++ b/utils/coverage/coverage.R
@@ -30,7 +30,7 @@
 
 library(covr)
 library(withr)
-library(here)   # non-package util, so here::here() is fair game for path resolution
+library(here) # non-package util, so here::here() is fair game for path resolution
 
 # ---------------------- Internal ----------------
 
@@ -48,9 +48,7 @@ library(here)   # non-package util, so here::here() is fair game for path resolu
 }
 
 ## -------- Run coverage for one R script (memoized within the session only)
-coverage_run <- function(file,
-                         spark_version = "3.5.8",
-                         refresh = FALSE) {
+coverage_run <- function(file, spark_version = "3.5.8", refresh = FALSE) {
   base <- .coverage_base(file)
   if (!refresh && !is.null(.coverage_memo[[base]])) {
     return(.coverage_memo[[base]])
@@ -62,7 +60,8 @@ coverage_run <- function(file,
     "library(sparklyr)",
     sprintf(
       'testthat::test_dir("%s", filter = "%s", package = "sparklyr", load_package = "installed")',
-      test_dir, base
+      test_dir,
+      base
     )
   )
 
@@ -94,15 +93,28 @@ coverage_run <- function(file,
 
   mark <- function(i) {
     s <- status[as.character(i)]
-    if (is.na(s)) "    " else if (s == 0) "  x " else "  . "  # x = uncovered, . = covered
+    if (is.na(s)) {
+      "    "
+    } else if (s == 0) {
+      "  x "
+    } else {
+      "  . "
+    } # x = uncovered, . = covered
   }
   line_at <- function(i) sprintf("%4d%s| %s", i, mark(i), src[i])
 
   out <- c(
-    sprintf("R/%s.R   (x = uncovered, . = covered, blank = non-executable)", base),
+    sprintf(
+      "R/%s.R   (x = uncovered, . = covered, blank = non-executable)",
+      base
+    ),
     sprintf(
       "R/%s.R: %.1f%% | %d executable lines | %d covered | %d NOT covered",
-      base, 100 * covered / nrow(dv), nrow(dv), covered, nrow(dv) - covered
+      base,
+      100 * covered / nrow(dv),
+      nrow(dv),
+      covered,
+      nrow(dv) - covered
     ),
     ""
   )
@@ -115,7 +127,7 @@ coverage_run <- function(file,
   if (!length(unc)) {
     return(c(out, "No uncovered lines."))
   }
-  blocks <- split(unc, cumsum(c(1, diff(unc) != 1)))   # group consecutive lines
+  blocks <- split(unc, cumsum(c(1, diff(unc) != 1))) # group consecutive lines
   for (b in blocks) {
     lo <- max(1, b[1] - context)
     hi <- min(length(src), b[length(b)] + context)
@@ -133,7 +145,11 @@ coverage_summary <- function(file, spark_version = "3.5.8", refresh = FALSE) {
   covered <- sum(dv$value > 0)
   cat(sprintf(
     "R/%s.R: %.1f%% | %d executable lines | %d covered | %d NOT covered\n",
-    .coverage_base(file), 100 * covered / nrow(dv), nrow(dv), covered, nrow(dv) - covered
+    .coverage_base(file),
+    100 * covered / nrow(dv),
+    nrow(dv),
+    covered,
+    nrow(dv) - covered
   ))
   invisible(dv)
 }
@@ -145,12 +161,14 @@ coverage_summary <- function(file, spark_version = "3.5.8", refresh = FALSE) {
 ##   show = "uncovered" (default) prints only uncovered blocks with `context`
 ##          lines around them; show = "all" annotates the whole file.
 ##   html = FALSE skips the HTML half (text artifact only).
-coverage_lines <- function(file,
-                           show = c("uncovered", "all"),
-                           context = 1,
-                           html = TRUE,
-                           spark_version = "3.5.8",
-                           refresh = FALSE) {
+coverage_lines <- function(
+  file,
+  show = c("uncovered", "all"),
+  context = 1,
+  html = TRUE,
+  spark_version = "3.5.8",
+  refresh = FALSE
+) {
   show <- match.arg(show)
   cov <- coverage_run(file, spark_version, refresh)
 
@@ -187,7 +205,11 @@ coverage_report <- function(file, spark_version = "3.5.8", refresh = FALSE) {
   cov <- coverage_run(file, spark_version, refresh)
   out <- file.path(
     .coverage_reports_dir(),
-    sprintf("%s-%s.html", .coverage_base(file), format(Sys.time(), "%Y%m%d-%H%M%S"))
+    sprintf(
+      "%s-%s.html",
+      .coverage_base(file),
+      format(Sys.time(), "%Y%m%d-%H%M%S")
+    )
   )
   covr::report(cov, file = out, browse = FALSE)
   invisible(out)

--- a/utils/coverage/estimate_coverage.R
+++ b/utils/coverage/estimate_coverage.R
@@ -96,7 +96,11 @@ compile_coverage_estimates <- function(
   info <- data.frame(
     path = htmls,
     base = sub(pattern, "", basename(htmls)),
-    stamp = sub(paste0("^.*-([0-9]{8}-[0-9]{6})[.]html$"), "\\1", basename(htmls)),
+    stamp = sub(
+      paste0("^.*-([0-9]{8}-[0-9]{6})[.]html$"),
+      "\\1",
+      basename(htmls)
+    ),
     stringsAsFactors = FALSE
   )
   # dedup by script, keeping the most recent report
@@ -137,7 +141,11 @@ compile_coverage_estimates <- function(
 
   writeLines(
     c(
-      paste0("# Coverage compiled ", stamp, " (covr canonical figures, read from HTML)"),
+      paste0(
+        "# Coverage compiled ",
+        stamp,
+        " (covr canonical figures, read from HTML)"
+      ),
       paste0("# ", nrow(result), " scripts, most recent report each"),
       "",
       utils::capture.output(print(result, row.names = FALSE)),

--- a/utils/coverage/estimate_coverage.R
+++ b/utils/coverage/estimate_coverage.R
@@ -1,0 +1,158 @@
+# Canonical coverage figures, read straight from covr's HTML reports.
+#
+# covr::report() (what coverage_lines()/coverage_report() write as the .html)
+# embeds a summary DataTable with one row per instrumented file and the columns
+#   File | Lines | Relevant | Covered | Missed | Hits / Line | Coverage
+# Those are covr's own numbers, so we read them directly rather than counting
+# lines in the .txt annotation (which counts every line a multi-line expression
+# spans, over-counting "missed" versus covr -- e.g. connection_livy 154 vs 117).
+#
+#   source("utils/coverage/estimate_coverage.R")
+#   read_coverage_report("connection_livy-20260626-155809.html")
+#   #>  relevant  covered    missed coverage
+#   #>       546      429       117    78.57
+#   compile_coverage_estimates()   # dedup + summarize all reports
+
+library(here)
+
+# Parse a covr report .html and return covr's canonical totals for the file the
+# report is named after: c(relevant, covered, missed, coverage).
+read_coverage_report <- function(html_file) {
+  path <- if (file.exists(html_file)) {
+    html_file
+  } else {
+    here::here("utils", "coverage", "reports", basename(html_file))
+  }
+  if (!file.exists(path)) {
+    stop("Report not found: ", html_file, call. = FALSE)
+  }
+
+  html <- paste(readLines(path, warn = FALSE), collapse = "\n")
+
+  # covr embeds several htmlwidget payloads; the summary table is the one whose
+  # header row contains a "Coverage" column.
+  payloads <- regmatches(
+    html,
+    gregexpr('application/json"[^>]*>\\{.*?\\}</script>', html)
+  )[[1]]
+  widget <- NULL
+  for (p in payloads) {
+    js <- sub('^application/json"[^>]*>', "", p)
+    js <- sub("</script>$", "", js)
+    w <- tryCatch(
+      jsonlite::fromJSON(js, simplifyVector = FALSE),
+      error = function(e) NULL
+    )
+    if (!is.null(w$x$container) && grepl("<th>Coverage</th>", w$x$container)) {
+      widget <- w$x
+      break
+    }
+  }
+  if (is.null(widget)) {
+    stop("No covr summary table in ", basename(path), call. = FALSE)
+  }
+
+  # column names, in order, from the table header
+  cols <- regmatches(
+    widget$container,
+    gregexpr("<th>[^<]+</th>", widget$container)
+  )[[1]]
+  cols <- sub("</th>$", "", sub("^<th>", "", cols))
+  col <- function(name) widget$data[[which(cols == name)]]
+
+  # locate the row for the file the report is named after (<base>.R)
+  base <- sub("-[0-9]{8}-[0-9]{6}[.]html$", "", basename(path))
+  files <- vapply(col("File"), as.character, character(1))
+  idx <- grep(paste0("/", base, "[.]R<"), files)
+  if (length(idx) != 1) {
+    stop("R/", base, ".R not found uniquely in ", basename(path), call. = FALSE)
+  }
+
+  num <- function(name) as.numeric(gsub("[^0-9.]", "", col(name)[[idx]]))
+  c(
+    lines = num("Lines"),
+    relevant = num("Relevant"),
+    covered = num("Covered"),
+    missed = num("Missed"),
+    coverage = num("Coverage")
+  )
+}
+
+# Compile covr's canonical coverage across every report. All report .html files
+# in `reports_dir` are deduplicated by script name (most recent date-time wins),
+# each chosen report is read with read_coverage_report(), and the accumulated
+# results are written to a timestamped file in utils/coverage/compiled/ (the
+# timestamp marks which compiled run is newest). Returns the output path.
+compile_coverage_estimates <- function(
+  reports_dir = here::here("utils", "coverage", "reports"),
+  compiled_dir = here::here("utils", "coverage", "compiled")
+) {
+  pattern <- "-[0-9]{8}-[0-9]{6}[.]html$"
+  htmls <- list.files(reports_dir, pattern = pattern, full.names = TRUE)
+  if (!length(htmls)) {
+    stop("No .html reports found in ", reports_dir, call. = FALSE)
+  }
+
+  info <- data.frame(
+    path = htmls,
+    base = sub(pattern, "", basename(htmls)),
+    stamp = sub(paste0("^.*-([0-9]{8}-[0-9]{6})[.]html$"), "\\1", basename(htmls)),
+    stringsAsFactors = FALSE
+  )
+  # dedup by script, keeping the most recent report
+  info <- info[order(info$base, info$stamp), ]
+  info <- info[!duplicated(info$base, fromLast = TRUE), ]
+
+  rows <- lapply(seq_len(nrow(info)), function(i) {
+    vals <- tryCatch(
+      read_coverage_report(info$path[i]),
+      error = function(e) {
+        warning("Skipping ", info$base[i], ": ", conditionMessage(e))
+        NULL
+      }
+    )
+    if (is.null(vals)) {
+      return(NULL)
+    }
+    data.frame(
+      script = info$base[i],
+      report = info$stamp[i],
+      relevant = vals[["relevant"]],
+      covered = vals[["covered"]],
+      missed = vals[["missed"]],
+      coverage = vals[["coverage"]],
+      stringsAsFactors = FALSE
+    )
+  })
+  result <- do.call(rbind, rows)
+  result <- result[order(result$coverage, result$script), ]
+
+  agg_rel <- sum(result$relevant)
+  agg_cov <- sum(result$covered)
+  agg_pct <- round(100 * agg_cov / agg_rel, 2)
+
+  dir.create(compiled_dir, showWarnings = FALSE, recursive = TRUE)
+  stamp <- format(Sys.time(), "%Y%m%d-%H%M%S")
+  out <- file.path(compiled_dir, paste0(stamp, ".txt"))
+
+  writeLines(
+    c(
+      paste0("# Coverage compiled ", stamp, " (covr canonical figures, read from HTML)"),
+      paste0("# ", nrow(result), " scripts, most recent report each"),
+      "",
+      utils::capture.output(print(result, row.names = FALSE)),
+      "",
+      sprintf(
+        "TOTAL: %d scripts | %d relevant | %d covered | %d missed | %.2f%% coverage",
+        nrow(result),
+        agg_rel,
+        agg_cov,
+        agg_rel - agg_cov,
+        agg_pct
+      )
+    ),
+    out
+  )
+
+  out
+}

--- a/utils/spark_versions/spark_versions.R
+++ b/utils/spark_versions/spark_versions.R
@@ -38,30 +38,43 @@ get_spark_files <- function(curr_folder, url) {
 
   sfs <- spark_page_links[valid_spark]
 
-  map(sfs, ~ {
-    list(
-      main = url,
-      folder = curr_folder,
-      file = .x
-    )
-  })
+  map(
+    sfs,
+    ~ {
+      list(
+        main = url,
+        folder = curr_folder,
+        file = .x
+      )
+    }
+  )
 }
 
 ## ---- Parses the file name to extract Spark, Hadoop and Scala version
 parse_file <- function(x, main, folder) {
   print(x)
-  if(str_sub(x, 1, 6) != "spark-") stop("Invalid file name")
+  if (str_sub(x, 1, 6) != "spark-") {
+    stop("Invalid file name")
+  }
   #if(str_sub(x, 12, 22) != "-bin-hadoop") stop("Invalid file name")
-  if(str_detect(x, "scala")) stop("No Scala version files")
-
+  if (str_detect(x, "scala")) {
+    stop("No Scala version files")
+  }
 
   xfp <- path_ext_remove(x)
 
   xf_split <- str_split(xfp, "-")[[1]]
 
-  if(any(str_detect(xf_split, "preview"))) {
+  if (any(str_detect(xf_split, "preview"))) {
     hadoop_no <- 5
-    pattern <- paste0(xf_split[1], "-%s-", xf_split[3], "-", xf_split[4], "-hadoop%s.tgz")
+    pattern <- paste0(
+      xf_split[1],
+      "-%s-",
+      xf_split[3],
+      "-",
+      xf_split[4],
+      "-hadoop%s.tgz"
+    )
   } else {
     hadoop_no <- 4
     pattern <- "spark-%s-bin-hadoop%s.tgz"
@@ -78,21 +91,23 @@ parse_file <- function(x, main, folder) {
 # ---------------------- Read / create versions.rds file ----------------
 
 versions_rds <- path("utils", "spark_versions", "versions.rds")
-if(file_exists(versions_rds)) {
+if (file_exists(versions_rds)) {
   rds_info <- file_info(versions_rds)
   rds_days <- as.integer(Sys.Date() - as.Date(rds_info$modification_time))
-  if(rds_days > 8) {
+  if (rds_days > 8) {
     file_delete(versions_rds)
   }
 }
 
-if(!file_exists(versions_rds)) {
-  c("https://dlcdn.apache.org/spark/",
+if (!file_exists(versions_rds)) {
+  c(
+    "https://dlcdn.apache.org/spark/",
     "https://archive.apache.org/dist/spark/"
   ) %>%
-    map(~ get_main_page(.x) %>%
-          map(get_spark_files, .x) %>%
-          purrr::flatten()
+    map(
+      ~ get_main_page(.x) %>%
+        map(get_spark_files, .x) %>%
+        purrr::flatten()
     ) %>%
     purrr::flatten() %>%
     write_rds(versions_rds)
@@ -103,11 +118,11 @@ all_files <- read_rds(versions_rds)
 # -------------------- Combine files -------------
 
 apache_entries <- all_files %>%
-  discard(~str_detect(.x$file, "incubating")) %>%
-  discard(~str_detect(.x$file, "without")) %>%
-  discard(~str_detect(.x$file, "scala")) %>%
-  discard(~str_detect(.x$file, "connect")) %>%
-  discard(~str_detect(.x$file, "hive")) %>%
+  discard(~ str_detect(.x$file, "incubating")) %>%
+  discard(~ str_detect(.x$file, "without")) %>%
+  discard(~ str_detect(.x$file, "scala")) %>%
+  discard(~ str_detect(.x$file, "connect")) %>%
+  discard(~ str_detect(.x$file, "hive")) %>%
   map(~ parse_file(.x$file, .x$main, .x$folder))
 
 versions_json <- path("inst/extdata/versions.json")
@@ -116,14 +131,23 @@ future_json <- path("inst/extdata/versions-next.json")
 # -------------------- Create new list -------------
 
 final_tbl <- apache_entries %>%
-  map(~{
-    x <- .x
-    x$priority <- 0
-    if(str_detect(x$base, "dlcdn.apache.org")) x$priority <- 1
-    if(str_detect(x$base, "archive.apache.org")) x$priority <- 2
-    x
-  }) %>%
-  discard(~str_detect(.x$base, "archive.apache.org") && str_detect(.x$base, "preview")) %>%
+  map(
+    ~ {
+      x <- .x
+      x$priority <- 0
+      if (str_detect(x$base, "dlcdn.apache.org")) {
+        x$priority <- 1
+      }
+      if (str_detect(x$base, "archive.apache.org")) {
+        x$priority <- 2
+      }
+      x
+    }
+  ) %>%
+  discard(
+    ~ str_detect(.x$base, "archive.apache.org") &&
+      str_detect(.x$base, "preview")
+  ) %>%
   map_dfr(~.x) %>%
   arrange(spark, hadoop, priority) %>%
   filter(spark >= "2.4.0") %>% # Matching minimum version to the original file
@@ -132,7 +156,7 @@ final_tbl <- apache_entries %>%
   select(-priority) %>%
   ungroup()
 
-if(any(str_detect(final_tbl$base, "preview"))) {
+if (any(str_detect(final_tbl$base, "preview"))) {
   previews <- final_tbl %>%
     filter(str_detect(base, "preview")) %>%
     filter(base != max(base)) %>%


### PR DESCRIPTION

- Fixed `augment()` on a linear / generalized-linear-regression model when
`type.residuals` is not `"working"` (e.g. `"deviance"`, `"pearson"`,
`"response"`) and no `newdata` is supplied. It errored with "Can't rename
columns that don't exist" because `ml_predict()` drops the residuals column;
the residuals are now re-attached to the predictions.

- Fixed `names<-()` on a `tbl_spark` (e.g. `names(tbl) <- value`), which errored
with "Can't escape back tick from string" on recent `dbplyr`. The replacement
view is now re-registered using the bare remote table name instead of the
back tick-quoted `table_path`.

- Fixed `ml_gbt_classifier()` on Spark < 2.2 so a fitted classification model is
classed `ml_gbt_classification_model` (it was mislabeled
`ml_multilayer_perceptron_classification_model` due to a copy-paste error).

- Fixed `ft_robust_scaler()` so a fitted model is now wrapped as an
`ml_robust_scaler_model` object. `RobustScaler`/`RobustScalerModel` were missing
from the JVM-class mapping, so a fitted robust scaler fell back to a generic
`ml_transformer` (and the model constructor carried the estimator's class by
mistake). Transformation worked, but the model's class was inconsistent with the
other scalers.

- Fixed the `sparklyr.stream.collect.timeout` and
`sparklyr.stream.validate.timeout` configuration options being silently ignored.
The internal code referenced a bare `config` that resolved to an unrelated
imported function instead of the connection's configuration, so the timeouts
always fell back to their defaults; they now read from the active connection.

- Fixed `sdf_pivot()` so a multi-column pivot specification (the right-hand side
of the formula, e.g. `a ~ b + c`) is now correctly rejected with a clear
"pivot column is not length one" error. Previously the right-hand side was not
split on `+`/`*` (an errant `fixed = TRUE`), so such a formula failed later with
a confusing "missing variables in dataset" error instead.

- Fixed `spark_write()` and `spark_write_table()` when passed a `spark_jobj`:
the internal JVM class check only accepted `org.apache.spark.sql.DataFrame`,
which has not been the concrete class since Spark 2.0 (it is now
`org.apache.spark.sql.Dataset`, or `org.apache.spark.sql.classic.Dataset` on
Spark 4.x), so these methods always errored. The check is now version-agnostic.